### PR TITLE
🐛 Fix: 픽셀 업로드 대표 사진 선택 버그 수정

### DIFF
--- a/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
@@ -3,11 +3,16 @@ import { usePhotoGrid } from './usePhotoGrid';
 import { usePhotoSelection } from './usePhotoSelection';
 
 export const usePhotoPicker = (variant: 'main' | 'extra') => {
-  const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto, resetPhotos } =
+  const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto } =
     usePhotoGrid();
 
-  const { mainPhoto, extraPhotos, selectMainPhoto, toggleExtraPhoto } =
-    usePhotoSelection();
+  const {
+    mainPhoto,
+    extraPhotos,
+    selectMainPhoto,
+    selectExtraPhoto,
+    resetCurrentPhoto,
+  } = usePhotoSelection(variant);
 
   const { capturePhoto } = useCameraCapture();
 
@@ -16,27 +21,33 @@ export const usePhotoPicker = (variant: 'main' | 'extra') => {
   const selectedUris = isMain ? (mainPhoto ? [mainPhoto] : []) : extraPhotos;
   const selectedCount = isMain ? selectedUris.length : extraPhotos.length;
 
+  const handleReset = () => {
+    resetCurrentPhoto();
+  };
+
   const handleSelectPhoto = (uri: string) => {
     if (variant === 'main') {
       selectMainPhoto(uri);
     } else {
-      toggleExtraPhoto(uri);
+      selectExtraPhoto(uri);
     }
   };
 
   const handleOpenCamera = async () => {
     const photo = await capturePhoto();
+
     if (!photo) {
       return;
     }
+
+    appendCapturedPhoto(photo);
 
     if (variant === 'main') {
       selectMainPhoto(photo.uri);
       return;
     }
 
-    appendCapturedPhoto(photo);
-    toggleExtraPhoto(photo.uri);
+    selectExtraPhoto(photo.uri);
   };
 
   return {
@@ -47,6 +58,6 @@ export const usePhotoPicker = (variant: 'main' | 'extra') => {
     hasNextPage,
     handleSelectPhoto,
     handleOpenCamera,
-    resetSelection: resetPhotos,
+    resetSelection: handleReset,
   };
 };

--- a/src/feature/picsel/picselUpload/hooks/usePhotoSelection.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoSelection.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { usePhotoStore } from '@/shared/store/picselUpload';
 import { useToastStore } from '@/shared/store/ui/toast';
 
-export const usePhotoSelection = () => {
+export const usePhotoSelection = (variant: 'main' | 'extra') => {
   const MAX_EXTRA_COUNT = 10;
   const { showToast } = useToastStore();
 
@@ -12,21 +12,28 @@ export const usePhotoSelection = () => {
     extraPhotos,
     setMainPhoto,
     addExtraPhotos,
+    setExtraPhotos,
     removeExtraPhoto,
   } = usePhotoStore();
 
   const selectMainPhoto = useCallback(
     (uri: string) => {
+      if (mainPhoto === uri) {
+        setMainPhoto(null);
+        return;
+      }
+
       if (mainPhoto) {
         showToast('대표사진은 1장만 선택 가능해요', 60);
         return;
       }
+
       setMainPhoto(uri);
     },
     [mainPhoto, setMainPhoto, showToast],
   );
 
-  const toggleExtraPhoto = useCallback(
+  const selectExtraPhoto = useCallback(
     (uri: string) => {
       const index = extraPhotos.indexOf(uri);
 
@@ -45,10 +52,19 @@ export const usePhotoSelection = () => {
     [extraPhotos, addExtraPhotos, removeExtraPhoto, showToast],
   );
 
+  const resetCurrentPhoto = useCallback(() => {
+    if (variant === 'main') {
+      setMainPhoto(null);
+    } else {
+      setExtraPhotos([]);
+    }
+  }, [variant, setMainPhoto]);
+
   return {
     mainPhoto,
     extraPhotos,
     selectMainPhoto,
-    toggleExtraPhoto,
+    selectExtraPhoto,
+    resetCurrentPhoto,
   };
 };

--- a/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
@@ -13,9 +13,9 @@ interface Props {
   hasSelected?: boolean;
 }
 
-const UploadPhotoHeader = ({ variant, onReset, hasSelected }: Props) => {
+const PhotoSelectHeader = ({ variant, onReset, hasSelected }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
-  const isMain = variant === 'main'; // 대표 사진을 선택하는 화면인 경우
+  const isMain = variant === 'main';
 
   return (
     <>
@@ -53,4 +53,4 @@ const UploadPhotoHeader = ({ variant, onReset, hasSelected }: Props) => {
   );
 };
 
-export default UploadPhotoHeader;
+export default PhotoSelectHeader;

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { View } from 'react-native';
@@ -6,7 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import SelectButton from '@/feature/brand/ui/organisms/SelectButton';
 import { usePhotoPicker } from '@/feature/picsel/picselUpload/hooks/usePhotoPicker';
-import SelectPhotoHeader from '@/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader';
+import PhotoSelectHeader from '@/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader';
 import { PhotoGrid } from '@/feature/picsel/picselUpload/ui/organisms/PhotoGrid';
 import { MainNavigationProps } from '@/navigation';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
@@ -39,19 +39,12 @@ const SelectPhotoScreen = () => {
     } else {
       addExtraPhotos(selectedUris);
     }
-
     navigation.navigate('PicselUpload');
   };
 
-  useEffect(() => {
-    if (selectedCount === 1 && variant === 'main') {
-      navigation.navigate('PicselUpload');
-    }
-  }, [selectedCount]);
-
   return (
     <SafeAreaView className="flex-1 bg-white" edges={['top']}>
-      <SelectPhotoHeader
+      <PhotoSelectHeader
         variant={variant}
         onReset={resetSelection}
         hasSelected={!!selectedUris}

--- a/src/shared/store/picselUpload/index.ts
+++ b/src/shared/store/picselUpload/index.ts
@@ -6,6 +6,8 @@ interface PhotoState {
 
   setMainPhoto: (uri: string | null) => void;
   addExtraPhotos: (uris: string[]) => void;
+
+  setExtraPhotos: (uris: string[]) => void;
   removeExtraPhoto: (index: number) => void;
   reset: () => void;
 }
@@ -20,6 +22,8 @@ export const usePhotoStore = create<PhotoState>(set => ({
     set(state => ({
       extraPhotos: Array.from(new Set([...state.extraPhotos, ...uris])),
     })),
+
+  setExtraPhotos: uris => set({ extraPhotos: uris }),
 
   removeExtraPhoto: index =>
     set(state => ({


### PR DESCRIPTION
## 이슈 번호

> #82

## 작업 내용 및 테스트 방법

> 대표 사진 1장 선택 시 바로 사진 등록 화면으로 `Redirect` 되어버리는 버그를 수정했습니다.
> 추가로 사진 등록 `Header` 우측 초기화 버튼이 동작하지 않는 버그를 수정했습니다.

## To reviewers
- 버그 수정하며, 적절하지 않아 보이는 네이밍까지 추가로 개선해보았습니다! 