### PR TITLE
✨ Feat: 내픽셀 API 연결

### DIFF
--- a/src/feature/picsel/mutations/useDeletePicsels.ts
+++ b/src/feature/picsel/mutations/useDeletePicsels.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deletePicselsApi } from '../myPicsel/api/deletePicselsApi';
+import { DeletePicselsRequest } from '../myPicsel/types';
+
+export const useDeletePicsels = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: DeletePicselsRequest) => deletePicselsApi(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myPicsels'] });
+    },
+    onError: error => {
+      console.error('픽셀 삭제 실패:', error);
+    },
+  });
+};

--- a/src/feature/picsel/myPicsel/api/deletePicselsApi.ts
+++ b/src/feature/picsel/myPicsel/api/deletePicselsApi.ts
@@ -1,0 +1,11 @@
+import { DeletePicselsRequest } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const deletePicselsApi = async (
+  request: DeletePicselsRequest,
+): Promise<void> => {
+  await axiosInstance.delete('/picsels', {
+    data: request,
+  });
+};

--- a/src/feature/picsel/myPicsel/api/getMyPicselsApi.ts
+++ b/src/feature/picsel/myPicsel/api/getMyPicselsApi.ts
@@ -13,7 +13,7 @@ export const getMyPicselsApi = async (
   const { page = 0, size = 20, sort = 'RECENT_DESC' } = params;
 
   const response = await axiosInstance.get<MyPicselsResponse>('/picsels/my', {
-    params: { page, size, sort },
+    params: { page, size, sortType: sort },
   });
 
   return response.data.data;

--- a/src/feature/picsel/myPicsel/api/getMyPicselsApi.ts
+++ b/src/feature/picsel/myPicsel/api/getMyPicselsApi.ts
@@ -1,0 +1,20 @@
+import { MyPicselParams, MyPicselResult } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+import { CommonResponseType } from '@/shared/api/types';
+
+interface MyPicselsResponse extends CommonResponseType {
+  data: MyPicselResult;
+}
+
+export const getMyPicselsApi = async (
+  params: MyPicselParams = {},
+): Promise<MyPicselResult> => {
+  const { page = 0, size = 20, sort = 'RECENT_DESC' } = params;
+
+  const response = await axiosInstance.get<MyPicselsResponse>('/picsels/my', {
+    params: { page, size, sort },
+  });
+
+  return response.data.data;
+};

--- a/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import { HORIZONTAL_PADDING, ITEM_SPACING } from '../../../constants/photoGrid';
-import { MonthGroup, YearGroup } from '../../../data/MOCK_YEAR_DATA';
+import { MonthGroup, YearGroup } from '../../../types';
 
 import PhotoCard from '@/feature/picsel/shared/components/ui/molecules/PhotoCard';
 import FilterViewSkeleton from '@/feature/picsel/shared/components/ui/molecules/Skeleton/FilterViewSkeleton';

--- a/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import { HORIZONTAL_PADDING, ITEM_SPACING } from '../../../constants/photoGrid';
-import { MonthGroup, YearGroup } from '../../../data/MOCK_YEAR_DATA';
+import { MonthGroup, YearGroup } from '../../../types';
 
 import PhotoCard from '@/feature/picsel/shared/components/ui/molecules/PhotoCard';
 import FilterViewSkeleton from '@/feature/picsel/shared/components/ui/molecules/Skeleton/FilterViewSkeleton';

--- a/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
@@ -8,10 +8,7 @@ import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecul
 import FolderHeader from '@/feature/picsel/shared/components/ui/molecules/FolderHeader';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import {
-  MyPicselSortType,
-  useSortActionSheet,
-} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
+import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
@@ -26,6 +23,8 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
     photoData,
     isLoading,
     totalPhotos,
+
+    setSortType,
 
     isSelecting,
     selectedPhotos,
@@ -50,13 +49,8 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
     handleMove,
   } = useMonthFolder({ year, month });
 
