### PR TITLE
✨ Feat : 브랜드 찾기 바텀시트 구현

### DIFF
--- a/src/assets/icons/replay/icon-replay-false.svg
+++ b/src/assets/icons/replay/icon-replay-false.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 13C4 17.4183 7.58172 21 12 21C16.4183 21 20 17.4183 20 13C20 8.58172 16.4183 5 12 5" stroke="#7E8392" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M13 7L11.3536 5.35355C11.1583 5.15829 11.1583 4.84171 11.3536 4.64645L13 3" stroke="#7E8392" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/src/assets/icons/replay/icon-replay-true.svg
+++ b/src/assets/icons/replay/icon-replay-true.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 13C4 17.4183 7.58172 21 12 21C16.4183 21 20 17.4183 20 13C20 8.58172 16.4183 5 12 5" stroke="#FF6C9A" stroke-width="1.6" stroke-linecap="round"/>
+<path d="M13 7L11.3536 5.35355C11.1583 5.15829 11.1583 4.84171 11.3536 4.64645L13 3" stroke="#FF6C9A" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/src/feature/brand/model/hooks/useBrandFilterSheet.ts
+++ b/src/feature/brand/model/hooks/useBrandFilterSheet.ts
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+
+import { Gesture } from 'react-native-gesture-handler';
+import {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+
+import { HEIGHT } from '@/shared/constants/size';
+import { useFilteredBrandsStore } from '@/shared/store/brand/filterBrands';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const SNAP_POINTS = {
+  FULL: HEIGHT * 0.9, // 바텀 시트의 높이가 90%
+  HALF: HEIGHT * 0.65, // 바텀 시트의 높이가 65%
+  HIDDEN: 0, // 바텀 시트가 사라진 상태
+};
+
+const DRAG_CLOSE_THRESHOLD = 150;
+
+export const useBrandFilterSheet = ({ visible, onClose }: Props) => {
+  const translateY = useSharedValue(SNAP_POINTS.HIDDEN);
+  const { filteredList, resetFilter } = useFilteredBrandsStore();
+  const midpoint = (SNAP_POINTS.HALF + SNAP_POINTS.FULL) / 2;
+
+  const panGesture = Gesture.Pan()
+    .onUpdate(event => {
+      const nextHeight = translateY.value - event.translationY;
+      if (nextHeight < SNAP_POINTS.HIDDEN || nextHeight > SNAP_POINTS.FULL) {
+        return;
+      }
+
+      translateY.value = nextHeight;
+    })
+    .onEnd(event => {
+      const dragDistance = event.translationY;
+
+      const targetHeight = translateY.value - dragDistance;
+
+      if (dragDistance > DRAG_CLOSE_THRESHOLD) {
+        runOnJS(onClose)(); // 충분히 아래로 드래그했으면 닫기
+      } else if (targetHeight < midpoint) {
+        translateY.value = withSpring(SNAP_POINTS.HALF);
+      } else {
+        translateY.value = withSpring(SNAP_POINTS.FULL);
+      }
+    });
+
+  useEffect(() => {
+    if (visible) {
+      resetFilter();
+      translateY.value = withSpring(SNAP_POINTS.HALF);
+    }
+  }, [visible]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: translateY.value,
+  }));
+
+  const isDisabled =
+    filteredList.length === 0 || filteredList.some(b => b.brandId === 'NONE');
+
+  const actualCount = filteredList.some(b => b.brandId === 'NONE')
+    ? 0
+    : filteredList.length;
+
+  const handleReset = () => {
+    resetFilter();
+  };
+
+  return {
+    panGesture,
+    animatedStyle,
+    isDisabled,
+    actualCount,
+    handleReset,
+  };
+};

