### PR TITLE
✨ Feat: API header 추가(백엔드 요청)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
 import MainRoute from '@/navigation';
+import SignupRoute from '@/navigation/route/signup';
 import AppProvider from '@/providers/AppProvider';
+import { useUserStore } from '@/shared/store';
 
 function App() {
+  const { refreshToken } = useUserStore();
+
   return (
-    <AppProvider>
-      <MainRoute />
-    </AppProvider>
+    <AppProvider>{refreshToken ? <MainRoute /> : <SignupRoute />}</AppProvider>
   );
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1875,6 +1875,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNCKakaoCore
     - Yoga
+  - RNDeviceInfo (14.1.1):
+    - React-Core
   - RNGestureHandler (2.25.0):
     - DoubleConversion
     - glog
@@ -2259,6 +2261,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCKakaoCore (from `../node_modules/@react-native-kakao/core`)"
   - "RNCKakaoUser (from `../node_modules/@react-native-kakao/user`)"
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
   - "RNNaverLogin (from `../node_modules/@react-native-seoul/naver-login`)"
@@ -2443,6 +2446,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-kakao/core"
   RNCKakaoUser:
     :path: "../node_modules/@react-native-kakao/user"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNGoogleSignin:
@@ -2550,6 +2555,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 2cf7d05f5b1bc38680b6c83971e535a6ae9c5bc7
   RNCKakaoCore: bd5aaf1330e66242e7a76397001af25bb3a21889
   RNCKakaoUser: 57d6e04b46a92389298465b9ecc90ecee126203d
+  RNDeviceInfo: 8b6fa8379062949dd79a009cf3d6b02a9c03ca59
   RNGestureHandler: 5d8431415d4b8518e86e289e9ad5bb9be78f6dba
   RNGoogleSignin: d216e84db1adedb0d6f5306d5aedf3b43451bbab
   RNNaverLogin: cef5c8e8d1ce3272efe05db3d826631184f6abf8

--- a/ios/picselFE/PrivacyInfo.xcprivacy
+++ b/ios/picselFE/PrivacyInfo.xcprivacy
@@ -28,6 +28,14 @@
 				<string>C617.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "19.0.0",
         "react-native": "0.79.1",
         "react-native-config": "^1.5.5",
+        "react-native-device-info": "^14.1.1",
         "react-native-dotenv": "^3.4.11",
         "react-native-gesture-handler": "^2.25.0",
         "react-native-linear-gradient": "^2.8.3",
@@ -14357,6 +14358,15 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-device-info": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-14.1.1.tgz",
+      "integrity": "sha512-lXFpe6DJmzbQXNLWxlMHP2xuTU5gwrKAvI8dCAZuERhW9eOXSubOQIesk9lIBnsi9pI19GMrcpJEvs4ARPRYmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/react-native-dotenv": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react": "19.0.0",
     "react-native": "0.79.1",
     "react-native-config": "^1.5.5",
+    "react-native-device-info": "^14.1.1",
     "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "^2.25.0",
     "react-native-linear-gradient": "^2.8.3",

--- a/src/feature/brand/api/favoriteBrandApi.ts
+++ b/src/feature/brand/api/favoriteBrandApi.ts
@@ -1,4 +1,4 @@
-import { BrandsResponse } from '../types/brandType';
+import { BrandsResponse } from '../types';
 
 import { axiosInstance } from '@/shared/api/axiosInstance';
 

--- a/src/feature/brand/api/getBrandListApi.ts
+++ b/src/feature/brand/api/getBrandListApi.ts
@@ -1,4 +1,4 @@
-import { BrandsResponse } from '../types/brandType';
+import { BrandsResponse } from '../types';
 
 import { axiosInstance } from '@/shared/api/axiosInstance';
 

--- a/src/feature/brand/queries/useGetBrandList.ts
+++ b/src/feature/brand/queries/useGetBrandList.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getBrandsListApi } from '../api/getBrandListApi';
-import { Brand } from '../types/brandType';
+import { Brand } from '../types';
 
 import { QUERY_KEYS } from '@/shared/constants/query/key';
 

