### PR TITLE
🐛 Fix: 이미지 업로드 API type 추가 및 적용

### DIFF
--- a/src/feature/picsel/picselUpload/mutations/useAddPicselToPicselBook.ts
+++ b/src/feature/picsel/picselUpload/mutations/useAddPicselToPicselBook.ts
@@ -12,7 +12,7 @@ export const useAddPicselToPicselBook = () => {
     mutationFn: async (request: PicselUploadRequest) => {
       const s3ImageUrls = await uploadMultipleImagesToS3(
         request.imagePaths,
-        'PICSELBOOK',
+        'PICSEL',
       );
 
       return addPicselToPicselBookApi({

--- a/src/shared/api/images/types/index.ts
+++ b/src/shared/api/images/types/index.ts
@@ -9,4 +9,4 @@ export interface PresignedUrlResponse extends CommonResponseType {
   data: PresignedUrlData;
 }
 
-export type ImageType = 'PROFILE' | 'PICSELBOOK';
+export type ImageType = 'PROFILE' | 'PICSELBOOK' | 'PICSEL';


### PR DESCRIPTION
## 이슈 번호

> #104 

## 작업 내용 및 테스트 방법

> **이미지 업로드 API** 내 추가된 **type** 파라미터를 정의하고 픽셀 업로드 로직에 적용하였습니다.

## To reviewers
적은 내용이지만, 추가된 타입으로 픽셀 업로드 요청을 보내야해서 급하게 수정 진행했습니다!  