--- a/src/feature/brand/ui/atoms/BrandFilterToast.tsx
+++ b/src/feature/brand/ui/atoms/BrandFilterToast.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect } from 'react';
+
+import { Text } from 'react-native';
+import LinearGradient from 'react-native-linear-gradient';
+import Animated, {
+  Easing,
+  runOnJS,
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { useToastStore } from '@/shared/store/ui/Toast';
+
+interface Props {
+  bottomAreaHeight: SharedValue<number>;
+}
+
+const BrandFilterToast = ({ bottomAreaHeight }: Props) => {
+  const { message, visible, hideToast } = useToastStore();
+  const animatedBottom = useSharedValue(0);
+
+  useEffect(() => {
+    if (visible) {
+      const height = bottomAreaHeight.value > 0 ? bottomAreaHeight.value : 72;
+
+      animatedBottom.value = withTiming(height + 12, {
+        duration: 300,
+        easing: Easing.bezier(0.42, 0, 0.58, 1),
+      });
+
+      const timer = setTimeout(() => {
+        animatedBottom.value = withTiming(
+          -height,
+          {
+            duration: 300,
+            easing: Easing.bezier(0.42, 0, 0.58, 1),
+          },
+          () => {
+            runOnJS(hideToast)();
+          },
+        );
+      }, 2000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [visible, bottomAreaHeight.value]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      bottom: animatedBottom.value,
+    };
+  });
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Animated.View
+      style={animatedStyle}
+      className="absolute z-50 w-full items-center">
+      <LinearGradient
+        colors={[
+          'rgba(255, 255, 255, 1)',
+          'rgba(17, 17, 20, 0.8)',
+          'rgba(17, 17, 20, 1)',
+          'rgba(17, 17, 20, 0.8)',
+          'rgba(255, 255, 255, 1)',
+        ]}
+        locations={[0, 0.2, 0.4, 0.95, 1]} // 각 색상의 위치를 비율(0~1)로 지정
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+        className="h-[40px] w-[288px] items-center justify-center rounded-xl">
+        <Text className="text-center text-white body-rg-02">{message}</Text>
+      </LinearGradient>
+    </Animated.View>
+  );
+};
+
+export default BrandFilterToast;

--- a/src/feature/brand/ui/atoms/BrandFilterToast.tsx
+++ b/src/feature/brand/ui/atoms/BrandFilterToast.tsx
@@ -13,6 +13,16 @@ import Animated, {
 
 import { useToastStore } from '@/shared/store/ui/Toast';
 
+const GRADIENT_COLORS = [
+  'rgba(255, 255, 255, 1)',
+  'rgba(17, 17, 20, 0.8)',
+  'rgba(17, 17, 20, 1)',
+  'rgba(17, 17, 20, 0.8)',
+  'rgba(255, 255, 255, 1)',
+] as string[];
+
+const GRADIENT_LOCATIONS = [0, 0.2, 0.4, 0.95, 1] as number[];
+
 interface Props {
   bottomAreaHeight: SharedValue<number>;
 }
@@ -62,14 +72,8 @@ const BrandFilterToast = ({ bottomAreaHeight }: Props) => {
       style={animatedStyle}
       className="absolute z-50 w-full items-center">
       <LinearGradient
-        colors={[
-          'rgba(255, 255, 255, 1)',
-          'rgba(17, 17, 20, 0.8)',
-          'rgba(17, 17, 20, 1)',
-          'rgba(17, 17, 20, 0.8)',
-          'rgba(255, 255, 255, 1)',
-        ]}
-        locations={[0, 0.2, 0.4, 0.95, 1]} // 각 색상의 위치를 비율(0~1)로 지정
+        colors={GRADIENT_COLORS}
+        locations={GRADIENT_LOCATIONS} // 각 색상의 위치를 비율(0~1)로 지정
         start={{ x: 0.5, y: 0 }}
         end={{ x: 0.5, y: 1 }}
         className="h-[40px] w-[288px] items-center justify-center rounded-xl">

--- a/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
+++ b/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect } from 'react';
+
+import {
+  LayoutChangeEvent,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { useSharedValue } from 'react-native-reanimated';
+
+import { useBrandFilterSheet } from '../../model/hooks/useBrandFilterSheet';
+import { useHandleScroll } from '../../model/hooks/useHandleScroll';
+import { useGetBrandsList } from '../../queries/useGetBrandList';
+import BrandFilterToast from '../atoms/BrandFilterToast';
+
+import BrandGridList from './BrandGridList';
+import SelectButton from './SelectButton';
+
+import ReplayIcons from '@/shared/icons/ReplayIcon';
+import { useBrandListStore } from '@/shared/store/brand/brandList';
+import { useFilteredBrandsStore } from '@/shared/store/brand/filterBrands';
+import { useToastStore } from '@/shared/store/ui/Toast';
+import BottomSheet from '@/shared/ui/molecules/BottomSheet';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const BrandFilterBottomSheet = ({ visible, onClose }: Props) => {
+  const { data: brands } = useGetBrandsList();
+  const { brandList, setBrandList } = useBrandListStore();
+  const { handleScroll, scrollViewRef } = useHandleScroll();
+  const { filteredList, filterBrand, resetFilter } = useFilteredBrandsStore();
+  const { showToast } = useToastStore();
+  const { panGesture, animatedStyle, isDisabled, actualCount } =
+    useBrandFilterSheet({ visible, onClose });
+
+  const bottomAreaHeight = useSharedValue(0);
+
+  useEffect(() => {
+    if (brands) {
+      setBrandList(brands);
+    }
+  }, [brands]);
+
+  const handleFilter = (brandId: string, name: string) => {
+    const success = filterBrand(brandId, name);
+    if (!success) {
+      showToast('브랜드는 최대 5개까지 선택 가능해요');
+    }
+  };
+
+  const handleButtonLayout = (event: LayoutChangeEvent) => {
+    bottomAreaHeight.value = event.nativeEvent.layout.height;
+  };
+
+  return (
+    <BottomSheet
+      onClose={onClose}
+      title="브랜드 찾기"
+      headerRight={
+        <Pressable onPress={resetFilter}>
+          <View className="flex-row">
+            <Text
+              className={`mr-1 headline-02 ${
+                filteredList.length > 0 ? 'text-pink-500' : 'text-gray-500'
+              }`}>
+              초기화
+            </Text>
+            <ReplayIcons
+              width={24}
+              height={24}
+              shape={filteredList.length > 0 ? 'true' : 'false'}
+            />
+          </View>
+        </Pressable>
+      }
+      visible={visible}
+      animatedStyle={animatedStyle}
+      panGesture={panGesture}>
+      <ScrollView
+        ref={scrollViewRef}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator
+        indicatorStyle="default">
+        <BrandGridList
+          brandList={brandList}
+          selectedList={filteredList}
+          onPress={handleFilter}
+          excludeNoneBrand
+        />
+      </ScrollView>
+      <View onLayout={handleButtonLayout} className="relative">
+        <BrandFilterToast bottomAreaHeight={bottomAreaHeight} />
+        <SelectButton
+          actualSelectedCount={actualCount}
+          disabled={!isDisabled}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default BrandFilterBottomSheet;

--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { View, Pressable, ImageBackground, Text } from 'react-native';
+import { ImageBackground, Pressable, Text, View } from 'react-native';
 import Config from 'react-native-config';
 
 import { Brand } from '../../types/brandType';
@@ -19,6 +19,7 @@ interface Props {
   onPress: (brandId: string, name: string) => void;
   keyword?: string;
   highlight?: boolean;
+  excludeNoneBrand?: boolean;
 }
 
 const BrandGridList = ({
@@ -27,10 +28,14 @@ const BrandGridList = ({
   onPress,
   keyword = '',
   highlight = false,
+  excludeNoneBrand = false,
 }: Props) => {
+  const filteredBrandList = excludeNoneBrand
+    ? brandList.filter(brand => brand.brandId !== 'NONE')
+    : brandList;
   return (
     <>
-      {chunkArray(brandList, 3).map((row, rowIndex) => (
+      {chunkArray(filteredBrandList, 3).map((row, rowIndex) => (
         <View key={rowIndex} className="mx-3 mb-6 flex-row justify-between">
           {row.map(item => {
             const isSelected = selectedList.some(

--- a/src/feature/brand/ui/organisms/SelectButton.tsx
+++ b/src/feature/brand/ui/organisms/SelectButton.tsx
@@ -9,10 +9,10 @@ import Button from '@/shared/ui/atoms/Button';
 interface Props {
   disabled: boolean;
   actualSelectedCount: number;
-  handleSelectedCompleted: () => Promise<void>;
-  showFloatingButton: boolean;
-  scrollToTop: () => void;
-  handleNavigation: () => void;
+  handleSelectedCompleted?: () => Promise<void>;
+  showFloatingButton?: boolean;
+  scrollToTop?: () => void;
+  handleNavigation?: () => void;
 }
 
 const SelectButton = ({
@@ -24,7 +24,7 @@ const SelectButton = ({
   scrollToTop,
 }: Props) => {
   return (
-    <View className="absolute bottom-10 w-full items-center">
+    <View className="w-full items-center">
       <Button
         color={!disabled ? 'disabled' : 'active'}
         textColor="white"

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -3,8 +3,10 @@ import React, { useState } from 'react';
 import { NaverMapView } from '@mj-studio/react-native-naver-map';
 import { StyleSheet } from 'react-native';
 
+import BrandFilterBottomSheet from '@/feature/brand/ui/organisms/BrandFilterBottomSheet';
 import BrandFilterButton from '@/feature/brand/ui/organisms/BrandFilterButton';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
+import { useModal } from '@/shared/hooks/useModal';
 import Input from '@/shared/ui/atoms/Input';
 
 // 초기 카메라 위치 설정
@@ -16,7 +18,7 @@ const INITIAL_CAMERA = {
 
 const HomeScreen = () => {
   const [brandName, setBrandName] = useState('');
-  const [isFilterActive, setIsFilterActive] = useState(false);
+  const { openModal, closeModal, isModalOpen } = useModal();
 
   return (
     <ScreenLayout>
@@ -34,9 +36,16 @@ const HomeScreen = () => {
         container="pb-[8px]"
       />
       <BrandFilterButton
-        variant={isFilterActive ? 'active' : 'inactive'}
-        onPress={() => setIsFilterActive(prev => !prev)}
+        variant={isModalOpen ? 'active' : 'inactive'}
+        onPress={() => {
+          if (isModalOpen) {
+            closeModal();
+          } else {
+            openModal();
+          }
+        }}
       />
+      <BrandFilterBottomSheet visible={isModalOpen} onClose={closeModal} />
     </ScreenLayout>
   );
 };

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { NaverMapView } from '@mj-studio/react-native-naver-map';
 import { StyleSheet } from 'react-native';
@@ -20,6 +20,14 @@ const HomeScreen = () => {
   const [brandName, setBrandName] = useState('');
   const { openModal, closeModal, isModalOpen } = useModal();
 
+  const handleModal = useCallback(() => {
+    if (isModalOpen) {
+      closeModal();
+    } else {
+      openModal();
+    }
+  }, [isModalOpen, openModal, closeModal]);
+
   return (
     <ScreenLayout>
       <NaverMapView
@@ -37,13 +45,7 @@ const HomeScreen = () => {
       />
       <BrandFilterButton
         variant={isModalOpen ? 'active' : 'inactive'}
-        onPress={() => {
-          if (isModalOpen) {
-            closeModal();
-          } else {
-            openModal();
-          }
-        }}
+        onPress={handleModal}
       />
       <BrandFilterBottomSheet visible={isModalOpen} onClose={closeModal} />
     </ScreenLayout>

--- a/src/shared/icons/ReplayIcon/index.tsx
+++ b/src/shared/icons/ReplayIcon/index.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
 
-import ReplayIcon from '@/assets/icons/replay/icon-replay.svg';
+import ReplayFalse from '@/assets/icons/replay/icon-replay-false.svg';
+import ReplayTrue from '@/assets/icons/replay/icon-replay-true.svg';
+import ReplayDefault from '@/assets/icons/replay/icon-replay.svg';
 
 interface Props {
-  shape: 'default';
+  shape: 'true' | 'false';
   width: number;
   height: number;
 }
 
 const ReplayIcons = ({ shape, width, height }: Props) => {
   switch (shape) {
-    case 'default':
-      return <ReplayIcon width={width} height={height} />;
+    case 'true':
+      return <ReplayTrue width={width} height={height} />;
+    case 'false':
+      return <ReplayFalse width={width} height={height} />;
     default:
-      return <ReplayIcon width={width} height={height} />;
+      return <ReplayDefault width={width} height={height} />;
   }
 };
 

--- a/src/shared/store/brand/filterBrands/index.ts
+++ b/src/shared/store/brand/filterBrands/index.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+interface FilteredBrand {
+  brandId: string;
+  name: string;
+}
+
+interface FilteredBrandStore {
+  filteredList: FilteredBrand[];
+  filterBrand: (brandId: string, name: string) => boolean;
+  resetFilter: () => void;
+}
+
+export const useFilteredBrandsStore = create<FilteredBrandStore>(
+  (set, get) => ({
+    filteredList: [] as FilteredBrand[],
+
+    filterBrand: (brandId, name) => {
+      const { filteredList } = get();
+
+      const isSelected = filteredList.some(b => b.brandId === brandId);
+      const isOverLimit = filteredList.length >= 5;
+
+      if (isSelected) {
+        set({
+          filteredList: filteredList.filter(b => b.brandId !== brandId),
+        });
+        return true;
+      }
+      if (!isOverLimit) {
+        set({
+          filteredList: [...filteredList, { brandId, name }],
+        });
+        return true;
+      }
+
+      return false;
+    },
+
+    resetFilter: () => {
+      set({ filteredList: [] });
+    },
+  }),
+);

--- a/src/shared/store/index.tsx
+++ b/src/shared/store/index.tsx
@@ -1,3 +1,4 @@
 export { useSelectedBrandsStore } from './brand/selectBrands';
 export { useBrandListStore } from './brand/brandList';
+export { useFilteredBrandsStore } from './brand/filterBrands';
 export { useUserStore } from './user';

--- a/src/shared/store/ui/Toast/index.ts
+++ b/src/shared/store/ui/Toast/index.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface ToastStore {
+  message: string;
+  visible: boolean;
+  showToast: (msg: string) => void;
+  hideToast: () => void;
+}
+
+export const useToastStore = create<ToastStore>(set => ({
+  message: '',
+  visible: false,
+  showToast: msg => set({ message: msg, visible: true }),
+  hideToast: () => set({ visible: false }),
+}));

--- a/src/shared/ui/molecules/BottomSheet/BottomSheetHeader/index.tsx
+++ b/src/shared/ui/molecules/BottomSheet/BottomSheetHeader/index.tsx
@@ -1,18 +1,20 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-import { View, Text } from 'react-native';
+import { Text, View } from 'react-native';
 
 interface Props {
   title: string;
+  right?: ReactNode;
 }
 
-const BottomSheetHeader = ({ title }: Props) => {
+const BottomSheetHeader = ({ title, right }: Props) => {
   return (
     <>
       <View className="mb-4 h-[5px] w-[36px] self-center rounded-full bg-gray-300" />
-      <Text className="mb-[29px] text-center text-gray-900 title-01">
-        {title}
-      </Text>
+      <View className="relative mb-[29px] items-center justify-center">
+        <Text className="text-gray-900 title-01">{title}</Text>
+        {right && <View className="absolute right-0 pr-[20px]">{right}</View>}
+      </View>
     </>
   );
 };

--- a/src/shared/ui/molecules/BottomSheet/index.tsx
+++ b/src/shared/ui/molecules/BottomSheet/index.tsx
@@ -1,12 +1,14 @@
 import React, { ReactNode } from 'react';
 
-import { Modal } from 'react-native';
+import { Modal, View } from 'react-native';
 import { GestureDetector, PanGesture } from 'react-native-gesture-handler';
 import Animated, { AnimatedStyle } from 'react-native-reanimated';
 
 import BackDrop from '../BackDrop';
 
 import BottomSheetHeader from './BottomSheetHeader';
+
+import { bottomSheetShadow } from '@/styles/bottomSheetShadow';
 
 interface Props {
   children: ReactNode;
@@ -15,7 +17,8 @@ interface Props {
   visible: boolean;
   backDrop?: boolean;
   panGesture: PanGesture;
-  animatedStyle: AnimatedStyle<{ transform: { translateY: number }[] }>;
+  animatedStyle: AnimatedStyle<{ height: number }>;
+  headerRight?: ReactNode;
 }
 
 const BottomSheet = ({
@@ -26,6 +29,7 @@ const BottomSheet = ({
   panGesture,
   animatedStyle,
   backDrop = false,
+  headerRight,
 }: Props) => {
   return (
     <Modal visible={visible} transparent animationType="slide">
@@ -33,11 +37,12 @@ const BottomSheet = ({
 
       <GestureDetector gesture={panGesture}>
         <Animated.View
-          style={animatedStyle}
-          className="absolute bottom-0 max-h-[80%] w-full rounded-t-2xl bg-white px-4 pb-8 pt-2">
-          <BottomSheetHeader title={title} />
-
-          {children}
+          style={[animatedStyle, bottomSheetShadow]}
+          className="absolute bottom-0 w-full rounded-t-2xl bg-white px-4 pb-8 pt-2">
+          <View className="flex-1 flex-col">
+            <BottomSheetHeader title={title} right={headerRight} />
+            {children}
+          </View>
         </Animated.View>
       </GestureDetector>
     </Modal>

--- a/src/styles/bottomSheetShadow.ts
+++ b/src/styles/bottomSheetShadow.ts
@@ -1,0 +1,7 @@
+export const bottomSheetShadow = {
+  shadowColor: '#000',
+  shadowOffset: { width: 0, height: -2 },
+  shadowOpacity: 0.2,
+  shadowRadius: 8,
+  elevation: 6,
+};


### PR DESCRIPTION
## 이슈 번호

> 26

## 작업 내용 및 테스트 방법

> - 브랜드 찾기 버튼 탭 시 브랜드 필터링 바텀시트 노출
> - 브랜드 그리드 리스트 내 선호 브랜드 없음 비활성화
> - 브랜드 1개 이상 선택 시 초기화 버튼 활성화
> - 브랜드 선택 5개 초과 시 토스트 노출

![브랜드 찾기 바텀시트 구현](https://github.com/user-attachments/assets/dba2654b-3380-4108-97e4-bf3c8ccd138d)


## To reviewers
우선 shadow style 구조 변경 건에 대해선 말씀 해주신대로 수정했습니다! 토스트 애니메이션과 snap point 잡기가 상당히 어렵더군요,, ㅎㅎ 이번 작업은 제가 새롭게 작성한 파일이 많았는데요..! 늘 더 좋은 코드로 개선될 수 있도록 적극적인 피드백 부탁드립니다 🌱👍🏻