### PR TITLE
✨ Feat: 브랜드 찾기 바텀시트 수정 대응

### DIFF
--- a/src/feature/brand/model/hooks/useBrandTooltipOnce.ts
+++ b/src/feature/brand/model/hooks/useBrandTooltipOnce.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Animated, Easing } from 'react-native';
+
+import { useTooltipStore } from '@/shared/store/ui/tooltip';
+
+/**
+ * useBrandTooltipOnce
+ * - 브랜드 필터 툴팁은 최초 1번만 노출
+ * - 3초 후 자동으로 사라지며, fade-out 애니메이션으로 서서히 사라지듯 구현
+ */
+export const useBrandTooltipOnce = () => {
+  const [showBrandTooltip, setShowBrandTooltip] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+
+  const { brandTooltipShown, setBrandTooltipShown } = useTooltipStore();
+
+  useEffect(() => {
+    if (brandTooltipShown) {
+      return;
+    }
+
+    setShowBrandTooltip(true);
+    setBrandTooltipShown(true);
+
+    const timer = setTimeout(() => {
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 300,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }).start(() => {
+        setShowBrandTooltip(false);
+      });
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return { showBrandTooltip, fadeAnim };
+};

--- a/src/feature/brand/ui/molecules/BrandFilterHeader.tsx
+++ b/src/feature/brand/ui/molecules/BrandFilterHeader.tsx
@@ -2,33 +2,44 @@ import React from 'react';
 
 import { Pressable, Text, View } from 'react-native';
 
-import ReplayIcons from '@/shared/icons/ReplayIcon';
+import { useFilteredBrandsStore } from '@/shared/store';
 
 interface Props {
-  selectedCount: number;
   onReset: () => void;
 }
 
-const BrandFilterHeader = ({ selectedCount, onReset }: Props) => {
+const BrandFilterHeader = ({ onReset }: Props) => {
+  const { applyFilter } = useFilteredBrandsStore();
   return (
-    <View className="relative my-1 w-full items-center justify-center px-4">
+    <View className="w-full flex-row items-center px-4 pb-2">
+      <View className="flex-1">
+        <Pressable onPress={onReset}>
+          <Text className="p-2 text-gray-600 headline-02">전체해제</Text>
+        </Pressable>
+      </View>
+
       <Text className="text-center text-gray-900 title-01">브랜드 찾기</Text>
 
-      <Pressable onPress={onReset} className="absolute right-5">
-        <View className="flex-row items-center">
-          <Text
-            className={`mr-1 headline-02 ${
-              selectedCount > 0 ? 'text-pink-500' : 'text-gray-500'
-            }`}>
-            초기화
-          </Text>
-          <ReplayIcons
-            width={24}
-            height={24}
-            shape={selectedCount > 0 ? 'true' : 'false'}
-          />
-        </View>
-      </Pressable>
+      <View className="flex-1 items-end">
+        <Pressable
+          onPress={applyFilter}
+          style={({ pressed }) => [
+            {
+              padding: 8,
+              borderRadius: 12,
+              backgroundColor: pressed ? '#FECDDD' : 'transparent',
+            },
+          ]}>
+          {({ pressed }) => (
+            <Text
+              className={`headline-02 ${
+                pressed ? 'text-white' : 'text-pink-500'
+              }`}>
+              적용하기
+            </Text>
+          )}
+        </Pressable>
+      </View>
     </View>
   );
 };

--- a/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
+++ b/src/feature/brand/ui/organisms/BrandFilterBottomSheet.tsx
@@ -9,7 +9,6 @@ import { useGetBrandsList } from '../../queries/useGetBrandList';
 import BrandFilterHeader from '../molecules/BrandFilterHeader';
 
 import BrandGridList from './BrandGridList';
-import SelectButton from './SelectButton';
 
 import { useBrandListStore } from '@/shared/store/brand/brandList';
 import { useFilteredBrandsStore } from '@/shared/store/brand/filterBrands';
@@ -30,8 +29,13 @@ const BrandFilterBottomSheet = ({ visible, showSheet, hideSheet }: Props) => {
 
   const { showToast } = useToastStore();
 
-  const { tempFilteredList, filterBrand, resetFilter, applyFilter } =
+  const { tempFilteredList, filterBrand, resetFilter } =
     useFilteredBrandsStore();
+
+  const handleReset = () => {
+    resetFilter();
+    showToast('선택한 브랜드가 모두 해제됐어요', 50);
+  };
 
   const { bottomSheetRef, snapPoints, animationConfigs, handleSheetChange } =
     useBrandFilterBottomSheet({ visible, showSheet, hideSheet });
@@ -50,11 +54,6 @@ const BrandFilterBottomSheet = ({ visible, showSheet, hideSheet }: Props) => {
     }
   };
 
-  const handleApply = () => {
-    applyFilter();
-    hideSheet();
-  };
-
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
@@ -69,32 +68,18 @@ const BrandFilterBottomSheet = ({ visible, showSheet, hideSheet }: Props) => {
       onChange={handleSheetChange}
       enablePanDownToClose>
       <View className="flex-1">
-        <BrandFilterHeader
-          selectedCount={tempFilteredList.length}
-          onReset={resetFilter}
-        />
-
+        <BrandFilterHeader onReset={handleReset} />
         <BottomSheetScrollView
           ref={scrollViewRef}
           onScroll={handleScroll}
           showsVerticalScrollIndicator={false}>
-          <View className="px-4 pt-2">
-            <BrandGridList
-              brandList={brandList}
-              selectedList={tempFilteredList}
-              onPress={handlePressBrand}
-              excludeNoneBrand
-            />
-          </View>
-        </BottomSheetScrollView>
-
-        <View className="p-5">
-          <SelectButton
-            actualSelectedCount={tempFilteredList.length}
-            disabled={tempFilteredList.length === 0}
-            onPress={handleApply}
+          <BrandGridList
+            brandList={brandList}
+            selectedList={tempFilteredList}
+            onPress={handlePressBrand}
+            excludeNoneBrand
           />
-        </View>
+        </BottomSheetScrollView>
       </View>
     </BottomSheetModal>
   );

--- a/src/feature/brand/ui/organisms/BrandFilterButton.tsx
+++ b/src/feature/brand/ui/organisms/BrandFilterButton.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Pressable, PressableProps, Text } from 'react-native';
+import { Animated, Pressable, PressableProps, View } from 'react-native';
+
+import BrandFilterTooltip from './BrandFilterTooltip';
 
 import { FILTER_BUTTON_STYLE } from '@/shared/constants/styles/filterButton';
 import FilterIcons from '@/shared/icons/FilterIcons';
@@ -19,34 +21,31 @@ const buttonVariants = cva(FILTER_BUTTON_STYLE, {
     variant: 'inactive',
   },
 });
+interface Props extends PressableProps, VariantProps<typeof buttonVariants> {
+  showTooltip?: boolean;
+  fadeAnim?: Animated.Value;
+}
 
-const textVariants = cva('body-rg-02', {
-  variants: {
-    variant: {
-      active: 'text-neutral-white',
-      inactive: 'text-gray-900',
-    },
-  },
-  defaultVariants: {
-    variant: 'inactive',
-  },
-});
-
-interface Props extends PressableProps, VariantProps<typeof buttonVariants> {}
-
-const BrandFilterButton = ({ variant = 'inactive', ...props }: Props) => {
+const BrandFilterButton = ({
+  variant = 'inactive',
+  showTooltip = false,
+  fadeAnim,
+  ...props
+}: Props) => {
   return (
-    <Pressable
-      className={cn(buttonVariants({ variant }))}
-      style={[filterButtonShadow[variant]]}
-      {...props}>
-      <FilterIcons
-        shape={variant === 'active' ? 'white' : 'gray'}
-        width={24}
-        height={24}
-      />
-      <Text className={cn(textVariants({ variant }))}>브랜드 찾기</Text>
-    </Pressable>
+    <View>
+      <Pressable
+        className={cn(buttonVariants({ variant }))}
+        style={[filterButtonShadow[variant]]}
+        {...props}>
+        <FilterIcons
+          shape={variant === 'active' ? 'white' : 'gray'}
+          width={24}
+          height={24}
+        />
+      </Pressable>
+      {showTooltip && <BrandFilterTooltip fadeAnim={fadeAnim} />}
+    </View>
   );
 };
 

--- a/src/feature/brand/ui/organisms/BrandFilterTooltip.tsx
+++ b/src/feature/brand/ui/organisms/BrandFilterTooltip.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Animated, Text, View } from 'react-native';
+import { scale } from 'react-native-size-matters';
+
+import { useFloatingAnimation } from '@/shared/hooks/useFloatingAnimation';
+import Tooltip from '@/shared/icons/Tooltip';
+import { insetShadow } from '@/styles/shadows';
+
+const BrandFilterTooltip = ({ fadeAnim }: { fadeAnim: Animated.Value }) => {
+  const translateY = useFloatingAnimation({
+    toValue: 2,
+    duration1: 900,
+    duration2: 500,
+  });
+
+  return (
+    <Animated.View
+      className="absolute top-[55px] z-10 mx-3 items-center rounded-2xl bg-primary-pink px-3 py-2"
+      style={{
+        width: scale(195),
+        boxShadow: insetShadow.default,
+        opacity: fadeAnim,
+        transform: [{ translateY }],
+      }}>
+      <View className="absolute -top-1.5 z-0" style={{ left: 15 }}>
+        <Tooltip shape="left" />
+      </View>
+      <Text className="text-white body-rg-02">
+        찾는 브랜드만 쏙 골라볼 수 있어요
+      </Text>
+    </Animated.View>
+  );
+};
+
+export default BrandFilterTooltip;

--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -36,7 +36,7 @@ const BrandGridList = ({
   return (
     <>
       {chunkArray(filteredBrandList, 3).map((row, rowIndex) => (
-        <View key={rowIndex} className="mb-6 flex-row justify-between">
+        <View key={rowIndex} className="mb-6 flex-row justify-between py-2">
           {row.map(item => {
             const isSelected = selectedList.some(
               selected => selected.brandId === item.brandId,

--- a/src/feature/map/ui/organisms/MapActionButton.tsx
+++ b/src/feature/map/ui/organisms/MapActionButton.tsx
@@ -1,5 +1,7 @@
 import React, { Dispatch, SetStateAction, useCallback } from 'react';
 
+import { Animated } from 'react-native';
+
 import CurrentLocationSearch from './CurrentLocationSearch';
 
 import BrandFilterButton from '@/feature/brand/ui/organisms/BrandFilterButton';
@@ -13,6 +15,8 @@ interface Props {
   showFilterSheet: () => void;
   brandFilterVisible: boolean;
   hideFilterSheet: () => void;
+  showBrandTooltip: boolean;
+  fadeAnim: Animated.Value;
 }
 
 const MapActionButton = ({
@@ -24,6 +28,8 @@ const MapActionButton = ({
   detailHideSheet,
   nearbyHideSheet,
   hideFilterSheet,
+  showBrandTooltip,
+  fadeAnim,
 }: Props) => {
   const handleModal = useCallback(() => {
     if (brandFilterVisible) {
@@ -47,6 +53,8 @@ const MapActionButton = ({
     <BrandFilterButton
       variant={brandFilterVisible ? 'active' : 'inactive'}
       onPress={handleModal}
+      showTooltip={showBrandTooltip}
+      fadeAnim={fadeAnim}
     />
   ) : (
     <CurrentLocationSearch onLocationSearch={handleLocationSearch} />

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { NaverMapView } from '@mj-studio/react-native-naver-map';
 import { StyleSheet } from 'react-native';
 
+import { useBrandTooltipOnce } from '@/feature/brand/model/hooks/useBrandTooltipOnce';
 import BrandFilterBottomSheet from '@/feature/brand/ui/organisms/BrandFilterBottomSheet';
 import { useHomeScreen } from '@/feature/map/hooks/useHomeScreen';
 import BrandDetailBottomSheet from '@/feature/map/ui/organisms/BrandDetailBottomSheet';
@@ -36,6 +37,8 @@ const HomeScreen = () => {
     handleNavigateSearch,
     userLocation,
   } = useHomeScreen();
+
+  const { showBrandTooltip, fadeAnim } = useBrandTooltipOnce();
 
   return (
     <ScreenLayout>
@@ -85,6 +88,8 @@ const HomeScreen = () => {
         hideFilterSheet={() => hideSheet('filter')}
         detailHideSheet={() => hideSheet('detail')}
         nearbyHideSheet={() => hideSheet('nearby')}
+        showBrandTooltip={showBrandTooltip}
+        fadeAnim={fadeAnim}
       />
 
       <BrandFilterBottomSheet

--- a/src/shared/constants/styles/filterButton.ts
+++ b/src/shared/constants/styles/filterButton.ts
@@ -1,2 +1,2 @@
 export const FILTER_BUTTON_STYLE =
-  'rounded-[27px] flex-row items-center justify-center pt-[8px] pb-[8px] pl-[12px] pr-[10px] flex-shrink-0 self-start ml-[16px]';
+  'w-10 h-10 rounded-full items-center justify-center mx-4';

--- a/src/shared/store/ui/tooltip/index.ts
+++ b/src/shared/store/ui/tooltip/index.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface TooltipStore {
+  brandTooltipShown: boolean; // 툴팁을 한 번이라도 보여줬는가? (최초 노출 여부 기억)
+  setBrandTooltipShown: (visible: boolean) => void;
+}
+
+export const useTooltipStore = create<TooltipStore>(set => ({
+  brandTooltipShown: false,
+  setBrandTooltipShown: visible => set({ brandTooltipShown: visible }),
+}));


### PR DESCRIPTION
## 이슈 번호

> ex) #57 

## 작업 내용 및 테스트 방법

> - 브랜드 찾기 액션 버튼 디자인 수정
> - 하단 CTA 적용하기 버튼 우측 상단으로 위치 및 디자인 수정
> - 초기화 → 전체 해제로 수정하여 좌측 상단에 적용
> - 브랜드 필터 설명 툴팁 구현

## To reviewers
툴팁 인터렉션에 대한 프로토 정의가 따로 되어있지 않아서
다은님께서 여쭤본 후, 소셜 로그인 내에서 나오는 애니메이션과 동일하게 하고, 페이드 인/아웃으로 사라지게 구현 했습니다!

토스트 노출 이슈는 여전히 미해결입니다,, 큰 버그를 안겨 드리고 가는 거 같아 죄송하네요.. 😭 코드 리뷰는 언제나 환영입니다! 🌱