--- a/src/feature/brand/types/index.ts
+++ b/src/feature/brand/types/index.ts
@@ -1,3 +1,5 @@
+import { CommonResponseType } from '@/shared/api/types';
+
 export interface Brand {
   brandId: string;
   name: string;
@@ -5,7 +7,6 @@ export interface Brand {
   displayOrder: number;
 }
 
-export interface BrandsResponse {
-  code: number;
+export interface BrandsResponse extends CommonResponseType {
   data: Brand[];
 }

--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ImageBackground, Pressable, Text, View } from 'react-native';
 import Config from 'react-native-config';
 
-import { Brand } from '../../types/brandType';
+import { Brand } from '../../types';
 
 import { HighlightedText } from '@/shared/components/HighlightedText';
 import CheckIcons from '@/shared/icons/CheckIcons';

--- a/src/feature/map/types/index.ts
+++ b/src/feature/map/types/index.ts
@@ -1,3 +1,5 @@
+import { CommonResponseType } from '@/shared/api/types';
+
 export interface StoreSearchParams {
   minX: number;
   maxX: number;
@@ -40,10 +42,6 @@ export interface StoreSearchResult {
   last: boolean;
 }
 
-// 서버 전체 응답 구조
-export interface StoreSearchResponse {
-  code: number;
-  codeMessage: string;
-  message: string;
+export interface StoreSearchResponse extends CommonResponseType {
   data: StoreSearchResult;
 }

--- a/src/feature/map/types/index.ts
+++ b/src/feature/map/types/index.ts
@@ -22,8 +22,15 @@ export interface StoreData {
   distance: number;
 }
 
-// 실제 content 포함한 내부 응답 구조
+export interface BrandData {
+  brandDisplayOrder: number;
+  brandIconImageUrl: string;
+  brandId: string;
+  brandName: string;
+}
+
 export interface StoreSearchResult {
+  brands: BrandData[];
   content: StoreData[];
   totalElements: number;
   totalPages: number;
@@ -31,14 +38,6 @@ export interface StoreSearchResult {
   pageSize: number;
   first: boolean;
   last: boolean;
-}
-
-export interface Store {
-  storeId: string;
-  storeName: string;
-  brandIconImageUrl: string;
-  x: number;
-  y: number;
 }
 
 // 서버 전체 응답 구조

--- a/src/feature/map/ui/organisms/MapOverlay.tsx
+++ b/src/feature/map/ui/organisms/MapOverlay.tsx
@@ -3,36 +3,46 @@ import React, { useMemo } from 'react';
 import { NaverMapMarkerOverlay } from '@mj-studio/react-native-naver-map';
 import Config from 'react-native-config';
 
-import { Store } from '../../types';
+import { BrandData, StoreData } from '../../types';
 import StoreMarker from '../atoms/StoreMarker';
 
 interface Props {
-  stores?: Store[];
+  store: StoreData[];
+  brand: BrandData[];
   selectedMarkerId: string | null;
   handleMarkerPress: (storeId: string) => void;
 }
 
-const MapOverlay = ({ stores, selectedMarkerId, handleMarkerPress }: Props) => {
+const MapOverlay = ({
+  brand,
+  store,
+  selectedMarkerId,
+  handleMarkerPress,
+}: Props) => {
   const markers = useMemo(() => {
-    return stores?.map(store => {
+    return store?.map(data => {
+      const matchedBrand = brand.find(b => b.brandId === data.brandId);
+
       const imageSource = {
-        uri: `${Config.IMAGE_URL}${store.brandIconImageUrl}?w=50&h=50`,
+        uri: matchedBrand
+          ? `${Config.IMAGE_URL}${matchedBrand.brandIconImageUrl}?w=50&h=50`
+          : `${Config.IMAGE_URL}/img/brand/logo/default.jpg`,
       };
 
       return (
         <NaverMapMarkerOverlay
-          key={`${store.storeId}-${selectedMarkerId === store.storeId}`}
-          latitude={store.y}
-          longitude={store.x}
-          onTap={() => handleMarkerPress(store.storeId)}>
+          key={`${data.storeId}-${selectedMarkerId === data.storeId}`}
+          latitude={data.y}
+          longitude={data.x}
+          onTap={() => handleMarkerPress(data.storeId)}>
           <StoreMarker
             imageSource={imageSource}
-            isSelected={selectedMarkerId === store.storeId}
+            isSelected={selectedMarkerId === data.storeId}
           />
         </NaverMapMarkerOverlay>
       );
     });
-  }, [stores, selectedMarkerId]);
+  }, [store, brand, selectedMarkerId]);
 
   return <>{markers}</>;
 };

--- a/src/feature/search/types/index.ts
+++ b/src/feature/search/types/index.ts
@@ -1,3 +1,5 @@
+import { CommonResponseType } from '@/shared/api/types';
+
 export interface AcSearchParams {
   query: string;
   latitude: number;
@@ -41,9 +43,6 @@ export interface AcSearchResult {
   administrativeDistricts: AcAdministrativeDistrict[];
 }
 
-export interface AcSearchResponse {
-  code: number;
-  codeMessage: string;
-  message: string;
+export interface AcSearchResponse extends CommonResponseType {
   data: AcSearchResult;
 }

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -5,8 +5,6 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SignupRoute from './route/signup';
 import BottomTabBar from './tabs';
 
-import LoginScreen from '@/screens/login';
-import OnboardingScreen from '@/screens/onboarding';
 import StoreSearchScreen from '@/screens/search';
 
 export type MainNavigationProps = {
@@ -21,11 +19,10 @@ const MainRoute = () => {
   const Stack = createNativeStackNavigator<MainNavigationProps>();
 
   return (
-    <Stack.Navigator id={undefined} screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
-
-      <Stack.Screen name="Login" component={LoginScreen} />
-
+    <Stack.Navigator
+      id={undefined}
+      screenOptions={{ headerShown: false }}
+      initialRouteName="Home">
       <Stack.Screen name="SignupRoute" component={SignupRoute} />
 
       <Stack.Screen name="Home" component={BottomTabBar} />

--- a/src/navigation/route/signup/index.tsx
+++ b/src/navigation/route/signup/index.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import LoginScreen from '@/screens/login';
+import OnboardingScreen from '@/screens/onboarding';
 import NicknameInputScreen from '@/screens/signup/nicknameInput';
 import BrandSearchScreen from '@/screens/signup/searchBrand';
 import SelectBrandScreen from '@/screens/signup/selectBrand';
 import SignupSuccessScreen from '@/screens/signup/signupSuccess';
 
 export type SignupNavigationProps = {
+  Onboarding: undefined;
+  Login: undefined;
   NicknameInput: undefined;
   SelectBrand: undefined;
   BrandSearch: undefined;
@@ -19,28 +23,31 @@ const SignupRoute = () => {
   const Stack = createNativeStackNavigator<SignupNavigationProps>();
 
   return (
-    <Stack.Navigator id={undefined} screenOptions={{ headerShown: false }}>
-      {/* 닉네임 입력 & 약관동의 화면 */}
+    <Stack.Navigator
+      id={undefined}
+      initialRouteName="Onboarding"
+      screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+
+      <Stack.Screen name="Login" component={LoginScreen} />
+
       <Stack.Screen name="NicknameInput" component={NicknameInputScreen} />
 
-      {/* 선호 브랜드 선택 화면 */}
       <Stack.Screen
         name="SelectBrand"
         component={SelectBrandScreen}
         options={{
-          gestureEnabled: false, // iOS 스와이프 뒤로가기 방지 & android 설절 필요
+          gestureEnabled: false,
         }}
       />
 
-      {/* 브랜드 검색 화면 */}
       <Stack.Screen name="BrandSearch" component={BrandSearchScreen} />
 
-      {/* 회원가입 완료 화면 */}
       <Stack.Screen
         name="SignupSuccess"
         component={SignupSuccessScreen}
         options={{
-          gestureEnabled: false, // iOS 스와이프 뒤로가기 방지 & android 설절 필요
+          gestureEnabled: false,
         }}
       />
     </Stack.Navigator>

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -7,6 +7,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { useSplashScreen } from '@/shared/hooks/useSplashScreen';
+import { useUserConfig } from '@/shared/hooks/useUserConfig';
 
 interface AppProviderProps {
   children: ReactNode;
@@ -43,6 +44,7 @@ const AppProvider = ({ children }: AppProviderProps) => {
   ).defaultProps!.allowFontScaling = false;
 
   useSplashScreen();
+  useUserConfig();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -21,7 +21,6 @@ import Input from '@/shared/ui/atoms/Input';
 
 const HomeScreen = () => {
   const mapRef = useRef<NaverMapViewRef>(null);
-
   const navigation = useNavigation<RootStackNavigationProp>();
 
   const [brandName, setBrandName] = useState('');
@@ -30,13 +29,10 @@ const HomeScreen = () => {
   );
 
   const { closeModal, isModalOpen, openModal } = useModal();
-
   const { storeParams, searchStoresByLocation } = useMapSearch();
   const { data: stores } = useFetchStores(storeParams);
-
   const { camera, handleMapIdle, hideSearchButton, INITIAL_CAMERA } =
     useMapCamera();
-
   const { setSelectedMarkerId, selectedMarkerId, handleMarkerPress } =
     useMarker();
 
@@ -67,7 +63,8 @@ const HomeScreen = () => {
         <MapOverlay
           handleMarkerPress={handleMarkerPress}
           selectedMarkerId={selectedMarkerId}
-          stores={stores?.data?.content}
+          store={stores?.data.content}
+          brand={stores?.data.brands}
         />
       </NaverMapView>
 

--- a/src/shared/api/types/index.ts
+++ b/src/shared/api/types/index.ts
@@ -1,0 +1,5 @@
+export interface CommonResponseType {
+  code: number;
+  codeMessage: string;
+  message: string;
+}

--- a/src/shared/api/user/fetchConfigApi.ts
+++ b/src/shared/api/user/fetchConfigApi.ts
@@ -1,0 +1,23 @@
+import { Platform } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+
+import { axiosInstance } from '../axiosInstance';
+
+import { UserConfigResponse } from './types';
+
+export const fetchUserConfig = async () => {
+  const appVersion = DeviceInfo.getVersion();
+  const platform = Platform.OS === 'ios' ? 'iOS' : 'Android';
+  const deviceModel = DeviceInfo.getModel();
+  const deviceUUID = await DeviceInfo.getUniqueId();
+
+  const userAgent = `PICSEL/${appVersion} (${platform}; ${deviceModel}; ${deviceUUID})`;
+
+  const response = await axiosInstance.get<UserConfigResponse>('/app/config', {
+    headers: {
+      'User-Agent': userAgent,
+    },
+  });
+
+  return response.data;
+};

--- a/src/shared/api/user/types/index.ts
+++ b/src/shared/api/user/types/index.ts
@@ -1,7 +1,6 @@
-export interface UserConfigResponse {
-  code: number;
-  codeMessage: string;
-  message: string;
+import { CommonResponseType } from '../../types';
+
+export interface UserConfigResponse extends CommonResponseType {
   data: UserVersion;
 }
 

--- a/src/shared/api/user/types/index.ts
+++ b/src/shared/api/user/types/index.ts
@@ -1,0 +1,14 @@
+export interface UserConfigResponse {
+  code: number;
+  codeMessage: string;
+  message: string;
+  data: UserVersion;
+}
+
+export interface UserVersion {
+  version: {
+    forceUpdate: boolean;
+    latest: string;
+    min: string;
+  };
+}

--- a/src/shared/hooks/useUserConfig.ts
+++ b/src/shared/hooks/useUserConfig.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+import { fetchUserConfig } from '../api/user/fetchConfigApi';
+
+export const useUserConfig = () => {
+  useEffect(() => {
+    const init = async () => {
+      const response = await fetchUserConfig();
+
+      console.log(response.data.version);
+    };
+    init();
+  }, []);
+};

--- a/src/shared/store/brand/brandList/index.ts
+++ b/src/shared/store/brand/brandList/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { Brand } from '@/feature/brand/types/brandType';
+import { Brand } from '@/feature/brand/types';
 
 interface BrandStore {
   brandList: Brand[];


### PR DESCRIPTION
## 이슈 번호

> #38 

## 작업 내용 및 테스트 방법

- issue 내용을 확인해주시면 감사하겠습니다!

## To reviewers

준희님께서 요청해주신 내용 그대로 클라이언트 파트에서의 구현을 완료하였습니다.

1. react-native-device-info 라이브러리를 활용하여 user의 device info를 받아옵니다.
2. config API를 호출하여 해당 정보 확인
3. 루트에서 호출하여 앱 실행시 최초 1회에만 실행되게끔 로직 설계하였습니다 -> 서버측 요청사항

- 아직 기획적인 정책상 서버에서 받아오는 meta-data를 어떻게 가공하는지에 대한 내용이 불분명하여 따로 상태관리에 대한 비즈니스 로직은 설계하지 못했습니다.
- 해당 이슈는 추후 기획팀과 논의 후 구현하는 방안이 좋을 것 같습니다.

## 추가로 구현된 type 선언
- 서버에서 내려주는 response에서 공통적으로 사용할 수 있는 type 포맷팅이 있을거 같아 구현해두었습니다.
[✨ Feat : 서버 공통 응답 데이터 type 구현](https://github.com/PICSEL-Labs/picsel-app/commit/7e37136e0bd5f337471fa91a1c2e9b378e7d09a7)

- features/brand/types 네이밍 수정하여 반영하였습니다.
[🔨 Modify: 파일명 및 디렉토리 수정](https://github.com/PICSEL-Labs/picsel-app/commit/07a7072c61cc3eb695d9427c509a73fb3486cb18)