-  // TODO: 정렬 로직 구현
-  const handleSort = (sortType: MyPicselSortType) => {
-    console.log('정렬 타입:', sortType);
-  };
-
   const { showSortSheet } = useSortActionSheet({
-    onSort: handleSort,
+    onSort: setSortType,
   });
 
   return (

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -16,10 +16,7 @@ import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/Pho
 import YearFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/YearFilterView';
 import UpButton from '@/feature/picsel/shared/components/ui/atoms/Button/UpButton';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import {
-  MyPicselSortType,
-  useSortActionSheet,
-} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
+import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
 const MyPicselTemplate = () => {
@@ -29,6 +26,8 @@ const MyPicselTemplate = () => {
     isLoading,
     totalPhotos,
     hasPhotos,
+
+    setSortType,
 
     dateFilter,
     handleDateFilterChange,
@@ -59,13 +58,8 @@ const MyPicselTemplate = () => {
     handleViewMonthFolder,
   } = useMyPicsel();
 
-  // TODO: 정렬 로직 구현
-  const handleSort = (sortType: MyPicselSortType) => {
-    console.log('정렬 타입:', sortType);
-  };
-
   const { showSortSheet } = useSortActionSheet({
-    onSort: handleSort,
+    onSort: setSortType,
   });
 
   if (!isLoading && !hasPhotos) {

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -14,7 +14,6 @@ import DateFilterButton from '../atoms/DateFilterButton';
 import MonthFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView';
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import YearFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/YearFilterView';
-import { MOCK_YEAR_DATA } from '@/feature/picsel/myPicsel/data/MOCK_YEAR_DATA';
 import UpButton from '@/feature/picsel/shared/components/ui/atoms/Button/UpButton';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
 import {
@@ -26,6 +25,7 @@ import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 const MyPicselTemplate = () => {
   const {
     photoData,
+    yearGroups,
     isLoading,
     totalPhotos,
     hasPhotos,
@@ -111,7 +111,7 @@ const MyPicselTemplate = () => {
         <YearFilterView
           ref={flatListRef}
           onScroll={handleScroll}
-          yearGroups={MOCK_YEAR_DATA}
+          yearGroups={yearGroups}
           isLoading={isLoading}
           onViewMore={handleViewMonthFolder}
           onViewAllYear={handleViewAllYear}
@@ -120,7 +120,7 @@ const MyPicselTemplate = () => {
         <MonthFilterView
           ref={flatListRef}
           onScroll={handleScroll}
-          yearGroups={MOCK_YEAR_DATA}
+          yearGroups={yearGroups}
           isLoading={isLoading}
           onViewMonthFolder={handleViewMonthFolder}
         />

--- a/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
@@ -8,10 +8,7 @@ import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecul
 import FolderHeader from '@/feature/picsel/shared/components/ui/molecules/FolderHeader';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import {
-  MyPicselSortType,
-  useSortActionSheet,
-} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
+import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
@@ -25,6 +22,8 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
     photoData,
     isLoading,
     totalPhotos,
+
+    setSortType,
 
     isSelecting,
     selectedPhotos,
@@ -49,13 +48,8 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
     handleMove,
   } = useYearFolder({ year });
 
-  // TODO: 정렬 로직 구현
-  const handleSort = (sortType: MyPicselSortType) => {
-    console.log('정렬 타입:', sortType);
-  };
-
   const { showSortSheet } = useSortActionSheet({
-    onSort: handleSort,
+    onSort: setSortType,
   });
 
   return (

--- a/src/feature/picsel/myPicsel/hooks/useFolderView.ts
+++ b/src/feature/picsel/myPicsel/hooks/useFolderView.ts
@@ -9,6 +9,7 @@ import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSel
 import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoActions';
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
+import { useMyPicselStore } from '@/shared/store';
 
 interface UseFolderViewOptions {
   filterType: 'year' | 'month';
@@ -29,11 +30,14 @@ export const useFolderView = ({
   year,
   month,
 }: UseFolderViewOptions) => {
+  // 정렬 상태 (전역 store)
+  const { sortType, setSortType } = useMyPicselStore();
+
   // API에서 전체 데이터 페칭
   const { data: myPicselsData, isLoading } = useGetMyPicsels({
     page: 0,
-    size: 1000, // 전체 데이터를 가져와 클라이언트에서 필터링
-    sort: 'RECENT_DESC',
+    size: 1000,
+    sort: sortType,
   });
 
   // 년도별/월별 필터링
@@ -112,6 +116,10 @@ export const useFolderView = ({
     photoData,
     isLoading,
     totalPhotos,
+
+    // 정렬
+    sortType,
+    setSortType,
 
     // 선택 모드
     isSelecting,

--- a/src/feature/picsel/myPicsel/hooks/useFolderView.ts
+++ b/src/feature/picsel/myPicsel/hooks/useFolderView.ts
@@ -1,7 +1,9 @@
-import { usePhotoData } from '../../shared/utils/usePhotoData';
-import { Photo } from '../components/ui/organisms/PhotoListView';
+import { useMemo } from 'react';
 
-import { MOCK_YEAR_DATA } from '@/feature/picsel/myPicsel/data/MOCK_YEAR_DATA';
+import { Photo } from '../components/ui/organisms/PhotoListView';
+import { useGetMyPicsels } from '../queries/useGetMyPicsels';
+import { getMonthFromDate, getYearFromDate } from '../utils/dateUtils';
+
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
 import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSelectingMode';
 import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoActions';
@@ -27,26 +29,40 @@ export const useFolderView = ({
   year,
   month,
 }: UseFolderViewOptions) => {
-  // 년도별/월별 사진 데이터 로딩
-  const { data: photoData, isLoading } = usePhotoData<Photo>({
-    loadData: () => {
-      const yearData = MOCK_YEAR_DATA.find(data => data.year === year);
-      if (!yearData) {
-        return [];
+  // API에서 전체 데이터 페칭
+  const { data: myPicselsData, isLoading } = useGetMyPicsels({
+    page: 0,
+    size: 1000, // 전체 데이터를 가져와 클라이언트에서 필터링
+    sort: 'RECENT_DESC',
+  });
+
+  // 년도별/월별 필터링
+  const photoData: Photo[] = useMemo(() => {
+    if (!myPicselsData?.content) {
+      return [];
+    }
+
+    const filtered = myPicselsData.content.filter(item => {
+      const itemYear = getYearFromDate(item.takenDate);
+      if (itemYear !== year) {
+        return false;
       }
 
-      if (filterType === 'year') {
-        // 년도별: 모든 월의 사진 반환
-        return yearData.months.flatMap(m => m.photos);
-      } else {
-        // 월별: 특정 월의 사진만 반환
-        const monthData = yearData.months.find(m => m.month === month);
-        return monthData?.photos || [];
+      if (filterType === 'month' && month) {
+        const itemMonth = getMonthFromDate(item.takenDate);
+        return itemMonth === month;
       }
-    },
-    delay: 1000,
-    deps: [year, month, filterType],
-  });
+
+      return true;
+    });
+
+    return filtered.map(item => ({
+      id: item.picselId,
+      uri: item.imagePath,
+      date: item.takenDate,
+      storeName: item.storeName,
+    }));
+  }, [myPicselsData, filterType, year, month]);
 
   const totalPhotos = photoData.length;
 

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -1,12 +1,12 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { usePhotoData } from '../../shared/utils/usePhotoData';
 import { Photo } from '../components/ui/organisms/PhotoListView';
-import { DateFilterType } from '../types';
+import { useGetMyPicsels } from '../queries/useGetMyPicsels';
+import { DateFilterType, MyPicselSortType, YearGroup } from '../types';
+import { groupByYearMonth } from '../utils/groupByDate';
 
-import { MOCK_YEAR_DATA } from '@/feature/picsel/myPicsel/data/MOCK_YEAR_DATA';
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
 import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSelectingMode';
 import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoActions';
@@ -29,17 +29,38 @@ export const useMyPicsel = () => {
   // 날짜 필터 상태
   const [dateFilter, setDateFilter] = useState<DateFilterType>('all');
 
-  // 사진 데이터 로딩
-  const { data: photoData, isLoading } = usePhotoData<Photo>({
-    loadData: () => {
-      return MOCK_YEAR_DATA.flatMap(yearData =>
-        yearData.months.flatMap(month => month.photos),
-      );
-    },
-    delay: 2000,
+  // 정렬 상태
+  const [sortType, setSortType] = useState<MyPicselSortType>('RECENT_DESC');
+
+  // 내 픽셀 데이터 페칭
+  const { data: myPicselsData, isLoading } = useGetMyPicsels({
+    page: 0,
+    size: 20,
+    sort: sortType,
   });
 
-  const totalPhotos = photoData.length;
+  // API 데이터를 Photo 형태로 변환
+  const photoData: Photo[] = useMemo(() => {
+    if (!myPicselsData?.content) {
+      return [];
+    }
+    return myPicselsData.content.map(item => ({
+      id: item.picselId,
+      uri: item.imagePath,
+      date: item.takenDate,
+      storeName: item.storeName,
+    }));
+  }, [myPicselsData]);
+
+  // 년/월별 그룹 데이터
+  const yearGroups: YearGroup[] = useMemo(() => {
+    if (!myPicselsData?.content) {
+      return [];
+    }
+    return groupByYearMonth(myPicselsData.content);
+  }, [myPicselsData]);
+
+  const totalPhotos = myPicselsData?.totalElements ?? 0;
   const hasPhotos = totalPhotos > 0;
 
   // 사진 선택
@@ -102,9 +123,14 @@ export const useMyPicsel = () => {
   return {
     // 데이터
     photoData,
+    yearGroups,
     isLoading,
     totalPhotos,
     hasPhotos,
+
+    // 정렬
+    sortType,
+    setSortType,
 
     // 날짜 필터
     dateFilter,

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { Photo } from '../components/ui/organisms/PhotoListView';
 import { useGetMyPicsels } from '../queries/useGetMyPicsels';
-import { DateFilterType, MyPicselSortType, YearGroup } from '../types';
+import { DateFilterType, YearGroup } from '../types';
 import { groupByYearMonth } from '../utils/groupByDate';
 
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
@@ -13,6 +13,7 @@ import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoAct
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { useMyPicselStore } from '@/shared/store';
 
 /**
  * MyPicsel 템플릿을 위한 통합 hook
@@ -29,8 +30,8 @@ export const useMyPicsel = () => {
   // 날짜 필터 상태
   const [dateFilter, setDateFilter] = useState<DateFilterType>('all');
 
-  // 정렬 상태
-  const [sortType, setSortType] = useState<MyPicselSortType>('RECENT_DESC');
+  // 정렬 상태 (전역 store)
+  const { sortType, setSortType } = useMyPicselStore();
 
   // 내 픽셀 데이터 페칭
   const { data: myPicselsData, isLoading } = useGetMyPicsels({
@@ -106,8 +107,6 @@ export const useMyPicsel = () => {
   // 날짜 필터 변경
   const handleDateFilterChange = (type: DateFilterType) => {
     setDateFilter(type);
-    console.log('날짜 필터:', type);
-    // TODO: 날짜 필터링 로직 구현
   };
 
   // 년도별 폴더로 이동

--- a/src/feature/picsel/myPicsel/queries/useGetMyPicsels.ts
+++ b/src/feature/picsel/myPicsel/queries/useGetMyPicsels.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyPicselsApi } from '../api/getMyPicselsApi';
+import { MyPicselParams, MyPicselResult } from '../types';
+
+export const useGetMyPicsels = (params: MyPicselParams = {}) => {
+  const { page = 0, size = 20, sort = 'RECENT_DESC' } = params;
+
+  return useQuery<MyPicselResult>({
+    queryKey: ['myPicsels', page, size, sort],
+    queryFn: () => getMyPicselsApi({ page, size, sort }),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: 2,
+  });
+};

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -1,1 +1,52 @@
 export type DateFilterType = 'all' | 'year' | 'month';
+
+// 정렬 타입
+export type MyPicselSortType = 'RECENT_DESC' | 'OLDEST_ASC';
+
+// 개별 픽셀 아이템
+export interface MyPicselItem {
+  picselId: string;
+  imagePath: string;
+  takenDate: string;
+  storeId: string;
+  storeName: string;
+  brandImagePath: string;
+}
+
+// 그룹핑용 Photo 타입
+export interface GroupPhoto {
+  id: string;
+  uri: string;
+  date: string;
+  storeName: string;
+}
+
+// 월별 그룹
+export interface MonthGroup {
+  month: string;
+  photos: GroupPhoto[];
+}
+
+// 년도별 그룹
+export interface YearGroup {
+  year: string;
+  months: MonthGroup[];
+}
+
+// API 요청 파라미터
+export interface MyPicselParams {
+  page?: number;
+  size?: number;
+  sort?: MyPicselSortType;
+}
+
+// API 응답 결과 (페이지네이션 포함)
+export interface MyPicselResult {
+  content: MyPicselItem[];
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+  pageSize: number;
+  first: boolean;
+  last: boolean;
+}

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -50,3 +50,8 @@ export interface MyPicselResult {
   first: boolean;
   last: boolean;
 }
+
+// 픽셀 삭제 요청
+export interface DeletePicselsRequest {
+  picselIds: string[];
+}

--- a/src/feature/picsel/myPicsel/utils/dateUtils.ts
+++ b/src/feature/picsel/myPicsel/utils/dateUtils.ts
@@ -44,3 +44,18 @@ export const formatMonth = (month: number): string => {
 export const formatYear = (year: number): string => {
   return `${year}년`;
 };
+
+/**
+ * 날짜 문자열에서 년도 추출
+ */
+export const getYearFromDate = (dateString: string): string => {
+  return new Date(dateString).getFullYear().toString();
+};
+
+/**
+ * 날짜 문자열에서 월 추출 (한글 형식)
+ */
+export const getMonthFromDate = (dateString: string): string => {
+  const month = new Date(dateString).getMonth() + 1;
+  return `${month}월`;
+};

--- a/src/feature/picsel/myPicsel/utils/groupByDate.ts
+++ b/src/feature/picsel/myPicsel/utils/groupByDate.ts
@@ -1,0 +1,62 @@
+import { GroupPhoto, MyPicselItem, YearGroup } from '../types';
+
+import { getMonthFromDate, getYearFromDate } from './dateUtils';
+
+const toGroupPhoto = (item: MyPicselItem): GroupPhoto => ({
+  id: item.picselId,
+  uri: item.imagePath,
+  date: item.takenDate,
+  storeName: item.storeName,
+});
+
+/**
+ * 픽셀 데이터를 년/월별로 그룹핑
+ * @param items - API에서 받은 픽셀 아이템 배열
+ * @returns 년도별 그룹 배열 (최신순 정렬)
+ */
+export const groupByYearMonth = (items: MyPicselItem[]): YearGroup[] => {
+  if (!items || items.length === 0) {
+    return [];
+  }
+
+  // 년도 -> 월 -> 사진 배열 맵 생성
+  const yearMap = new Map<string, Map<string, GroupPhoto[]>>();
+
+  items.forEach(item => {
+    const year = getYearFromDate(item.takenDate);
+    const month = getMonthFromDate(item.takenDate);
+    const photo = toGroupPhoto(item);
+
+    if (!yearMap.has(year)) {
+      yearMap.set(year, new Map());
+    }
+
+    const monthMap = yearMap.get(year)!;
+    if (!monthMap.has(month)) {
+      monthMap.set(month, []);
+    }
+
+    monthMap.get(month)!.push(photo);
+  });
+
+  // YearGroup 배열로 변환
+  const yearGroups: YearGroup[] = [];
+
+  yearMap.forEach((monthMap, year) => {
+    const months = Array.from(monthMap.entries())
+      .map(([month, photos]) => ({ month, photos }))
+      .sort((a, b) => {
+        // 월 숫자 추출하여 내림차순 정렬 (12월 -> 1월)
+        const monthA = parseInt(a.month.replace('월', ''), 10);
+        const monthB = parseInt(b.month.replace('월', ''), 10);
+        return monthB - monthA;
+      });
+
+    yearGroups.push({ year, months });
+  });
+
+  // 년도 내림차순 정렬 (최신순)
+  yearGroups.sort((a, b) => parseInt(b.year, 10) - parseInt(a.year, 10));
+
+  return yearGroups;
+};

--- a/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
@@ -56,9 +56,13 @@ const SelectablePhotoCard = ({
         </View>
 
         {/* 매장명 */}
-        <View className="mt-1 flex-row items-center">
+        <View
+          className="mt-1 flex-row items-center"
+          style={{ width: imageWidth }}>
           <SparkleImages shape="icon-one" width={25} height={25} />
-          <Text className="ml-1 text-gray-900 body-rg-03" numberOfLines={1}>
+          <Text
+            className="ml-1 flex-1 text-gray-900 body-rg-03"
+            numberOfLines={1}>
             {photo.storeName}
           </Text>
         </View>

--- a/src/feature/picsel/shared/hooks/animation/useSortActionSheet.ts
+++ b/src/feature/picsel/shared/hooks/animation/useSortActionSheet.ts
@@ -1,6 +1,6 @@
+import { MyPicselSortType } from '@/feature/picsel/myPicsel/types';
 import { useActionSheetStore } from '@/shared/store/ui/actionSheet';
 
-export type MyPicselSortType = 'latest' | 'date';
 export type PicselBookSortType = 'latest' | 'add' | 'length';
 
 export interface SortOption<T = MyPicselSortType | PicselBookSortType> {
@@ -10,8 +10,8 @@ export interface SortOption<T = MyPicselSortType | PicselBookSortType> {
 
 // 내픽셀 정렬 옵션
 export const MY_PICSEL_SORT_OPTIONS: SortOption<MyPicselSortType>[] = [
-  { type: 'latest', label: '최신 순' },
-  { type: 'date', label: '오래된 순' },
+  { type: 'RECENT_DESC', label: '최신 순' },
+  { type: 'OLDEST_ASC', label: '오래된 순' },
 ];
 
 // 픽셀북 정렬 옵션

--- a/src/feature/picsel/shared/hooks/photo/usePhotoActions.ts
+++ b/src/feature/picsel/shared/hooks/photo/usePhotoActions.ts
@@ -1,3 +1,4 @@
+import { useDeletePicsels } from '@/feature/picsel/mutations/useDeletePicsels';
 import { showDeleteConfirmModal } from '@/shared/lib/confirmModal';
 import { useToastStore } from '@/shared/store/ui/toast';
 
@@ -11,6 +12,7 @@ interface UsePhotoActionsOptions {
 interface UsePhotoActionsReturn {
   handleDelete: () => void;
   handleMove: () => void;
+  isDeleting: boolean;
 }
 
 export const usePhotoActions = ({
@@ -20,17 +22,28 @@ export const usePhotoActions = ({
   exitSelectingMode,
 }: UsePhotoActionsOptions): UsePhotoActionsReturn => {
   const { showToast } = useToastStore();
+  const { mutate: deletePicsels, isPending: isDeleting } = useDeletePicsels();
 
   const handleDelete = () => {
     if (selectedPhotos.length === 0) {
-      showToast('삭제할 픽셀북을 선택해주세요', 60);
+      showToast('삭제할 픽셀을 선택해주세요', 60);
       return;
     }
 
     showDeleteConfirmModal('photo', selectedPhotos.length, () => {
-      showToast(`${selectedPhotos.length}장의 픽셀을 삭제했어요`, 60);
-      onDeleteSuccess?.();
-      exitSelectingMode?.();
+      deletePicsels(
+        { picselIds: selectedPhotos },
+        {
+          onSuccess: () => {
+            showToast(`${selectedPhotos.length}장의 픽셀을 삭제했어요`, 60);
+            onDeleteSuccess?.();
+            exitSelectingMode?.();
+          },
+          onError: () => {
+            showToast('픽셀 삭제에 실패했어요', 60);
+          },
+        },
+      );
     });
   };
 
@@ -47,5 +60,6 @@ export const usePhotoActions = ({
   return {
     handleDelete,
     handleMove,
+    isDeleting,
   };
 };

--- a/src/shared/store/index.tsx
+++ b/src/shared/store/index.tsx
@@ -7,3 +7,4 @@ export { useLocationStore } from './location';
 export { useMapLocationStore } from './searchLocation';
 export { useConfirmModalStore } from './ui/confirmModal';
 export { useActionSheetStore } from './ui/actionSheet';
+export { useMyPicselStore } from './myPicsel';

--- a/src/shared/store/myPicsel/index.ts
+++ b/src/shared/store/myPicsel/index.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+import { MyPicselSortType } from '@/feature/picsel/myPicsel/types';
+
+interface MyPicselState {
+  sortType: MyPicselSortType;
+  setSortType: (sort: MyPicselSortType) => void;
+}
+
+export const useMyPicselStore = create<MyPicselState>(set => ({
+  sortType: 'RECENT_DESC',
+  setSortType: sort => set({ sortType: sort }),
+}));


### PR DESCRIPTION
## 이슈 번호

> close #83 

## 작업 내용 및 테스트 방법
1. 내 픽셀 API 페칭 기능 :
GET /picsels/my 

2. 년/월 그룹핑 (클라이언트 사이드) → MOCK_YEAR_DATA 제거, 실제 API 데이터 사용 

3. 정렬 기능 (전역 상태) → 한 곳에서 정렬 변경 시 모든 화면에 동일 적용

4. 픽셀 삭제 API :
DELETE /picsels

## To reviewers
MOCK DATA 파일은 만약을 대비하여 삭제하지 않고 남겨두었습니다 👍🏻 

imagePath에 대한 응답값은 이미지 서버에 반영이 안된거 같아서
준희님께 슬랙으로 문의드린 상태입니다 💯 
