### PR TITLE
✨ Feat: 픽셀북 API 연결

### DIFF
--- a/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
@@ -8,7 +8,6 @@ import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecul
 import FolderHeader from '@/feature/picsel/shared/components/ui/molecules/FolderHeader';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
@@ -24,7 +23,7 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
     isLoading,
     totalPhotos,
 
-    setSortType,
+    showSortSheet,
 
     isSelecting,
     selectedPhotos,
@@ -48,10 +47,6 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
     handleDelete,
     handleMove,
   } = useMonthFolder({ year, month });
-
-  const { showSortSheet } = useSortActionSheet({
-    onSort: setSortType,
-  });
 
   return (
     <ScreenLayout>

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -16,7 +16,6 @@ import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/Pho
 import YearFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/YearFilterView';
 import UpButton from '@/feature/picsel/shared/components/ui/atoms/Button/UpButton';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
 const MyPicselTemplate = () => {
@@ -27,7 +26,7 @@ const MyPicselTemplate = () => {
     totalPhotos,
     hasPhotos,
 
-    setSortType,
+    showSortSheet,
 
     dateFilter,
     handleDateFilterChange,
@@ -57,10 +56,6 @@ const MyPicselTemplate = () => {
     handleViewAllYear,
     handleViewMonthFolder,
   } = useMyPicsel();
-
-  const { showSortSheet } = useSortActionSheet({
-    onSort: setSortType,
-  });
 
   if (!isLoading && !hasPhotos) {
     return (

--- a/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
@@ -8,7 +8,6 @@ import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecul
 import FolderHeader from '@/feature/picsel/shared/components/ui/molecules/FolderHeader';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import { useSortActionSheet } from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
@@ -23,7 +22,7 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
     isLoading,
     totalPhotos,
 
-    setSortType,
+    showSortSheet,
 
     isSelecting,
     selectedPhotos,
@@ -47,10 +46,6 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
     handleDelete,
     handleMove,
   } = useYearFolder({ year });
-
-  const { showSortSheet } = useSortActionSheet({
-    onSort: setSortType,
-  });
 
   return (
     <ScreenLayout>

--- a/src/feature/picsel/myPicsel/hooks/useFolderView.ts
+++ b/src/feature/picsel/myPicsel/hooks/useFolderView.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { useSortActionSheet } from '../../shared/hooks/animation/useSortActionSheet';
 import { Photo } from '../components/ui/organisms/PhotoListView';
 import { useGetMyPicsels } from '../queries/useGetMyPicsels';
 import { getMonthFromDate, getYearFromDate } from '../utils/dateUtils';
@@ -111,6 +112,11 @@ export const useFolderView = ({
     exitSelectingMode: handleExitSelecting,
   });
 
+  // 정렬 액션시트
+  const { showSortSheet } = useSortActionSheet({
+    onSort: setSortType,
+  });
+
   return {
     // 데이터
     photoData,
@@ -119,7 +125,7 @@ export const useFolderView = ({
 
     // 정렬
     sortType,
-    setSortType,
+    showSortSheet,
 
     // 선택 모드
     isSelecting,

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { useSortActionSheet } from '../../shared/hooks/animation/useSortActionSheet';
 import { Photo } from '../components/ui/organisms/PhotoListView';
 import { useGetMyPicsels } from '../queries/useGetMyPicsels';
 import { DateFilterType, YearGroup } from '../types';
@@ -119,6 +120,11 @@ export const useMyPicsel = () => {
     navigation.navigate('MonthFolder', { year, month });
   };
 
+  // 정렬 액션시트
+  const { showSortSheet } = useSortActionSheet({
+    onSort: setSortType,
+  });
+
   return {
     // 데이터
     photoData,
@@ -129,7 +135,7 @@ export const useMyPicsel = () => {
 
     // 정렬
     sortType,
-    setSortType,
+    showSortSheet,
 
     // 날짜 필터
     dateFilter,

--- a/src/feature/picsel/myPicsel/mutations/useDeletePicsels.ts
+++ b/src/feature/picsel/myPicsel/mutations/useDeletePicsels.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { deletePicselsApi } from '../myPicsel/api/deletePicselsApi';
-import { DeletePicselsRequest } from '../myPicsel/types';
+import { deletePicselsApi } from '../api/deletePicselsApi';
+import { DeletePicselsRequest } from '../types';
 
 export const useDeletePicsels = () => {
   const queryClient = useQueryClient();

--- a/src/feature/picsel/picselBook/api/deletePicselBooksApi.ts
+++ b/src/feature/picsel/picselBook/api/deletePicselBooksApi.ts
@@ -1,0 +1,11 @@
+import { DeletePicselBooksRequest } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const deletePicselBooksApi = async (
+  request: DeletePicselBooksRequest,
+): Promise<void> => {
+  await axiosInstance.delete('/picselbooks', {
+    data: request,
+  });
+};

--- a/src/feature/picsel/picselBook/api/getPicselBookPicselsApi.ts
+++ b/src/feature/picsel/picselBook/api/getPicselBookPicselsApi.ts
@@ -1,0 +1,28 @@
+import { PicselBookFolderParams, PicselBookFolderResult } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+import { CommonResponseType } from '@/shared/api/types';
+
+interface PicselBookPicselsResponse extends CommonResponseType {
+  data: PicselBookFolderResult;
+}
+
+export const getPicselBookPicselsApi = async (
+  params: PicselBookFolderParams,
+): Promise<PicselBookFolderResult> => {
+  const {
+    picselbookId,
+    page = 0,
+    size = 20,
+    sortType = 'RECENT_DESC',
+  } = params;
+
+  const response = await axiosInstance.get<PicselBookPicselsResponse>(
+    `/picselbooks/${picselbookId}/picsels`,
+    {
+      params: { page, size, sortType },
+    },
+  );
+
+  return response.data.data;
+};

--- a/src/feature/picsel/picselBook/api/getPicselBooksApi.ts
+++ b/src/feature/picsel/picselBook/api/getPicselBooksApi.ts
@@ -1,21 +1,21 @@
-import { PicselBookParams, PicselBookResult } from '../types';
+import { PicselBookItem, PicselBookParams } from '../types';
 
 import { axiosInstance } from '@/shared/api/axiosInstance';
 import { CommonResponseType } from '@/shared/api/types';
 
 interface PicselBooksResponse extends CommonResponseType {
-  data: PicselBookResult;
+  data: PicselBookItem[];
 }
 
 export const getPicselBooksApi = async (
   params: PicselBookParams = {},
-): Promise<PicselBookResult> => {
-  const { page = 0, size = 20, sort = 'RECENT_CREATED_DESC' } = params;
+): Promise<PicselBookItem[]> => {
+  const { sort = 'RECENT_CREATED_DESC' } = params;
 
   const response = await axiosInstance.get<PicselBooksResponse>(
     '/picselbooks',
     {
-      params: { page, size, sortType: sort },
+      params: { sortType: sort },
     },
   );
 

--- a/src/feature/picsel/picselBook/api/getPicselBooksApi.ts
+++ b/src/feature/picsel/picselBook/api/getPicselBooksApi.ts
@@ -1,0 +1,23 @@
+import { PicselBookParams, PicselBookResult } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+import { CommonResponseType } from '@/shared/api/types';
+
+interface PicselBooksResponse extends CommonResponseType {
+  data: PicselBookResult;
+}
+
+export const getPicselBooksApi = async (
+  params: PicselBookParams = {},
+): Promise<PicselBookResult> => {
+  const { page = 0, size = 20, sort = 'RECENT_CREATED_DESC' } = params;
+
+  const response = await axiosInstance.get<PicselBooksResponse>(
+    '/picselbooks',
+    {
+      params: { page, size, sortType: sort },
+    },
+  );
+
+  return response.data.data;
+};

--- a/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
+++ b/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
@@ -14,7 +14,7 @@ interface Props {
   isSelecting?: boolean;
   isSelected?: boolean;
   isLoading?: boolean;
-  onPress?: (id: string) => void;
+  onPress?: (id: string, title: string) => void;
   onEdit?: (id: string, title: string) => void;
   onChangeCover?: (id: string) => void;
   onDelete?: (id: string, title: string) => void;
@@ -33,7 +33,7 @@ const PicselBookCard = ({
   onDelete,
 }: Props) => {
   const handlePress = () => {
-    onPress?.(id);
+    onPress?.(id, title);
   };
 
   // 스켈레톤 상태일 때

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
@@ -10,14 +10,14 @@ import {
 } from '../../../constants/photo';
 import { CARD_SHADOW, TEXT_LIST_CARD } from '../../../constants/styles';
 
-import type { Photo } from '@/feature/picsel/picselBook/data/mockPicselBookPhotoData';
+import { PicselBookPicselItem } from '@/feature/picsel/picselBook/types';
 import { usePhotoFormat } from '@/feature/picsel/shared/utils/usePhotoFormat';
 import CheckRoundIcons from '@/shared/icons/CheckRound';
 import SparkleImages from '@/shared/images/Sparkle';
 import { cn } from '@/shared/lib/cn';
 
 interface Props {
-  photo: Photo;
+  picsel: PicselBookPicselItem;
   isSelecting: boolean;
   isSelected: boolean;
   onToggleSelection: (photoId: string) => void;
@@ -25,7 +25,7 @@ interface Props {
 }
 
 const PhotoTextListItem = ({
-  photo,
+  picsel,
   isSelecting,
   isSelected,
   onToggleSelection,
@@ -33,15 +33,15 @@ const PhotoTextListItem = ({
 }: Props) => {
   const { formatDate } = usePhotoFormat();
 
-  const formattedDate = formatDate(photo.date);
-  const isDefaultTitle = photo.title === PHOTO_DEFAULT_TITLE || !photo.title;
-  const isDefaultContent = !photo.content;
+  const formattedDate = formatDate(picsel.takenDate);
+  const isDefaultTitle = picsel.title === PHOTO_DEFAULT_TITLE || !picsel.title;
+  const isDefaultContent = !picsel.contentPreview;
 
   const handlePress = () => {
     if (isSelecting) {
-      onToggleSelection(photo.id);
+      onToggleSelection(picsel.picselId);
     } else {
-      onPress?.(photo.id);
+      onPress?.(picsel.picselId);
     }
   };
 
@@ -56,7 +56,7 @@ const PhotoTextListItem = ({
       {/* 이미지 */}
       <View className="relative flex-shrink-0">
         <Image
-          source={{ uri: photo.uri }}
+          source={{ uri: picsel.representativeImagePath }}
           style={{
             width: TEXT_LIST_CARD.IMAGE_WIDTH,
             height: TEXT_LIST_CARD.IMAGE_HEIGHT,
@@ -91,7 +91,7 @@ const PhotoTextListItem = ({
                   : 'text-gray-900 headline-03',
               )}
               numberOfLines={TITLE_MAX_LINES}>
-              {photo.title || PHOTO_DEFAULT_TITLE}
+              {picsel.title || PHOTO_DEFAULT_TITLE}
             </Text>
 
             <Text
@@ -100,7 +100,7 @@ const PhotoTextListItem = ({
                 isDefaultContent ? 'text-gray-500' : 'text-gray-900',
               )}
               numberOfLines={CONTENT_MAX_LINES}>
-              {photo.content || PHOTO_PLACEHOLDER_TEXT}
+              {picsel.contentPreview || PHOTO_PLACEHOLDER_TEXT}
             </Text>
           </View>
         </View>
@@ -109,7 +109,7 @@ const PhotoTextListItem = ({
         <View className="flex-row items-center justify-end self-stretch">
           <SparkleImages shape="icon-one" width={25} height={25} />
           <Text className="text-primary-pink body-rg-02">
-            {photo.storeName}
+            {picsel.storeName}
           </Text>
         </View>
       </View>

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
@@ -9,6 +9,7 @@ import {
 import PhotoTextListItem from './PhotoTextListItem';
 
 import { PicselBookPicselItem } from '@/feature/picsel/picselBook/types';
+import PhotoTextListSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PhotoTextListItemSkeleton';
 
 interface Props {
   data: PicselBookPicselItem[];
@@ -26,12 +27,17 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
       data,
       selectedPhotos,
       isSelecting,
+      isLoading = false,
       onScroll,
       onToggleSelection,
       onPhotoPress,
     },
     ref,
   ) => {
+    if (isLoading) {
+      return <PhotoTextListSkeleton count={4} />;
+    }
+
     const renderItem = ({ item }: { item: PicselBookPicselItem }) => {
       const isSelected = selectedPhotos.includes(item.picselId);
 

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
@@ -8,10 +8,10 @@ import {
 
 import PhotoTextListItem from './PhotoTextListItem';
 
-import type { Photo } from '@/feature/picsel/picselBook/data/mockPicselBookPhotoData';
+import { PicselBookPicselItem } from '@/feature/picsel/picselBook/types';
 
 interface Props {
-  data: Photo[];
+  data: PicselBookPicselItem[];
   selectedPhotos: string[];
   isSelecting: boolean;
   isLoading?: boolean;
@@ -32,12 +32,12 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
     },
     ref,
   ) => {
-    const renderItem = ({ item }: { item: Photo }) => {
-      const isSelected = selectedPhotos.includes(item.id);
+    const renderItem = ({ item }: { item: PicselBookPicselItem }) => {
+      const isSelected = selectedPhotos.includes(item.picselId);
 
       return (
         <PhotoTextListItem
-          photo={item}
+          picsel={item}
           isSelecting={isSelecting}
           isSelected={isSelected}
           onToggleSelection={onToggleSelection}
@@ -51,7 +51,7 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
         ref={ref}
         data={data}
         renderItem={renderItem}
-        keyExtractor={item => item.id}
+        keyExtractor={item => item.picselId}
         contentContainerStyle={{
           alignItems: 'center',
           paddingHorizontal: 16,

--- a/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
@@ -21,7 +21,7 @@ interface Props {
   isSelecting?: boolean;
   selectedBookIds?: string[];
   isLoading?: boolean;
-  onBookPress?: (bookId: string) => void;
+  onBookPress?: (bookId: string, bookName: string) => void;
   onEdit?: (id: string, title: string) => void;
   onChangeCover?: (id: string) => void;
   onDelete?: (id: string, title: string) => void;
@@ -53,7 +53,7 @@ const PicselBookList = ({
     const availableHeight = screenHeight - TOP_OFFSET;
     const rowCount = Math.ceil(availableHeight / ITEM_HEIGHT);
     const totalItems = rowCount * NUM_COLUMNS;
-    return totalItems - 1;
+    return totalItems - 1; // AddButton 제외
   }, [screenHeight]);
 
   const allItems = isLoading

--- a/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
@@ -7,16 +7,16 @@ import {
   GAP,
   NUM_COLUMNS,
 } from '../../../constants/picselBookGrid';
+import { PicselBookItem } from '../../../types';
 import PicselBookCard from '../molecules/PicselBookCard';
 
 import AddBookButton from './AddBookButton';
 
-import { PicselBook } from '@/feature/picsel/picselBook/data/mockPicselBookData';
 import PicselBookSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PicselBookSkeleton';
 import { cn } from '@/shared/lib/cn';
 
 interface Props {
-  books: PicselBook[];
+  books: PicselBookItem[];
   isSelecting?: boolean;
   selectedBookIds?: string[];
   isLoading?: boolean;
@@ -24,7 +24,7 @@ interface Props {
   onEdit?: (id: string, title: string) => void;
   onChangeCover?: (id: string) => void;
   onDelete?: (id: string, title: string) => void;
-  onAddBook: () => void;
+  onAddBook?: () => void;
 }
 
 const PicselBookList = ({
@@ -58,7 +58,11 @@ const PicselBookList = ({
       ]
     : [
         { id: 'add-button', type: 'add' },
-        ...books.map(book => ({ ...book, type: 'book' })),
+        ...books.map(book => ({
+          ...book,
+          id: book.picselbookId,
+          type: 'book',
+        })),
       ];
 
   return (
@@ -89,16 +93,16 @@ const PicselBookList = ({
           );
         }
 
-        const book = item as PicselBook & { type: string };
+        const book = item as PicselBookItem & { type: string };
 
         return (
           <View className="mb-7">
             <PicselBookCard
-              id={book.id}
-              title={book.title}
-              coverImage={book.coverImage}
+              id={book.picselbookId}
+              title={book.bookName}
+              coverImage={book.coverImagePath}
               isSelecting={isSelecting}
-              isSelected={selectedBookIds.includes(book.id)}
+              isSelected={selectedBookIds.includes(book.picselbookId)}
               onPress={onBookPress}
               onEdit={onEdit}
               onChangeCover={onChangeCover}

--- a/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
@@ -7,6 +7,7 @@ import {
   GAP,
   NUM_COLUMNS,
 } from '../../../constants/picselBookGrid';
+import { ITEM_HEIGHT, TOP_OFFSET } from '../../../constants/styles';
 import { PicselBookItem } from '../../../types';
 import PicselBookCard from '../molecules/PicselBookCard';
 
@@ -38,7 +39,7 @@ const PicselBookList = ({
   onDelete,
   onAddBook,
 }: Props) => {
-  const { width: screenWidth } = useWindowDimensions();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const horizontalPadding = useMemo(() => {
     const totalCardsWidth = CARD_WIDTH * NUM_COLUMNS;
@@ -48,10 +49,17 @@ const PicselBookList = ({
     return remainingSpace / 2;
   }, [screenWidth]);
 
+  const skeletonCount = useMemo(() => {
+    const availableHeight = screenHeight - TOP_OFFSET;
+    const rowCount = Math.ceil(availableHeight / ITEM_HEIGHT);
+    const totalItems = rowCount * NUM_COLUMNS;
+    return totalItems - 1;
+  }, [screenHeight]);
+
   const allItems = isLoading
     ? [
         { id: 'add-button', type: 'add' },
-        ...Array.from({ length: 5 }, (_, i) => ({
+        ...Array.from({ length: skeletonCount }, (_, i) => ({
           id: `skeleton-${i}`,
           type: 'skeleton',
         })),

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { View } from 'react-native';
 
-import { PicselBookEditType, PicselBookSortType } from '../../../types';
+import { PicselBookEditType } from '../../../types';
 
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import PhotoTextListView from '@/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView';
@@ -22,15 +22,18 @@ import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
 interface Props {
   bookId: string;
+  bookName?: string;
   onBack: () => void;
 }
 
-const PicselBookFolderTemplate = ({ bookId, onBack }: Props) => {
+const PicselBookFolderTemplate = ({ bookId, bookName = '', onBack }: Props) => {
   const {
     photoData,
-    bookTitle,
+    rawData,
     isLoading,
     totalPhotos,
+
+    showSortSheet,
 
     viewMode,
     handleToggleViewMode,
@@ -60,15 +63,6 @@ const PicselBookFolderTemplate = ({ bookId, onBack }: Props) => {
     formatPhotoCount,
   } = usePicselBookFolder({ bookId });
 
-  // TODO: 정렬 로직 구현
-  const handleSort = (sortType: PicselBookSortType) => {
-    console.log('정렬 타입:', sortType);
-  };
-
-  const { showSortSheet } = useSortActionSheet({
-    onSort: handleSort,
-  });
-
   // TODO: 편집 로직 구현
   const handleEdit = (editType: PicselBookEditType) => {
     console.log('편집 타입:', editType);
@@ -85,7 +79,7 @@ const PicselBookFolderTemplate = ({ bookId, onBack }: Props) => {
   return (
     <ScreenLayout>
       <FolderHeader
-        title={`${bookTitle}(${formatPhotoCount(totalPhotos)})`}
+        title={`${bookName}(${formatPhotoCount(totalPhotos)})`}
         onBack={onBack}
         showToggle={true}
         onTogglePress={showEditSheet}
@@ -142,7 +136,7 @@ const PicselBookFolderTemplate = ({ bookId, onBack }: Props) => {
           ) : (
             <PhotoTextListView
               ref={flatListRef}
-              data={photoData}
+              data={rawData}
               selectedPhotos={selectedPhotos}
               isSelecting={isSelecting}
               isLoading={isLoading}

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
@@ -14,11 +14,6 @@ import EmptyMessage from '@/feature/picsel/shared/components/ui/molecules/EmptyM
 import PicselBookBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
-import {
-  PicselBookSortType,
-  PICSEL_BOOK_SORT_OPTIONS,
-  useSortActionSheet,
-} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 
 const PicselBookTemplate = () => {
   const {
@@ -52,23 +47,15 @@ const PicselBookTemplate = () => {
     handleDelete,
 
     picselBookRef,
+
+    showSortSheet,
   } = usePicselBook();
-
-  // TODO: 정렬 로직 구현
-  const handleSort = (sortType: PicselBookSortType) => {
-    console.log('픽셀북 정렬 타입:', sortType);
-  };
-
-  const { showSortSheet } = useSortActionSheet<PicselBookSortType>({
-    onSort: handleSort,
-    options: PICSEL_BOOK_SORT_OPTIONS,
-  });
 
   if (!isLoading && !hasBooks) {
     return (
       <EmptyStateLayout
         floatingButton={
-          <View className="absolute bottom-1 right-1">
+          <View className="absolute bottom-8 right-0">
             {showFunctionButtons ? (
               <FunctionButton
                 onAlbumPress={handleAlbumPress}
@@ -81,7 +68,7 @@ const PicselBookTemplate = () => {
           </View>
         }>
         <View className="flex-1">
-          <View className="absolute left-9 top-16">
+          <View className="absolute left-[41px] top-16">
             <AddBookButton onPress={handleAddBook} />
           </View>
 

--- a/src/feature/picsel/picselBook/constants/styles.ts
+++ b/src/feature/picsel/picselBook/constants/styles.ts
@@ -17,3 +17,8 @@ export const TEXT_LIST_CARD = {
   IMAGE_WIDTH: 100,
   IMAGE_HEIGHT: 150,
 } as const;
+
+// 스켈레톤 아이템 높이 (아이콘 72px + mb-2 8px + 제목 16px + mb-1 4px + mb-7 28px)
+export const ITEM_HEIGHT = 128;
+// 툴바 + 상단 패딩 등 오프셋
+export const TOP_OFFSET = 100;

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -3,10 +3,6 @@ import { useRef, useState } from 'react';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
 
-import {
-  PICSEL_BOOK_SORT_OPTIONS,
-  useSortActionSheet,
-} from '../../shared/hooks/animation/useSortActionSheet';
 import { useGetPicselBooks } from '../queries/useGetPicselBooks';
 import { PicselBookItem } from '../types';
 
@@ -14,6 +10,10 @@ import { usePicselBookActions } from './usePicselBookActions';
 
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
 import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSelectingMode';
+import {
+  PICSEL_BOOK_SORT_OPTIONS,
+  useSortActionSheet,
+} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
@@ -47,9 +47,9 @@ export const usePicselBook = () => {
     sort: sortType,
   });
 
-  const books: PicselBookItem[] = data?.content ?? [];
-  const totalBooks = data?.totalElements ?? 0;
-  const hasBooks = totalBooks > 0;
+  const books: PicselBookItem[] = data ?? [];
+  const totalBooks = books.length;
+  const hasBooks = books.length > 0;
 
   // 선택 관련
   const { isSelecting, setIsSelecting, resetSelection } = usePhotoSelection();
@@ -114,7 +114,7 @@ export const usePicselBook = () => {
     if (selectedBookIds.length === books.length) {
       setSelectedBookIds([]);
     } else {
-      setSelectedBookIds(books.map(book => book.picselBookId));
+      setSelectedBookIds(books.map(book => book.picselbookId));
     }
   };
 

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -97,7 +97,7 @@ export const usePicselBook = () => {
   };
 
   // 픽셀북 클릭
-  const handleBookPress = (bookId: string) => {
+  const handleBookPress = (bookId: string, bookName: string) => {
     if (isSelecting) {
       setSelectedBookIds(prev =>
         prev.includes(bookId)
@@ -105,7 +105,7 @@ export const usePicselBook = () => {
           : [...prev, bookId],
       );
     } else {
-      navigation.navigate('PicselBookFolder', { bookId });
+      navigation.navigate('PicselBookFolder', { bookId, bookName });
     }
   };
 

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
 
+import { useDeletePicselBooks } from '../mutations/useDeletePicselBooks';
 import { useGetPicselBooks } from '../queries/useGetPicselBooks';
 import { PicselBookItem } from '../types';
 
@@ -46,6 +47,9 @@ export const usePicselBook = () => {
   const { data, isLoading, refetch } = useGetPicselBooks({
     sort: sortType,
   });
+
+  // 픽셀북 삭제 mutation
+  const { mutate: deletePicselBooks } = useDeletePicselBooks();
 
   const books: PicselBookItem[] = data ?? [];
   const totalBooks = books.length;
@@ -126,11 +130,19 @@ export const usePicselBook = () => {
     }
 
     showDeleteConfirmModal('picselBook', selectedBookIds.length, () => {
-      // TODO: 픽셀북 삭제 API 호출
       const deletedCount = selectedBookIds.length;
-      handleExitSelecting();
-      showToast(`${deletedCount}개의 픽셀북을 삭제했어요`, 60);
-      refetch();
+      deletePicselBooks(
+        { picselbookIds: selectedBookIds },
+        {
+          onSuccess: () => {
+            handleExitSelecting();
+            showToast(`${deletedCount}개의 픽셀북을 삭제했어요`, 60);
+          },
+          onError: () => {
+            showToast('픽셀북 삭제에 실패했어요', 60);
+          },
+        },
+      );
     });
   };
 
@@ -175,8 +187,5 @@ export const usePicselBook = () => {
 
     // Refs
     picselBookRef,
-
-    // 리프레시
-    refetch,
   };
 };

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -3,26 +3,23 @@ import { useRef, useState } from 'react';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
 
-import { usePhotoData } from '../../shared/utils/usePhotoData';
+import {
+  PICSEL_BOOK_SORT_OPTIONS,
+  useSortActionSheet,
+} from '../../shared/hooks/animation/useSortActionSheet';
+import { useGetPicselBooks } from '../queries/useGetPicselBooks';
+import { PicselBookItem } from '../types';
 
 import { usePicselBookActions } from './usePicselBookActions';
 
-import { MOCK_PICSEL_BOOK_DATA } from '@/feature/picsel/picselBook/data/mockPicselBookData';
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
 import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSelectingMode';
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { showDeleteConfirmModal } from '@/shared/lib/confirmModal';
+import { usePicselBookStore } from '@/shared/store/picselBook';
 import { useToastStore } from '@/shared/store/ui/toast';
-
-interface Book {
-  id: string;
-  title: string;
-  photoCount: number;
-  createdAt: string;
-  updatedAt: string;
-}
 
 /**
  * PicselBook 템플릿을 위한 통합 hook
@@ -31,27 +28,27 @@ interface Book {
  * - 스크롤 관리
  * - 기능 버튼 (업로드)
  * - 픽셀북 액션 (생성, 삭제, 수정)
+ * - 정렬 기능
  */
 export const usePicselBook = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const { showToast } = useToastStore();
   const picselBookRef = useRef<BottomSheetModal>(null);
 
+  // 정렬 상태 (전역 store)
+  const { sortType, setSortType } = usePicselBookStore();
+
   // 픽셀북 액션 (Context Menu)
   const { handleEdit, handleChangeCover, handleDelete } =
     usePicselBookActions();
 
-  // 픽셀북 데이터 로딩
-  const {
-    data: books,
-    isLoading,
-    setData: setBooks,
-  } = usePhotoData<Book>({
-    loadData: () => MOCK_PICSEL_BOOK_DATA,
-    delay: 2000,
+  // 픽셀북 데이터 로딩 (API 연동)
+  const { data, isLoading, refetch } = useGetPicselBooks({
+    sort: sortType,
   });
 
-  const totalBooks = books.length;
+  const books: PicselBookItem[] = data?.content ?? [];
+  const totalBooks = data?.totalElements ?? 0;
   const hasBooks = totalBooks > 0;
 
   // 선택 관련
@@ -81,6 +78,12 @@ export const usePicselBook = () => {
     closeFunctionButtons,
   } = useFunctionButtons();
 
+  // 정렬 액션시트
+  const { showSortSheet } = useSortActionSheet({
+    onSort: setSortType,
+    options: PICSEL_BOOK_SORT_OPTIONS,
+  });
+
   // 픽셀북 추가 바텀시트 열기
   const handleAddBook = () => {
     picselBookRef.current?.present();
@@ -90,15 +93,7 @@ export const usePicselBook = () => {
   const handleSubmit = (bookName: string) => {
     // TODO: 픽셀북 생성 API 호출
     console.log('픽셀북 생성:', bookName);
-
-    const newBook: Book = {
-      id: String(books.length + 1),
-      title: bookName,
-      photoCount: 0,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    setBooks([newBook, ...books]);
+    refetch();
   };
 
   // 픽셀북 클릭
@@ -116,10 +111,10 @@ export const usePicselBook = () => {
 
   // 전체 선택
   const handleSelectAll = () => {
-    if (selectedBookIds.length === totalBooks) {
+    if (selectedBookIds.length === books.length) {
       setSelectedBookIds([]);
     } else {
-      setSelectedBookIds(books.map(book => book.id));
+      setSelectedBookIds(books.map(book => book.picselBookId));
     }
   };
 
@@ -135,6 +130,7 @@ export const usePicselBook = () => {
       const deletedCount = selectedBookIds.length;
       handleExitSelecting();
       showToast(`${deletedCount}개의 픽셀북을 삭제했어요`, 60);
+      refetch();
     });
   };
 
@@ -144,6 +140,10 @@ export const usePicselBook = () => {
     isLoading,
     totalBooks,
     hasBooks,
+
+    // 정렬
+    sortType,
+    showSortSheet,
 
     // 선택 모드
     isSelecting,
@@ -175,5 +175,8 @@ export const usePicselBook = () => {
 
     // Refs
     picselBookRef,
+
+    // 리프레시
+    refetch,
   };
 };

--- a/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
@@ -1,12 +1,15 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
-import { usePhotoData } from '../../shared/utils/usePhotoData';
-import { usePhotoFormat } from '../../shared/utils/usePhotoFormat';
+import { useGetPicselBookPicsels } from '../queries/useGetPicselBookPicsels';
+import { PicselBookFolderSortType, PicselBookPicselItem } from '../types';
 
-import type { Photo } from '@/feature/picsel/picselBook/data/mockPicselBookPhotoData';
-import { MOCK_PICSEL_BOOK_PHOTO_DATA } from '@/feature/picsel/picselBook/data/mockPicselBookPhotoData';
+import { Photo } from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import { useScrollWithUpButton } from '@/feature/picsel/shared/hooks/animation/useScrollWithUpButton';
 import { useSelectingMode } from '@/feature/picsel/shared/hooks/animation/useSelectingMode';
+import {
+  MY_PICSEL_SORT_OPTIONS,
+  useSortActionSheet,
+} from '@/feature/picsel/shared/hooks/animation/useSortActionSheet';
 import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoActions';
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
@@ -19,39 +22,46 @@ interface UsePicselBookFolderOptions {
 
 /**
  * PicselBook 폴더 템플릿을 위한 통합 hook
- * - 데이터 로딩
+ * - 데이터 로딩 (API 연동)
  * - 선택 모드
  * - 스크롤 관리
  * - 사진 액션 (삭제, 이동)
  * - 기능 버튼 (업로드)
  * - 뷰 모드 (list, textList)
+ * - 정렬 기능
  */
 export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
-  // 초기 데이터 설정
-  const initialBookData = MOCK_PICSEL_BOOK_PHOTO_DATA.find(
-    data => data.bookId === bookId,
-  );
-
   // 상태 관리
   const [viewMode, setViewMode] = useState<ViewMode>('list');
-  const [bookTitle, setBookTitle] = useState(initialBookData?.bookTitle || '');
+  const [sortType, setSortType] =
+    useState<PicselBookFolderSortType>('RECENT_DESC');
 
-  // 데이터 로딩
-  const { data: photoData, isLoading } = usePhotoData<Photo>({
-    loadData: () => {
-      const bookData = MOCK_PICSEL_BOOK_PHOTO_DATA.find(
-        data => data.bookId === bookId,
-      );
-      if (bookData) {
-        setBookTitle(bookData.bookTitle);
-        return bookData.photos;
-      }
-      setBookTitle('');
-      return [];
-    },
-    delay: 1000,
-    deps: [bookId],
+  // 픽셀북 내 픽셀 데이터 페칭 (API 연동)
+  const { data, isLoading, refetch } = useGetPicselBookPicsels({
+    picselbookId: bookId,
+    sortType,
   });
+
+  // API 데이터를 Photo 형태로 변환
+  const photoData: Photo[] = useMemo(() => {
+    if (!data?.content) {
+      return [];
+    }
+    return data.content.map((item: PicselBookPicselItem) => ({
+      id: item.picselId,
+      uri: item.representativeImagePath,
+      date: item.takenDate,
+      storeName: item.storeName,
+    }));
+  }, [data]);
+
+  console.log(data);
+
+  // 원본 데이터 (텍스트 리스트 뷰용)
+  const rawData: PicselBookPicselItem[] = data?.content ?? [];
+
+  const totalPhotos = data?.totalElements ?? 0;
+  const hasPhotos = totalPhotos > 0;
 
   // 사진 선택
   const {
@@ -90,24 +100,40 @@ export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
   // 사진 액션 (삭제, 이동)
   const { handleDelete, handleMove } = usePhotoActions({
     selectedPhotos,
-    onDeleteSuccess: resetSelection,
+    onDeleteSuccess: () => {
+      resetSelection();
+      refetch();
+    },
     exitSelectingMode: handleExitSelecting,
   });
 
-  // 유틸리티
-  const { formatPhotoCount } = usePhotoFormat();
+  // 정렬 액션시트
+  const { showSortSheet } = useSortActionSheet({
+    onSort: setSortType,
+    options: MY_PICSEL_SORT_OPTIONS,
+  });
 
   // 뷰 모드 토글
   const handleToggleViewMode = () => {
     setViewMode(prev => (prev === 'list' ? 'textList' : 'list'));
   };
 
+  // 사진 개수 포맷
+  const formatPhotoCount = (count: number) => {
+    return count.toLocaleString();
+  };
+
   return {
     // 데이터
     photoData,
-    bookTitle,
+    rawData,
     isLoading,
-    totalPhotos: photoData.length,
+    totalPhotos,
+    hasPhotos,
+
+    // 정렬
+    sortType,
+    showSortSheet,
 
     // 뷰 모드
     viewMode,
@@ -141,5 +167,8 @@ export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
 
     // 유틸리티
     formatPhotoCount,
+
+    // 리프레시
+    refetch,
   };
 };

--- a/src/feature/picsel/picselBook/mutations/useDeletePicselBooks.ts
+++ b/src/feature/picsel/picselBook/mutations/useDeletePicselBooks.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deletePicselBooksApi } from '../api/deletePicselBooksApi';
+import { DeletePicselBooksRequest } from '../types';
+
+export const useDeletePicselBooks = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: DeletePicselBooksRequest) =>
+      deletePicselBooksApi(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['picselBooks'] });
+    },
+    onError: error => {
+      console.error('픽셀북 삭제 실패:', error);
+    },
+  });
+};

--- a/src/feature/picsel/picselBook/queries/useGetPicselBookPicsels.ts
+++ b/src/feature/picsel/picselBook/queries/useGetPicselBookPicsels.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPicselBookPicselsApi } from '../api/getPicselBookPicselsApi';
+import { PicselBookFolderParams, PicselBookFolderResult } from '../types';
+
+export const useGetPicselBookPicsels = (params: PicselBookFolderParams) => {
+  const {
+    picselbookId,
+    page = 0,
+    size = 20,
+    sortType = 'RECENT_DESC',
+  } = params;
+
+  return useQuery<PicselBookFolderResult>({
+    queryKey: ['picselBookPicsels', picselbookId, page, size, sortType],
+    queryFn: () =>
+      getPicselBookPicselsApi({ picselbookId, page, size, sortType }),
+    enabled: !!picselbookId,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: 2,
+  });
+};

--- a/src/feature/picsel/picselBook/queries/useGetPicselBooks.ts
+++ b/src/feature/picsel/picselBook/queries/useGetPicselBooks.ts
@@ -1,14 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getPicselBooksApi } from '../api/getPicselBooksApi';
-import { PicselBookParams, PicselBookResult } from '../types';
+import { PicselBookItem, PicselBookParams } from '../types';
 
 export const useGetPicselBooks = (params: PicselBookParams = {}) => {
-  const { page = 0, size = 20, sort = 'RECENT_CREATED_DESC' } = params;
+  const { sort = 'RECENT_CREATED_DESC' } = params;
 
-  return useQuery<PicselBookResult>({
-    queryKey: ['picselBooks', page, size, sort],
-    queryFn: () => getPicselBooksApi({ page, size, sort }),
+  return useQuery<PicselBookItem[]>({
+    queryKey: ['picselBooks', sort],
+    queryFn: () => getPicselBooksApi({ sort }),
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 10,
     retry: 2,

--- a/src/feature/picsel/picselBook/queries/useGetPicselBooks.ts
+++ b/src/feature/picsel/picselBook/queries/useGetPicselBooks.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPicselBooksApi } from '../api/getPicselBooksApi';
+import { PicselBookParams, PicselBookResult } from '../types';
+
+export const useGetPicselBooks = (params: PicselBookParams = {}) => {
+  const { page = 0, size = 20, sort = 'RECENT_CREATED_DESC' } = params;
+
+  return useQuery<PicselBookResult>({
+    queryKey: ['picselBooks', page, size, sort],
+    queryFn: () => getPicselBooksApi({ page, size, sort }),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: 2,
+  });
+};

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -23,3 +23,37 @@ export interface PicselBookItem {
   photoCount: number;
   createdAt: string;
 }
+
+// 픽셀북 폴더 정렬 타입
+export type PicselBookFolderSortType = 'RECENT_DESC' | 'OLDEST_ASC';
+
+// 픽셀북 폴더 API 요청 파라미터
+export interface PicselBookFolderParams {
+  picselbookId: string;
+  page?: number;
+  size?: number;
+  sortType?: PicselBookFolderSortType;
+}
+
+// 픽셀북 내 픽셀 아이템
+export interface PicselBookPicselItem {
+  picselId: string;
+  representativeImagePath: string;
+  title: string;
+  contentPreview: string;
+  takenDate: string;
+  storeId: string;
+  storeName: string;
+  brandImagePath: string;
+}
+
+// 픽셀북 폴더 API 응답 (페이지네이션)
+export interface PicselBookFolderResult {
+  content: PicselBookPicselItem[];
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+  pageSize: number;
+  first: boolean;
+  last: boolean;
+}

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -57,3 +57,8 @@ export interface PicselBookFolderResult {
   first: boolean;
   last: boolean;
 }
+
+// 픽셀북 삭제 요청
+export interface DeletePicselBooksRequest {
+  picselbookIds: string[];
+}

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -1,2 +1,35 @@
-export type PicselBookSortType = 'latest' | 'oldest';
+// 정렬 타입 (API 명세 기준)
+export type PicselBookSortType =
+  | 'RECENT_CREATED_DESC'
+  | 'PHOTO_ADDED_DESC'
+  | 'PHOTO_COUNT_DESC';
+
 export type PicselBookEditType = 'editName' | 'editCover';
+
+// API 요청 파라미터
+export interface PicselBookParams {
+  page?: number;
+  size?: number;
+  sort?: PicselBookSortType;
+}
+
+// 개별 픽셀북 아이템
+export interface PicselBookItem {
+  picselBookId: string;
+  name: string;
+  photoCount: number;
+  coverImagePath?: string;
+  createdAt: string;
+  lastPhotoAddedAt: string;
+}
+
+// API 응답 (페이지네이션)
+export interface PicselBookResult {
+  content: PicselBookItem[];
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+  pageSize: number;
+  first: boolean;
+  last: boolean;
+}

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -15,21 +15,11 @@ export interface PicselBookParams {
 
 // 개별 픽셀북 아이템
 export interface PicselBookItem {
-  picselBookId: string;
-  name: string;
+  picselbookId: string;
+  bookName: string;
+  coverImagePath: string;
+  displayOrder: number;
+  lastPicselAddedAt: string | null;
   photoCount: number;
-  coverImagePath?: string;
   createdAt: string;
-  lastPhotoAddedAt: string;
-}
-
-// API 응답 (페이지네이션)
-export interface PicselBookResult {
-  content: PicselBookItem[];
-  totalElements: number;
-  totalPages: number;
-  pageNumber: number;
-  pageSize: number;
-  first: boolean;
-  last: boolean;
 }

--- a/src/feature/picsel/shared/components/ui/atoms/Skeleton/PhotoTextListItemSkeleton.tsx
+++ b/src/feature/picsel/shared/components/ui/atoms/Skeleton/PhotoTextListItemSkeleton.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef } from 'react';
+
+import { Animated, View } from 'react-native';
+
+import {
+  CARD_SHADOW,
+  TEXT_LIST_CARD,
+} from '@/feature/picsel/picselBook/constants/styles';
+
+const PhotoTextListItemSkeleton = ({
+  opacity,
+}: {
+  opacity: Animated.AnimatedInterpolation<number>;
+}) => {
+  return (
+    <View
+      className="mb-3 flex-row items-center space-x-4 self-stretch rounded-xl border border-gray-100 bg-white px-4 py-3"
+      style={{
+        width: TEXT_LIST_CARD.WIDTH,
+        ...CARD_SHADOW,
+      }}>
+      {/* 이미지 스켈레톤 */}
+      <Animated.View
+        className="flex-shrink-0 rounded bg-gray-200"
+        style={{
+          width: TEXT_LIST_CARD.IMAGE_WIDTH,
+          height: TEXT_LIST_CARD.IMAGE_HEIGHT,
+          opacity,
+        }}
+      />
+
+      {/* 텍스트 영역 스켈레톤 */}
+      <View className="h-[160px] flex-1 justify-between">
+        {/* 상단 영역 */}
+        <View className="flex-col items-start self-stretch">
+          {/* 날짜 스켈레톤 */}
+          <Animated.View
+            className="h-4 w-20 rounded bg-gray-200"
+            style={{ opacity }}
+          />
+
+          {/* 제목 스켈레톤 */}
+          <Animated.View
+            className="mt-2 h-5 w-40 rounded bg-gray-200"
+            style={{ opacity }}
+          />
+
+          {/* 내용 스켈레톤 - 3줄 */}
+          <Animated.View
+            className="mt-2 h-4 w-full rounded bg-gray-200"
+            style={{ opacity }}
+          />
+          <Animated.View
+            className="mt-1 h-4 w-full rounded bg-gray-200"
+            style={{ opacity }}
+          />
+          <Animated.View
+            className="mt-1 h-4 w-3/4 rounded bg-gray-200"
+            style={{ opacity }}
+          />
+        </View>
+
+        {/* 하단 매장명 스켈레톤 */}
+        <View className="flex-row items-center justify-end self-stretch">
+          <Animated.View
+            className="h-4 w-24 rounded bg-gray-200"
+            style={{ opacity }}
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+interface Props {
+  count?: number;
+}
+
+const PhotoTextListSkeleton = ({ count = 4 }: Props) => {
+  const shimmerAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmerAnim, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(shimmerAnim, {
+          toValue: 0,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [shimmerAnim]);
+
+  const opacity = shimmerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.3, 0.7],
+  });
+
+  return (
+    <View
+      style={{
+        alignItems: 'center',
+        paddingHorizontal: 21,
+        paddingTop: 8,
+        paddingBottom: 30,
+      }}>
+      {Array.from({ length: count }).map((_, index) => (
+        <PhotoTextListItemSkeleton
+          key={`skeleton-${index}`}
+          opacity={opacity}
+        />
+      ))}
+    </View>
+  );
+};
+
+export default PhotoTextListSkeleton;

--- a/src/feature/picsel/shared/hooks/animation/useSortActionSheet.ts
+++ b/src/feature/picsel/shared/hooks/animation/useSortActionSheet.ts
@@ -1,7 +1,6 @@
 import { MyPicselSortType } from '@/feature/picsel/myPicsel/types';
+import { PicselBookSortType } from '@/feature/picsel/picselBook/types';
 import { useActionSheetStore } from '@/shared/store/ui/actionSheet';
-
-export type PicselBookSortType = 'latest' | 'add' | 'length';
 
 export interface SortOption<T = MyPicselSortType | PicselBookSortType> {
   type: T;
@@ -16,9 +15,9 @@ export const MY_PICSEL_SORT_OPTIONS: SortOption<MyPicselSortType>[] = [
 
 // 픽셀북 정렬 옵션
 export const PICSEL_BOOK_SORT_OPTIONS: SortOption<PicselBookSortType>[] = [
-  { type: 'latest', label: '최신 생성 순' },
-  { type: 'add', label: '사진 추가 순' },
-  { type: 'length', label: '사진 개수 순' },
+  { type: 'RECENT_CREATED_DESC', label: '최신 생성 순' },
+  { type: 'PHOTO_ADDED_DESC', label: '사진 추가 순' },
+  { type: 'PHOTO_COUNT_DESC', label: '사진 개수 순' },
 ];
 
 interface UseSortActionSheetParams<T = MyPicselSortType | PicselBookSortType> {

--- a/src/feature/picsel/shared/hooks/photo/usePhotoActions.ts
+++ b/src/feature/picsel/shared/hooks/photo/usePhotoActions.ts
@@ -1,4 +1,4 @@
-import { useDeletePicsels } from '@/feature/picsel/mutations/useDeletePicsels';
+import { useDeletePicsels } from '@/feature/picsel/myPicsel/mutations/useDeletePicsels';
 import { showDeleteConfirmModal } from '@/shared/lib/confirmModal';
 import { useToastStore } from '@/shared/store/ui/toast';
 

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -38,7 +38,7 @@ export type MainNavigationProps = {
   PicselTab: undefined;
   YearFolder: { year: string };
   MonthFolder: { year: string; month: string };
-  PicselBookFolder: { bookId: string };
+  PicselBookFolder: { bookId: string; bookName: string };
 };
 
 const MainRoute = () => {

--- a/src/screens/picsel/picselBook/picselBookFolder/index.tsx
+++ b/src/screens/picsel/picselBook/picselBookFolder/index.tsx
@@ -6,20 +6,26 @@ import PicselBookFolderTemplate from '@/feature/picsel/picselBook/components/ui/
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 
 type PicselBookFolderRouteProp = RouteProp<
-  { PicselBookFolder: { bookId: string } },
+  { PicselBookFolder: { bookId: string; bookName: string } },
   'PicselBookFolder'
 >;
 
 const PicselBookFolderScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const route = useRoute<PicselBookFolderRouteProp>();
-  const { bookId } = route.params;
+  const { bookId, bookName } = route.params;
 
   const handleBack = () => {
     navigation.goBack();
   };
 
-  return <PicselBookFolderTemplate bookId={bookId} onBack={handleBack} />;
+  return (
+    <PicselBookFolderTemplate
+      bookId={bookId}
+      bookName={bookName}
+      onBack={handleBack}
+    />
+  );
 };
 
 export default PicselBookFolderScreen;

--- a/src/shared/store/index.tsx
+++ b/src/shared/store/index.tsx
@@ -8,3 +8,4 @@ export { useMapLocationStore } from './searchLocation';
 export { useConfirmModalStore } from './ui/confirmModal';
 export { useActionSheetStore } from './ui/actionSheet';
 export { useMyPicselStore } from './myPicsel';
+export { usePicselBookStore } from './picselBook';

--- a/src/shared/store/picselBook/index.ts
+++ b/src/shared/store/picselBook/index.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+import { PicselBookSortType } from '@/feature/picsel/picselBook/types';
+
+interface PicselBookState {
+  sortType: PicselBookSortType;
+  setSortType: (sort: PicselBookSortType) => void;
+}
+
+export const usePicselBookStore = create<PicselBookState>(set => ({
+  sortType: 'RECENT_CREATED_DESC',
+  setSortType: sort => set({ sortType: sort }),
+}));


### PR DESCRIPTION
## 이슈 번호

> close #85 

## 작업 내용 및 테스트 방법
 ### 작업 내용                                                                                   
                                                                                              
  - 픽셀북 목록 조회 API 연동 (/picselbooks GET)                                              
    - 정렬 기능 포함 (최근 생성순, 사진 추가순, 사진 개수순) 
                                     
  - 픽셀북 폴더 조회 API 연동 (/picselbooks/{picselbookId}/picsels GET)                       
    - PhotoTextListView에 API 타입 적용                                                       
    - 스켈레톤 UI 추가                                                  
                          
  - 픽셀북 삭제 API 연동 (/picselbooks DELETE)                                                
    - React Query mutation 사용                                                               