### PR TITLE
⛑️ QA: TestFlight 0.1(6)v 수정사항 대응

### DIFF
--- a/src/feature/brand/model/hooks/useBrandFilterBottomSheet.ts
+++ b/src/feature/brand/model/hooks/useBrandFilterBottomSheet.ts
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { Easing } from 'react-native-reanimated';
+
+import { useFilteredBrandsStore } from '@/shared/store/brand/filterBrands';
+
+interface Props {
+  visible: boolean;
+  showSheet?: () => void;
+  hideSheet?: () => void;
+}
+
+export const useBrandFilterBottomSheet = ({ visible, hideSheet }: Props) => {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const { resetFilter } = useFilteredBrandsStore();
+
+  const snapPoints = useMemo(() => ['60%', '80%'], []);
+
+  const animationConfigs = useMemo(
+    () => ({
+      duration: 300,
+      easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    if (visible) {
+      bottomSheetRef.current?.present();
+      resetFilter();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  const handleSheetChange = (index: number) => {
+    if (index === -1) {
+      hideSheet();
+    }
+  };
+
+  return {
+    bottomSheetRef,
+    snapPoints,
+    animationConfigs,
+    handleSheetChange,
+  };
+};

--- a/src/feature/brand/ui/molecules/BrandFilterHeader.tsx
+++ b/src/feature/brand/ui/molecules/BrandFilterHeader.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Pressable, Text, View } from 'react-native';
+
+import ReplayIcons from '@/shared/icons/ReplayIcon';
+
+interface Props {
+  selectedCount: number;
+  onReset: () => void;
+}
+
+const BrandFilterHeader = ({ selectedCount, onReset }: Props) => {
+  return (
+    <View className="relative my-1 w-full items-center justify-center px-4">
+      <Text className="text-center text-gray-900 title-01">브랜드 찾기</Text>
+
+      <Pressable onPress={onReset} className="absolute right-5">
+        <View className="flex-row items-center">
+          <Text
+            className={`mr-1 headline-02 ${
+              selectedCount > 0 ? 'text-pink-500' : 'text-gray-500'
+            }`}>
+            초기화
+          </Text>
+          <ReplayIcons
+            width={24}
+            height={24}
+            shape={selectedCount > 0 ? 'true' : 'false'}
+          />
+        </View>
+      </Pressable>
+    </View>
+  );
+};
+
+export default BrandFilterHeader;

--- a/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
+++ b/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
@@ -1,100 +1,102 @@
 import React, { useEffect } from 'react';
 
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
 
-import { useBrandFilterSheet } from '../../model/hooks/useBrandFilterSheet';
+import { useBrandFilterBottomSheet } from '../../model/hooks/useBrandFilterBottomSheet';
 import { useHandleScroll } from '../../model/hooks/useHandleScroll';
 import { useGetBrandsList } from '../../queries/useGetBrandList';
+import BrandFilterHeader from '../molecules/BrandFilterHeader';
 
 import BrandGridList from './BrandGridList';
 import SelectButton from './SelectButton';
 
-import ReplayIcons from '@/shared/icons/ReplayIcon';
 import { useBrandListStore } from '@/shared/store/brand/brandList';
 import { useFilteredBrandsStore } from '@/shared/store/brand/filterBrands';
-import BottomSheet from '@/shared/ui/molecules/BottomSheet';
+import { useToastStore } from '@/shared/store/ui/toast';
+import { bottomSheetIndicator } from '@/styles/bottomSheetIndicator';
+import { bottomSheetShadow } from '@/styles/shadows';
 
 interface Props {
   visible: boolean;
-  onClose: () => void;
+  showSheet: () => void;
+  hideSheet: () => void;
 }
 
-const BrandFilterBottomSheet = ({ visible, onClose }: Props) => {
+const BrandFilterBottomSheet = ({ visible, showSheet, hideSheet }: Props) => {
   const { data: brands } = useGetBrandsList();
   const { brandList, setBrandList } = useBrandListStore();
-  const { handleScroll, scrollViewRef } = useHandleScroll();
+  const { scrollViewRef, handleScroll } = useHandleScroll();
+
+  const { showToast } = useToastStore();
+
   const { tempFilteredList, filterBrand, resetFilter, applyFilter } =
     useFilteredBrandsStore();
-  // const { showToast } = useToastStore();
-  const { panGesture, animatedStyle } = useBrandFilterSheet({
-    visible,
-    onClose,
-  });
+
+  const { bottomSheetRef, snapPoints, animationConfigs, handleSheetChange } =
+    useBrandFilterBottomSheet({ visible, showSheet, hideSheet });
 
   useEffect(() => {
     if (brands) {
       setBrandList(brands);
     }
-  }, [brands, setBrandList]);
+  }, [brands]);
 
-  const handleFilter = (brandId: string, name: string) => {
+  const handlePressBrand = (brandId: string, name: string) => {
     const success = filterBrand(brandId, name);
-
     if (!success) {
-      // showToast('브랜드는 최대 5개까지 선택 가능해요', 600); -> 바텀시트 리팩토링이 진행되지 않아 토스트 z-index가 묻혀서 바텀시트 뒤로 렌더링 되는거 같아요
-      // 일단 마진값 크게 줘서 토스트 정상 렌더링 확인하였습니다.
-      // 리팩토링 진행해주시면 토스트가 시트 위로 올라올 거 같아요.
+      showToast('브랜드는 최대 5개까지 선택할 수 있어요', 50);
+      return;
     }
   };
 
-  const handleApplyFilter = () => {
+  const handleApply = () => {
     applyFilter();
-    onClose();
+    hideSheet();
   };
 
   return (
-    <BottomSheet
-      title="브랜드 찾기"
-      headerRight={
-        <Pressable onPress={resetFilter}>
-          <View className="flex-row">
-            <Text
-              className={`mr-1 headline-02 ${
-                tempFilteredList.length > 0 ? 'text-pink-500' : 'text-gray-500'
-              }`}>
-              초기화
-            </Text>
-            <ReplayIcons
-              width={24}
-              height={24}
-              shape={tempFilteredList.length > 0 ? 'true' : 'false'}
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      index={0}
+      enableDynamicSizing={false} // 동적 높이 조절 기능 Off -> 최대 높이 snapPoints의 index={1}
+      enableOverDrag={false}
+      style={bottomSheetShadow}
+      snapPoints={snapPoints}
+      handleIndicatorStyle={bottomSheetIndicator}
+      animationConfigs={animationConfigs}
+      enableContentPanningGesture={false} // 드래그로 시트 움직임 (기본 동작) 차단
+      onChange={handleSheetChange}
+      enablePanDownToClose>
+      <View className="flex-1">
+        <BrandFilterHeader
+          selectedCount={tempFilteredList.length}
+          onReset={resetFilter}
+        />
+
+        <BottomSheetScrollView
+          ref={scrollViewRef}
+          onScroll={handleScroll}
+          showsVerticalScrollIndicator={false}>
+          <View className="px-4 pt-2">
+            <BrandGridList
+              brandList={brandList}
+              selectedList={tempFilteredList}
+              onPress={handlePressBrand}
+              excludeNoneBrand
             />
           </View>
-        </Pressable>
-      }
-      visible={visible}
-      animatedStyle={animatedStyle}
-      panGesture={panGesture}>
-      <ScrollView
-        ref={scrollViewRef}
-        onScroll={handleScroll}
-        scrollEventThrottle={16}
-        showsVerticalScrollIndicator
-        indicatorStyle="default">
-        <BrandGridList
-          brandList={brandList}
-          selectedList={tempFilteredList}
-          onPress={handleFilter}
-          excludeNoneBrand
-        />
-      </ScrollView>
+        </BottomSheetScrollView>
 
-      <SelectButton
-        actualSelectedCount={tempFilteredList.length}
-        disabled={!!tempFilteredList.length}
-        onPress={handleApplyFilter}
-      />
-    </BottomSheet>
+        <View className="p-5">
+          <SelectButton
+            actualSelectedCount={tempFilteredList.length}
+            disabled={tempFilteredList.length === 0}
+            onPress={handleApply}
+          />
+        </View>
+      </View>
+    </BottomSheetModal>
   );
 };
 

--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -36,7 +36,7 @@ const BrandGridList = ({
   return (
     <>
       {chunkArray(filteredBrandList, 3).map((row, rowIndex) => (
-        <View key={rowIndex} className="mx-3 mb-6 flex-row justify-between">
+        <View key={rowIndex} className="mb-6 flex-row justify-between">
           {row.map(item => {
             const isSelected = selectedList.some(
               selected => selected.brandId === item.brandId,

--- a/src/feature/brand/ui/organisms/SelectButton.tsx
+++ b/src/feature/brand/ui/organisms/SelectButton.tsx
@@ -28,7 +28,7 @@ const SelectButton = ({
   return (
     <View className="w-full items-center">
       <Button
-        color={!disabled ? 'disabled' : 'active'}
+        color={disabled ? 'disabled' : 'active'}
         textColor="white"
         text={`선택 완료 (${actualSelectedCount})`}
         disabled={!disabled}

--- a/src/feature/map/hooks/useBottomSheetManager.ts
+++ b/src/feature/map/hooks/useBottomSheetManager.ts
@@ -1,37 +1,58 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
-export type BottomSheetType = 'nearby' | 'detail';
+export type BottomSheetType = 'nearby' | 'detail' | 'filter'; // 브랜드 찾기 타입 추가
 
 export const useBottomSheetManager = () => {
   const [nearbyBrandVisible, setNearbyBrandVisible] = useState(false);
   const [detailBrandVisible, setDetailBrandVisible] = useState(false);
+  const [brandFilterVisible, setBrandFilterVisible] = useState(false);
 
   const hideAllSheet = useCallback(() => {
     setNearbyBrandVisible(false);
     setDetailBrandVisible(false);
+    setBrandFilterVisible(false);
   }, []);
 
   const showSheet = useCallback((type: BottomSheetType) => {
-    if (type === 'nearby') {
-      setDetailBrandVisible(false);
-      setNearbyBrandVisible(true);
-    } else {
-      setNearbyBrandVisible(false);
-      setDetailBrandVisible(true);
+    switch (type) {
+      case 'nearby':
+        setNearbyBrandVisible(true);
+        setDetailBrandVisible(false);
+        setBrandFilterVisible(false);
+        break;
+
+      case 'detail':
+        setDetailBrandVisible(true);
+        setNearbyBrandVisible(false);
+        setBrandFilterVisible(false);
+        break;
+
+      case 'filter':
+        setBrandFilterVisible(true);
+        setNearbyBrandVisible(false);
+        setDetailBrandVisible(false);
+        break;
     }
   }, []);
 
   const hideSheet = useCallback((type: BottomSheetType) => {
-    if (type === 'nearby') {
-      setNearbyBrandVisible(false);
-    } else {
-      setDetailBrandVisible(false);
+    switch (type) {
+      case 'nearby':
+        setNearbyBrandVisible(false);
+        break;
+      case 'detail':
+        setDetailBrandVisible(false);
+        break;
+      case 'filter':
+        setBrandFilterVisible(false);
+        break;
     }
   }, []);
 
   return {
     nearbyBrandVisible,
     detailBrandVisible,
+    brandFilterVisible,
     hideAllSheet,
     showSheet,
     hideSheet,

--- a/src/feature/map/hooks/useHomeScreen.ts
+++ b/src/feature/map/hooks/useHomeScreen.ts
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import { NaverMapViewRef } from '@mj-studio/react-native-naver-map';
 import { useNavigation } from '@react-navigation/native';
@@ -38,6 +38,7 @@ export const useHomeScreen = () => {
   const {
     nearbyBrandVisible,
     detailBrandVisible,
+    brandFilterVisible,
     hideAllSheet,
     hideSheet,
     showSheet,
@@ -102,6 +103,7 @@ export const useHomeScreen = () => {
     // Bottom Sheets
     nearbyBrandVisible,
     detailBrandVisible,
+    brandFilterVisible,
     hideSheet,
     showSheet,
 

--- a/src/feature/map/ui/organisms/MapActionButton.tsx
+++ b/src/feature/map/ui/organisms/MapActionButton.tsx
@@ -8,37 +8,44 @@ interface Props {
   activeButton: 'brand' | 'location';
   setActiveButton: Dispatch<SetStateAction<'brand' | 'location'>>;
   handleLocationSearch: () => void;
-  isModalOpen: boolean;
-  openModal: () => void;
-  closeModal: () => void;
   detailHideSheet: () => void;
   nearbyHideSheet: () => void;
+  showFilterSheet: () => void;
+  brandFilterVisible: boolean;
+  hideFilterSheet: () => void;
 }
 
 const MapActionButton = ({
   setActiveButton,
   activeButton,
   handleLocationSearch,
-  isModalOpen,
-  openModal,
-  closeModal,
+  showFilterSheet,
+  brandFilterVisible,
   detailHideSheet,
   nearbyHideSheet,
+  hideFilterSheet,
 }: Props) => {
   const handleModal = useCallback(() => {
-    if (isModalOpen) {
-      closeModal();
+    if (brandFilterVisible) {
+      hideFilterSheet();
     } else {
       detailHideSheet();
       nearbyHideSheet();
-      openModal();
+      showFilterSheet();
       setActiveButton('brand');
     }
-  }, [isModalOpen, openModal, closeModal, setActiveButton]);
+  }, [
+    brandFilterVisible,
+    hideFilterSheet,
+    showFilterSheet,
+    detailHideSheet,
+    nearbyHideSheet,
+    setActiveButton,
+  ]);
 
   return activeButton === 'brand' ? (
     <BrandFilterButton
-      variant={isModalOpen ? 'active' : 'inactive'}
+      variant={brandFilterVisible ? 'active' : 'inactive'}
       onPress={handleModal}
     />
   ) : (

--- a/src/feature/qr/ui/molecules/QrScanFooter.tsx
+++ b/src/feature/qr/ui/molecules/QrScanFooter.tsx
@@ -10,7 +10,7 @@ const QrScanFooter = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
 
   return (
-    <View className="w-full items-center gap-4 pb-11">
+    <View className="w-full items-center gap-4 pb-28">
       <Text className="text-center text-white body-rg-01">
         QR 스캔을 지원하지 않는 브랜드일 땐,{'\n'} 사진이 담긴 링크를
         열어드릴게요

--- a/src/feature/qr/ui/organisms/QrScanOverlay.tsx
+++ b/src/feature/qr/ui/organisms/QrScanOverlay.tsx
@@ -10,7 +10,7 @@ import { QrScanFrame } from '../molecules/QrScanFrame';
 
 const { width, height } = Dimensions.get('window');
 const BOX_SIZE = width * 0.7;
-const FRAME_TOP = (height - BOX_SIZE) / 2;
+const FRAME_TOP = (height - BOX_SIZE) / 2.5;
 const FRAME_LEFT = (width - BOX_SIZE) / 2;
 
 const QrScanOverlay = () => {

--- a/src/feature/search/hooks/useStoreSearch.ts
+++ b/src/feature/search/hooks/useStoreSearch.ts
@@ -2,10 +2,9 @@ import { useMemo } from 'react';
 
 import { useSearchAutocomplete } from '@/feature/search/queries/useSearchAutoComplete';
 import { useDebouncedValue } from '@/shared/hooks/useDebouncedValue';
+import { useLocationStore } from '@/shared/store';
 
 type UIState = 'hasResults' | 'noResults';
-
-const DEFAULT_COORDS = { latitude: 37.5666102, longitude: 126.9783881 };
 
 interface Props {
   minLen?: number;
@@ -16,12 +15,14 @@ interface Props {
 }
 
 export const useStoreSearch = (query: string, props: Props = {}) => {
+  const { userLocation } = useLocationStore();
+
   const {
     minLen = 2, // 최소 2글자로 요청
     debounceMs = 400, // 0.4초로 디바운스
     radius = 999, // 임시 반경값
-    latitude = DEFAULT_COORDS.latitude,
-    longitude = DEFAULT_COORDS.longitude,
+    latitude = userLocation.latitude,
+    longitude = userLocation.longitude,
   } = props;
 
   const debouncedQuery = useDebouncedValue(query, debounceMs);

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -19,9 +19,6 @@ const HomeScreen = () => {
     setBrandName,
     activeButton,
     setActiveButton,
-    isModalOpen,
-    openModal,
-    closeModal,
     filteredStores,
     filteredBrands,
     isFavorite,
@@ -32,6 +29,7 @@ const HomeScreen = () => {
     clearSelection,
     nearbyBrandVisible,
     detailBrandVisible,
+    brandFilterVisible,
     hideSheet,
     showSheet,
     handleLocationSearch,
@@ -82,14 +80,18 @@ const HomeScreen = () => {
         activeButton={activeButton}
         setActiveButton={setActiveButton}
         handleLocationSearch={handleLocationSearch}
-        isModalOpen={isModalOpen}
-        openModal={openModal}
-        closeModal={closeModal}
+        brandFilterVisible={brandFilterVisible}
+        showFilterSheet={() => showSheet('filter')}
+        hideFilterSheet={() => hideSheet('filter')}
         detailHideSheet={() => hideSheet('detail')}
         nearbyHideSheet={() => hideSheet('nearby')}
       />
 
-      <BrandFilterBottomSheet visible={isModalOpen} onClose={closeModal} />
+      <BrandFilterBottomSheet
+        visible={brandFilterVisible}
+        hideSheet={() => hideSheet('filter')}
+        showSheet={() => showSheet('filter')}
+      />
 
       <NearbyBrandBottomSheet
         visible={nearbyBrandVisible}

--- a/src/shared/ui/atoms/Toast/index.tsx
+++ b/src/shared/ui/atoms/Toast/index.tsx
@@ -14,11 +14,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useToastStore } from '@/shared/store/ui/toast';
 
 const GRADIENT_COLORS = [
-  'rgba(255, 255, 255, 1)',
+  'rgba(17, 17, 20, 0.9)',
+  'rgba(17, 17, 20, 0.9)',
+  'rgba(17, 17, 20, 1.3)',
   'rgba(17, 17, 20, 0.8)',
-  'rgba(17, 17, 20, 1)',
   'rgba(17, 17, 20, 0.8)',
-  'rgba(255, 255, 255, 1)',
 ];
 
 const GRADIENT_LOCATIONS = [0, 0.2, 0.4, 0.95, 1];


### PR DESCRIPTION
## 이슈 번호

> ex) #52 

## 작업 내용 및 테스트 방법

- QR 인식 영역 정렬 수정
- Toast 디자인 그라디언트 컬러값 수정
- bottom sheet 인터렉션 수정 (`@gorhom/bottom-sheet` 사용)
- 브랜드 검색 결과 리스트 정렬 시 위/경도 값 파라미터 적용

## To reviewers
브랜드 5개 초과 선택 시 노출되는 토스트 이슈는 해결하지 못했습니다.. 😭
말씀해주신 대로 리소스 누수 방지를 위해 우선 일단락 했습니다.. 😅

`HomeScreen`에서 구현 진행해주신 두 가지 바텀 시트(이 근처 브랜드, 브랜드 상세 정보) 내용 참고하였고,
`useBottomSheetManager` 내 `BottomSheetType`에 `'filter'`로 타입 추가하여 바텀 시트 한 종류로써
브랜드 찾기(filter) 바텀시트를 추가하였습니다! 