### PR TITLE
♻️ Refactor: 마이페이지 리팩토링

### DIFF
--- a/src/feature/mypage/account/hooks/useAccountMenu.tsx
+++ b/src/feature/mypage/account/hooks/useAccountMenu.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { useUserStore } from '@/shared/store';
 
 export const useAccountMenu = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const { logout } = useUserStore();
 
   const executeLogout = useCallback(() => {

--- a/src/feature/mypage/brand/components/ui/atoms/BrandBottomAction.tsx
+++ b/src/feature/mypage/brand/components/ui/atoms/BrandBottomAction.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { Pressable, Text, View } from 'react-native';
+
+import {
+  BrandSettingMode,
+  ACTION_TEXTS,
+} from '../../../constants/brandSettingTexts';
+
+import PicselActionIcons from '@/shared/icons/PicselActionIcons';
+
+interface Props {
+  mode: BrandSettingMode;
+  removeCount: number;
+  addCount: number;
+  hasFavorites: boolean;
+  onConfirmRemove: () => void;
+  onConfirmAdd: () => void;
+}
+
+const BrandBottomAction = ({
+  mode,
+  removeCount,
+  addCount,
+  hasFavorites,
+  onConfirmRemove,
+  onConfirmAdd,
+}: Props) => {
+  if (mode === 'remove' && hasFavorites) {
+    return (
+      <View className="flex-row">
+        <Pressable
+          className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
+          onPress={onConfirmRemove}>
+          <PicselActionIcons shape="delete" width={24} height={24} />
+          <Text className="text-semantic-error headline-02">
+            {ACTION_TEXTS.REMOVE(removeCount)}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (mode === 'add') {
+    return (
+      <View className="flex-row">
+        <Pressable
+          className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
+          onPress={onConfirmAdd}>
+          <Text className="text-primary-pink headline-02">
+            {ACTION_TEXTS.ADD(addCount)}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return null;
+};
+
+export default BrandBottomAction;

--- a/src/feature/mypage/brand/components/ui/atoms/BrandGuideText.tsx
+++ b/src/feature/mypage/brand/components/ui/atoms/BrandGuideText.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Text, View } from 'react-native';
+
+import {
+  BrandSettingMode,
+  GUIDE_TEXTS,
+} from '../../../constants/brandSettingTexts';
+
+interface Props {
+  mode: BrandSettingMode;
+  hasFavorites: boolean;
+}
+
+const BrandGuideText = ({ mode, hasFavorites }: Props) => {
+  if (mode === 'default') {
+    return null;
+  }
+  if (mode === 'remove' && !hasFavorites) {
+    return null;
+  }
+
+  const { highlight, rest } = GUIDE_TEXTS[mode];
+
+  return (
+    <View
+      className={`flex items-center justify-center px-1 py-2 ${mode === 'remove' ? '-mb-3' : ''}`}>
+      <Text className="text-gray-500 headline-01">
+        <Text className="text-primary-pink headline-01">{highlight}</Text>
+        {rest}
+      </Text>
+    </View>
+  );
+};
+
+export default BrandGuideText;

--- a/src/feature/mypage/brand/components/ui/molecules/BrandEmptyState.tsx
+++ b/src/feature/mypage/brand/components/ui/molecules/BrandEmptyState.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Text, View } from 'react-native';
+
+import { EMPTY_TEXT } from '../../../constants/brandSettingTexts';
+
+import SparkleImages from '@/shared/images/Sparkle';
+
+const BrandEmptyState = () => {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SparkleImages shape="bg-opacity" height={418} width={340} />
+      <Text className="absolute text-gray-900 headline-04">{EMPTY_TEXT}</Text>
+    </View>
+  );
+};
+
+export default BrandEmptyState;

--- a/src/feature/mypage/brand/components/ui/molecules/BrandSettingContent.tsx
+++ b/src/feature/mypage/brand/components/ui/molecules/BrandSettingContent.tsx
@@ -1,0 +1,76 @@
+import React, { RefObject } from 'react';
+
+import { ScrollView } from 'react-native';
+
+import BrandEmptyState from '../molecules/BrandEmptyState';
+import BrandSettingGrid from '../organisms/BrandSettingGrid';
+
+import { Brand } from '@/feature/brand/types';
+import { BrandSettingMode } from '@/feature/mypage/brand/constants/brandSettingTexts';
+
+interface Props {
+  mode: BrandSettingMode;
+  favoriteBrands: Brand[];
+  allBrandsForAdd: Brand[];
+  removeSelectedIds: string[];
+  addSelectedIds: string[];
+  favoriteBrandIds: Set<string>;
+  toggleRemoveSelect: (brandId: string) => void;
+  toggleAddSelect: (brandId: string) => void;
+  scrollViewRef: RefObject<ScrollView | null>;
+  onScroll: (event: any) => void;
+}
+
+const BrandSettingContent = ({
+  mode,
+  favoriteBrands,
+  allBrandsForAdd,
+  removeSelectedIds,
+  addSelectedIds,
+  favoriteBrandIds,
+  toggleRemoveSelect,
+  toggleAddSelect,
+  scrollViewRef,
+  onScroll,
+}: Props) => {
+  if (mode === 'add') {
+    return (
+      <ScrollView
+        ref={scrollViewRef}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        className="flex-1 px-2"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 10 }}>
+        <BrandSettingGrid
+          brands={allBrandsForAdd}
+          selectedIds={addSelectedIds}
+          onPress={toggleAddSelect}
+          disabledBrandIds={favoriteBrandIds}
+        />
+      </ScrollView>
+    );
+  }
+
+  if (favoriteBrands.length === 0) {
+    return <BrandEmptyState />;
+  }
+
+  return (
+    <ScrollView
+      ref={scrollViewRef}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      className="flex-1 px-2 pt-4"
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ paddingBottom: 10 }}>
+      <BrandSettingGrid
+        brands={favoriteBrands}
+        selectedIds={mode === 'remove' ? removeSelectedIds : []}
+        onPress={mode === 'remove' ? toggleRemoveSelect : undefined}
+      />
+    </ScrollView>
+  );
+};
+
+export default BrandSettingContent;

--- a/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
+++ b/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { ImageBackground, Pressable, Text, View } from 'react-native';
+import Config from 'react-native-config';
+
+import { Brand } from '@/feature/brand/types';
+import { chunkArray } from '@/feature/brand/utils/arrayUtils';
+import CheckIcons from '@/shared/icons/CheckIcons';
+import { defaultShadow } from '@/shared/styles/shadows';
+
+interface Props {
+  brands: Brand[];
+  selectedIds: string[];
+  onPress?: (brandId: string) => void;
+  disabledBrandIds?: Set<string>;
+}
+
+const COLUMNS = 3;
+
+const BrandSettingGrid = ({
+  brands,
+  selectedIds,
+  onPress,
+  disabledBrandIds,
+}: Props) => {
+  return (
+    <>
+      {chunkArray(brands, COLUMNS).map((row, rowIndex) => (
+        <View key={rowIndex} className="mb-6 flex-row justify-between py-1">
+          {row.map(item => {
+            const isSelected = selectedIds.includes(item.brandId);
+            const isDisabled = disabledBrandIds?.has(item.brandId) ?? false;
+
+            return (
+              <View
+                key={item.brandId}
+                className="flex-1 items-center"
+                style={isDisabled ? { opacity: 0.35 } : undefined}>
+                <View style={defaultShadow} className="mb-[7px] rounded-full">
+                  <Pressable
+                    onPress={onPress ? () => onPress(item.brandId) : undefined}
+                    disabled={isDisabled}>
+                    <ImageBackground
+                      source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
+                      className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
+                      {isSelected && !isDisabled && (
+                        <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
+                          <CheckIcons shape="white" width={24} height={24} />
+                        </View>
+                      )}
+                    </ImageBackground>
+                  </Pressable>
+                </View>
+                <Text
+                  className="text-center text-gray-900 body-rg-02"
+                  numberOfLines={1}
+                  ellipsizeMode="tail">
+                  {item.name}
+                </Text>
+              </View>
+            );
+          })}
+
+          {row.length < COLUMNS &&
+            Array.from({ length: COLUMNS - row.length }).map((_, i) => (
+              <View key={`empty-${i}`} className="flex-1" />
+            ))}
+        </View>
+      ))}
+    </>
+  );
+};
+
+export default BrandSettingGrid;

--- a/src/feature/mypage/brand/constants/brandSettingTexts.ts
+++ b/src/feature/mypage/brand/constants/brandSettingTexts.ts
@@ -1,0 +1,38 @@
+export type BrandSettingMode = 'default' | 'remove' | 'add';
+
+export const HEADER_TITLES: Record<BrandSettingMode, string> = {
+  default: '찜한 브랜드',
+  remove: '찜한 브랜드 삭제',
+  add: '찜 브랜드 추가',
+} as const;
+
+export const GUIDE_TEXTS: Record<
+  'remove' | 'add',
+  { highlight: string; rest: string }
+> = {
+  remove: { highlight: '찜 해제', rest: '할 브랜드를 골라주세요.' },
+  add: { highlight: '추가로 찜할', rest: ' 브랜드를 골라주세요.' },
+} as const;
+
+export const TOAST_MESSAGES = {
+  REMOVE_EMPTY: '찜 해제할 브랜드를 골라주세요',
+  REMOVE_ERROR: '찜 해제 중 오류가 발생했어요',
+  REMOVE_SUCCESS: (count: number) => `${count}개의 브랜드를 찜 해제 했어요`,
+  ADD_EMPTY: '찜 추가할 브랜드를 골라주세요',
+  ADD_ERROR: '브랜드 추가 중 오류가 발생했어요',
+  ADD_SUCCESS: (count: number) => `${count}개의 브랜드를 찜 추가했어요`,
+} as const;
+
+export const ACTION_TEXTS = {
+  REMOVE: (count: number) =>
+    count > 0 ? `${count}개의 브랜드 찜 해제하기` : '찜 해제하기',
+  ADD: (count: number) =>
+    count > 0 ? `${count}개의 브랜드 찜 추가하기` : '추가하기',
+} as const;
+
+export const DROPDOWN_ITEMS = {
+  ADD: '찜 브랜드 추가',
+  REMOVE: '찜 해제',
+} as const;
+
+export const EMPTY_TEXT = '찜한 브랜드가 없어요';

--- a/src/feature/mypage/brand/hooks/useBrandSetting.ts
+++ b/src/feature/mypage/brand/hooks/useBrandSetting.ts
@@ -1,0 +1,168 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+
+import {
+  BrandSettingMode,
+  TOAST_MESSAGES,
+} from '../constants/brandSettingTexts';
+
+import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
+import {
+  useBrandListStore,
+  useFavoriteStore,
+  useSearchSelectedBrandsStore,
+} from '@/shared/store';
+import { useToastStore } from '@/shared/store/ui/toast';
+
+const toggleId = (ids: string[], id: string) =>
+  ids.includes(id) ? ids.filter(v => v !== id) : [...ids, id];
+
+export const useBrandSetting = () => {
+  const [mode, setMode] = useState<BrandSettingMode>('default');
+  const [removeSelectedIds, setRemoveSelectedIds] = useState<string[]>([]);
+  const [addSelectedIds, setAddSelectedIds] = useState<string[]>([]);
+
+  const { brandList } = useBrandListStore();
+  const { optimisticFavorites, setOptimisticFavorite } = useFavoriteStore();
+  const { searchSelectedBrandIds, clearSearchSelectedBrandIds } =
+    useSearchSelectedBrandsStore();
+  const { showToast } = useToastStore();
+  const { mutate: toggleFavorite } = useToggleFavoriteBrand();
+
+  useEffect(() => {
+    if (searchSelectedBrandIds.length > 0) {
+      setMode('add');
+      setAddSelectedIds(prev => {
+        const merged = new Set([...prev, ...searchSelectedBrandIds]);
+        return Array.from(merged);
+      });
+      clearSearchSelectedBrandIds();
+    }
+  }, [searchSelectedBrandIds, clearSearchSelectedBrandIds]);
+
+  const favoriteBrands = useMemo(
+    () =>
+      brandList.filter(brand => optimisticFavorites[brand.brandId] === true),
+    [brandList, optimisticFavorites],
+  );
+
+  const favoriteBrandIds = useMemo(
+    () => new Set(favoriteBrands.map(b => b.brandId)),
+    [favoriteBrands],
+  );
+
+  const allBrandsForAdd = useMemo(
+    () => brandList.filter(brand => brand.brandId !== 'NONE'),
+    [brandList],
+  );
+
+  const removeSelectedList = useMemo(
+    () => removeSelectedIds.map(id => ({ brandId: id, name: '' })),
+    [removeSelectedIds],
+  );
+
+  const addSelectedList = useMemo(
+    () => addSelectedIds.map(id => ({ brandId: id, name: '' })),
+    [addSelectedIds],
+  );
+
+  const toggleRemoveSelect = useCallback((brandId: string) => {
+    setRemoveSelectedIds(prev => toggleId(prev, brandId));
+  }, []);
+
+  const toggleAddSelect = useCallback(
+    (brandId: string) => {
+      if (favoriteBrandIds.has(brandId)) {
+        return;
+      }
+      setAddSelectedIds(prev => toggleId(prev, brandId));
+    },
+    [favoriteBrandIds],
+  );
+
+  const enterAddMode = useCallback(() => {
+    setMode('add');
+    setAddSelectedIds([]);
+  }, []);
+
+  const enterRemoveMode = useCallback(() => {
+    setMode('remove');
+    setRemoveSelectedIds([]);
+  }, []);
+
+  const exitMode = useCallback(() => {
+    setMode('default');
+    setRemoveSelectedIds([]);
+    setAddSelectedIds([]);
+  }, []);
+
+  const resetRemoveSelection = useCallback(() => {
+    setRemoveSelectedIds([]);
+  }, []);
+
+  const confirmRemove = useCallback(() => {
+    if (removeSelectedIds.length === 0) {
+      showToast(TOAST_MESSAGES.REMOVE_EMPTY);
+      return;
+    }
+
+    removeSelectedIds.forEach(brandId => {
+      setOptimisticFavorite(brandId, false);
+      toggleFavorite(
+        { brandId, action: 'REMOVE' },
+        {
+          onError: () => {
+            setOptimisticFavorite(brandId, true);
+            showToast(TOAST_MESSAGES.REMOVE_ERROR);
+          },
+        },
+      );
+    });
+
+    showToast(TOAST_MESSAGES.REMOVE_SUCCESS(removeSelectedIds.length));
+    setMode('default');
+    setRemoveSelectedIds([]);
+  }, [removeSelectedIds, setOptimisticFavorite, toggleFavorite, showToast]);
+
+  const confirmAdd = useCallback(() => {
+    if (addSelectedIds.length === 0) {
+      showToast(TOAST_MESSAGES.ADD_EMPTY);
+      return;
+    }
+
+    addSelectedIds.forEach(brandId => {
+      setOptimisticFavorite(brandId, true);
+      toggleFavorite(
+        { brandId, action: 'ADD' },
+        {
+          onError: () => {
+            setOptimisticFavorite(brandId, false);
+            showToast(TOAST_MESSAGES.ADD_ERROR);
+          },
+        },
+      );
+    });
+
+    showToast(TOAST_MESSAGES.ADD_SUCCESS(addSelectedIds.length));
+    setMode('default');
+    setAddSelectedIds([]);
+  }, [addSelectedIds, setOptimisticFavorite, toggleFavorite, showToast]);
+
+  return {
+    mode,
+    favoriteBrands,
+    favoriteBrandIds,
+    allBrandsForAdd,
+    removeSelectedIds,
+    addSelectedIds,
+    removeSelectedList,
+    addSelectedList,
+    toggleRemoveSelect,
+    toggleAddSelect,
+    enterAddMode,
+    enterRemoveMode,
+    exitMode,
+    resetRemoveSelection,
+    confirmRemove,
+    confirmAdd,
+  };
+};

--- a/src/feature/mypage/brand/hooks/useBrandSettingHeader.tsx
+++ b/src/feature/mypage/brand/hooks/useBrandSettingHeader.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+import { Pressable, Text } from 'react-native';
+
+import { DROPDOWN_ITEMS } from '../constants/brandSettingTexts';
+import type { BrandSettingMode } from '../constants/brandSettingTexts';
+
+import Kebab from '@/assets/icons/kebab/icon-kebab.svg';
+import PlusIcon from '@/assets/icons/plus/icon-plus-S.svg';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
+import PicselActionIcons from '@/shared/icons/PicselActionIcons';
+import ReplayIcons from '@/shared/icons/ReplayIcon';
+import SearchIcons from '@/shared/icons/SearchIcons';
+
+interface Params {
+  mode: BrandSettingMode;
+  removeSelectedCount: number;
+  resetRemoveSelection: () => void;
+  enterAddMode: () => void;
+  enterRemoveMode: () => void;
+  hideDropdown: (onComplete?: () => void) => void;
+}
+
+export const useBrandSettingHeader = ({
+  mode,
+  removeSelectedCount,
+  resetRemoveSelection,
+  enterAddMode,
+  enterRemoveMode,
+  hideDropdown,
+}: Params) => {
+  const navigation = useNavigation<MypageNavigationProp>();
+
+  const dropdownItems: DropdownMenuItem[] = useMemo(
+    () => [
+      {
+        label: DROPDOWN_ITEMS.ADD,
+        onPress: () => hideDropdown(enterAddMode),
+        icon: <PlusIcon />,
+      },
+
+      {
+        label: DROPDOWN_ITEMS.REMOVE,
+        onPress: () => hideDropdown(enterRemoveMode),
+        textClassName: 'text-semantic-error body-rg-04',
+        icon: <PicselActionIcons shape="delete" width={20} height={20} />,
+      },
+    ],
+    [hideDropdown, enterAddMode, enterRemoveMode],
+  );
+
+  const rightElement = useMemo(() => {
+    switch (mode) {
+      case 'remove':
+        return removeSelectedCount > 0 ? (
+          <Pressable
+            onPress={resetRemoveSelection}
+            className="flex-row items-center">
+            <Text className="text-pink-500 headline-02">초기화</Text>
+            <ReplayIcons width={24} height={24} shape="true" />
+          </Pressable>
+        ) : undefined;
+      case 'add':
+        return (
+          <Pressable
+            onPress={() =>
+              navigation.navigate('BrandSearchScreen', { variant: 'mypage' })
+            }>
+            <SearchIcons shape="black" width={24} height={24} />
+          </Pressable>
+        );
+      default:
+        return <Kebab />;
+    }
+  }, [mode, removeSelectedCount, resetRemoveSelection, navigation]);
+
+  return { dropdownItems, rightElement };
+};

--- a/src/feature/mypage/main/hooks/useMypageMenu.tsx
+++ b/src/feature/mypage/main/hooks/useMypageMenu.tsx
@@ -24,15 +24,15 @@ export const useMypageMenu = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
 
   const handleNotice = () => {
-    navigation.navigate('NoticeScreen');
+    navigation.navigate('MypageRoute', { screen: 'NoticeScreen' });
   };
 
   const handleInquiry = () => {
-    navigation.navigate('InquiryScreen');
+    navigation.navigate('MypageRoute', { screen: 'InquiryScreen' });
   };
 
   const handleTeamIntro = () => {
-    navigation.navigate('TeamIntro');
+    navigation.navigate('MypageRoute', { screen: 'TeamIntro' });
   };
 
   const menuItems = MYPAGE_MENU_ITEMS.map(item => {

--- a/src/feature/mypage/setting/hooks/useSettingMenu.tsx
+++ b/src/feature/mypage/setting/hooks/useSettingMenu.tsx
@@ -9,7 +9,7 @@ import {
   SETTING_MENU_ITEMS,
 } from '../constants/settingMenuItems';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import BellIcons from '@/shared/icons/BellIcons';
 import MypageIcons from '@/shared/icons/MypageIcons';
@@ -30,7 +30,7 @@ const getIconByType = (iconType?: string) => {
 };
 
 export const useSettingMenu = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
 
   const handleAccountManage = useCallback(() => {
     navigation.navigate('MypageAccount');

--- a/src/feature/mypage/withdrawal/hooks/useWithdrawal.ts
+++ b/src/feature/mypage/withdrawal/hooks/useWithdrawal.ts
@@ -6,11 +6,11 @@ import { Keyboard } from 'react-native';
 import { withdrawApi } from '../api/withdrawApi';
 import { ETC_REASON_ID } from '../constants/withdrawalText';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 
 export const useWithdrawal = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
   const [etcReason, setEtcReason] = useState('');
 

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,23 +1,12 @@
 import React from 'react';
 
+import { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import MypageRoute, { MypageNavigationProps } from './route/mypage';
 import SignupRoute from './route/signup';
 import BottomTabBar from './tabs';
 
-import BrandSearchScreen from '@/screens/brandSearch';
-import MypageScreen from '@/screens/mypage';
-import MypageAccountScreen from '@/screens/mypage/account';
-import BrandSettingScreen from '@/screens/mypage/brand';
-import EditNicknameScreen from '@/screens/mypage/editNickname';
-import InquiryScreen from '@/screens/mypage/inquiry';
-import NoticeScreen from '@/screens/mypage/notice';
-import NotificationScreen from '@/screens/mypage/notification';
-import NotificationSettingScreen from '@/screens/mypage/notification/setting';
-import MypageSettingScreen from '@/screens/mypage/setting';
-import TeamIntroScreen from '@/screens/mypage/teamIntro';
-import WithdrawalScreen from '@/screens/mypage/withdrawal';
-import WithdrawalSuccessScreen from '@/screens/mypage/withdrawal/success';
 import PicselTabScreen from '@/screens/picsel';
 import MonthFolderScreen from '@/screens/picsel/myPicsel/monthFolder';
 import YearFolderScreen from '@/screens/picsel/myPicsel/yearFolder';
@@ -57,19 +46,7 @@ export type MainNavigationProps = {
   SelectBookCover: { variant: 'cover'; bookName: string };
 
   // Mypage
-  Mypage: { toastMessage?: string } | undefined;
-  MypageSetting: undefined;
-  MypageAccount: undefined;
-  MypageWithdrawal: undefined;
-  MypageWithdrawalSuccess: undefined;
-  EditNicknameScreen: undefined;
-  NotificationScreen: undefined;
-  NotificationSettingScreen: undefined;
-  BrandSettingScreen: undefined;
-  BrandSearchScreen: { variant: 'signup' | 'mypage' };
-  NoticeScreen: undefined;
-  InquiryScreen: undefined;
-  TeamIntro: undefined;
+  MypageRoute: NavigatorScreenParams<MypageNavigationProps>;
 };
 
 const MainRoute = () => {
@@ -127,29 +104,7 @@ const MainRoute = () => {
       />
 
       {/* Mypage */}
-      <Stack.Screen name="Mypage" component={MypageScreen} />
-      <Stack.Screen name="MypageSetting" component={MypageSettingScreen} />
-      <Stack.Screen name="MypageAccount" component={MypageAccountScreen} />
-      <Stack.Screen name="MypageWithdrawal" component={WithdrawalScreen} />
-      <Stack.Screen
-        name="MypageWithdrawalSuccess"
-        component={WithdrawalSuccessScreen}
-      />
-      <Stack.Screen name="EditNicknameScreen" component={EditNicknameScreen} />
-      <Stack.Screen name="NotificationScreen" component={NotificationScreen} />
-      <Stack.Screen
-        name="NotificationSettingScreen"
-        component={NotificationSettingScreen}
-      />
-      <Stack.Screen name="BrandSettingScreen" component={BrandSettingScreen} />
-      <Stack.Screen
-        name="BrandSearchScreen"
-        component={BrandSearchScreen}
-        initialParams={{ variant: 'mypage' }}
-      />
-      <Stack.Screen name="NoticeScreen" component={NoticeScreen} />
-      <Stack.Screen name="InquiryScreen" component={InquiryScreen} />
-      <Stack.Screen name="TeamIntro" component={TeamIntroScreen} />
+      <Stack.Screen name="MypageRoute" component={MypageRoute} />
     </Stack.Navigator>
   );
 };

--- a/src/navigation/route/mypage/index.tsx
+++ b/src/navigation/route/mypage/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import BrandSearchScreen from '@/screens/brandSearch';
+import MypageAccountScreen from '@/screens/mypage/account';
+import BrandSettingScreen from '@/screens/mypage/brand';
+import EditNicknameScreen from '@/screens/mypage/editNickname';
+import InquiryScreen from '@/screens/mypage/inquiry';
+import NoticeScreen from '@/screens/mypage/notice';
+import NotificationScreen from '@/screens/mypage/notification';
+import NotificationSettingScreen from '@/screens/mypage/notification/setting';
+import MypageSettingScreen from '@/screens/mypage/setting';
+import TeamIntroScreen from '@/screens/mypage/teamIntro';
+import WithdrawalScreen from '@/screens/mypage/withdrawal';
+import WithdrawalSuccessScreen from '@/screens/mypage/withdrawal/success';
+
+export type MypageNavigationProps = {
+  MypageSetting: undefined;
+  MypageAccount: undefined;
+  MypageWithdrawal: undefined;
+  MypageWithdrawalSuccess: undefined;
+  EditNicknameScreen: undefined;
+  NotificationScreen: undefined;
+  NotificationSettingScreen: undefined;
+  BrandSettingScreen: undefined;
+  BrandSearchScreen: { variant: 'signup' | 'mypage' };
+  NoticeScreen: undefined;
+  InquiryScreen: undefined;
+  TeamIntro: undefined;
+};
+
+const MypageRoute = () => {
+  const Stack = createNativeStackNavigator<MypageNavigationProps>();
+
+  return (
+    <Stack.Navigator
+      id={undefined}
+      initialRouteName="MypageSetting"
+      screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="MypageSetting" component={MypageSettingScreen} />
+      <Stack.Screen name="MypageAccount" component={MypageAccountScreen} />
+      <Stack.Screen name="MypageWithdrawal" component={WithdrawalScreen} />
+      <Stack.Screen
+        name="MypageWithdrawalSuccess"
+        component={WithdrawalSuccessScreen}
+      />
+      <Stack.Screen name="EditNicknameScreen" component={EditNicknameScreen} />
+      <Stack.Screen name="NotificationScreen" component={NotificationScreen} />
+      <Stack.Screen
+        name="NotificationSettingScreen"
+        component={NotificationSettingScreen}
+      />
+      <Stack.Screen name="BrandSettingScreen" component={BrandSettingScreen} />
+      <Stack.Screen
+        name="BrandSearchScreen"
+        component={BrandSearchScreen}
+        initialParams={{ variant: 'mypage' }}
+      />
+      <Stack.Screen name="NoticeScreen" component={NoticeScreen} />
+      <Stack.Screen name="InquiryScreen" component={InquiryScreen} />
+      <Stack.Screen name="TeamIntro" component={TeamIntroScreen} />
+    </Stack.Navigator>
+  );
+};
+
+export default MypageRoute;

--- a/src/navigation/types/navigateTypeUtil.ts
+++ b/src/navigation/types/navigateTypeUtil.ts
@@ -1,9 +1,12 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { MainNavigationProps } from '@/navigation';
+import { MypageNavigationProps } from '@/navigation/route/mypage';
 import { SignupNavigationProps } from '@/navigation/route/signup';
 
 export type RootStackNavigationProp =
   NativeStackNavigationProp<MainNavigationProps>;
+export type MypageNavigationProp =
+  NativeStackNavigationProp<MypageNavigationProps>;
 export type SignupNavigationProp =
   NativeStackNavigationProp<SignupNavigationProps>;

--- a/src/screens/mypage/brand/index.tsx
+++ b/src/screens/mypage/brand/index.tsx
@@ -25,7 +25,7 @@ import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
 import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
 import { chunkArray } from '@/feature/brand/utils/arrayUtils';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import CheckIcons from '@/shared/icons/CheckIcons';
 import FloatingButton from '@/shared/icons/FloatingButton';
@@ -63,7 +63,7 @@ const BrandSettingScreen = () => {
     useSearchSelectedBrandsStore();
   const { showToast } = useToastStore();
   const { mutate: toggleFavorite } = useToggleFavoriteBrand();
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const { showFloatingButton, handleScroll, scrollToTop, scrollViewRef } =
     useHandleScroll();
 

--- a/src/screens/mypage/brand/index.tsx
+++ b/src/screens/mypage/brand/index.tsx
@@ -1,498 +1,70 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React from 'react';
 
-import { useNavigation } from '@react-navigation/native';
-import {
-  ImageBackground,
-  Modal,
-  Pressable,
-  ScrollView,
-  Text,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
-import Config from 'react-native-config';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  runOnJS,
-  Easing,
-} from 'react-native-reanimated';
+import { Pressable } from 'react-native';
 
-import Kebab from '@/assets/icons/kebab/icon-kebab.svg';
-import PlusIcon from '@/assets/icons/plus/icon-plus-S.svg';
 import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
-import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
-import { chunkArray } from '@/feature/brand/utils/arrayUtils';
+import BrandBottomAction from '@/feature/mypage/brand/components/ui/atoms/BrandBottomAction';
+import BrandGuideText from '@/feature/mypage/brand/components/ui/atoms/BrandGuideText';
+import BrandSettingContent from '@/feature/mypage/brand/components/ui/molecules/BrandSettingContent';
+import { HEADER_TITLES } from '@/feature/mypage/brand/constants/brandSettingTexts';
+import { useBrandSetting } from '@/feature/mypage/brand/hooks/useBrandSetting';
+import { useBrandSettingHeader } from '@/feature/mypage/brand/hooks/useBrandSettingHeader';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
-import CheckIcons from '@/shared/icons/CheckIcons';
+import DropdownMenu from '@/shared/components/ui/molecules/DropdownMenu';
+import { useDropdownMenu } from '@/shared/hooks/useDropdownMenu';
 import FloatingButton from '@/shared/icons/FloatingButton';
-import PicselActionIcons from '@/shared/icons/PicselActionIcons';
-import ReplayIcons from '@/shared/icons/ReplayIcon';
-import SearchIcons from '@/shared/icons/SearchIcons';
-import SparkleImages from '@/shared/images/Sparkle';
-import {
-  useBrandListStore,
-  useFavoriteStore,
-  useSearchSelectedBrandsStore,
-} from '@/shared/store';
-import { useToastStore } from '@/shared/store/ui/toast';
-import { defaultShadow } from '@/shared/styles/shadows';
-
-// ─── Screen Mode ───
-type ScreenMode = 'default' | 'remove' | 'add';
 
 const BrandSettingScreen = () => {
-  // ─── Menu State ───
-  const [menuVisible, setMenuVisible] = useState(false);
-  const [menuMounted, setMenuMounted] = useState(false);
-  const menuOpacity = useSharedValue(0);
-  const menuScale = useSharedValue(0.95);
+  const brand = useBrandSetting();
+  const dropdown = useDropdownMenu();
+  const scroll = useHandleScroll();
 
-  // ─── Mode & Selection State ───
-  const [mode, setMode] = useState<ScreenMode>('default');
-  const [selectedBrandIds, setSelectedBrandIds] = useState<string[]>([]);
-  const [addSelectedBrandIds, setAddSelectedBrandIds] = useState<string[]>([]);
+  const { dropdownItems, rightElement } = useBrandSettingHeader({
+    mode: brand.mode,
+    removeSelectedCount: brand.removeSelectedIds.length,
+    resetRemoveSelection: brand.resetRemoveSelection,
+    enterAddMode: brand.enterAddMode,
+    enterRemoveMode: brand.enterRemoveMode,
+    hideDropdown: dropdown.hide,
+  });
 
-  // ─── Store & Mutation ───
-  const { brandList } = useBrandListStore();
-  const { optimisticFavorites, setOptimisticFavorite } = useFavoriteStore();
-  const { searchSelectedBrandIds, clearSearchSelectedBrandIds } =
-    useSearchSelectedBrandsStore();
-  const { showToast } = useToastStore();
-  const { mutate: toggleFavorite } = useToggleFavoriteBrand();
-  const navigation = useNavigation<MypageNavigationProp>();
-  const { showFloatingButton, handleScroll, scrollToTop, scrollViewRef } =
-    useHandleScroll();
-
-  // ─── 검색 화면에서 전달받은 선택 브랜드 반영 ───
-  useEffect(() => {
-    if (searchSelectedBrandIds.length > 0) {
-      setMode('add');
-      setAddSelectedBrandIds(prev => {
-        const merged = new Set([...prev, ...searchSelectedBrandIds]);
-        return Array.from(merged);
-      });
-      clearSearchSelectedBrandIds();
-    }
-  }, [searchSelectedBrandIds, clearSearchSelectedBrandIds]);
-
-  // ─── Derived Data ───
-  const favoriteBrands = useMemo(
-    () =>
-      brandList.filter(brand => optimisticFavorites[brand.brandId] === true),
-    [brandList, optimisticFavorites],
-  );
-
-  const favoriteBrandIds = useMemo(
-    () => new Set(favoriteBrands.map(b => b.brandId)),
-    [favoriteBrands],
-  );
-
-  const allBrandsForAdd = useMemo(
-    () => brandList.filter(brand => brand.brandId !== 'NONE'),
-    [brandList],
-  );
-
-  // ─── Menu Animation ───
-  const showMenu = useCallback(() => {
-    setMenuMounted(true);
-    setMenuVisible(true);
-    menuOpacity.value = withTiming(1, {
-      duration: 180,
-      easing: Easing.out(Easing.ease),
-    });
-    menuScale.value = withTiming(1, {
-      duration: 180,
-      easing: Easing.out(Easing.ease),
-    });
-  }, [menuOpacity, menuScale]);
-
-  const hideMenu = useCallback(
-    (onComplete?: () => void) => {
-      setMenuVisible(false);
-      menuOpacity.value = withTiming(
-        0,
-        { duration: 150, easing: Easing.in(Easing.ease) },
-        finished => {
-          if (finished) {
-            runOnJS(setMenuMounted)(false);
-            if (onComplete) {
-              runOnJS(onComplete)();
-            }
-          }
-        },
-      );
-      menuScale.value = withTiming(0.95, {
-        duration: 150,
-        easing: Easing.in(Easing.ease),
-      });
-    },
-    [menuOpacity, menuScale],
-  );
-
-  const handleToggleMenu = useCallback(() => {
-    if (menuVisible) {
-      hideMenu();
-    } else {
-      showMenu();
-    }
-  }, [menuVisible, showMenu, hideMenu]);
-
-  const menuAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: menuOpacity.value,
-    transform: [{ scale: menuScale.value }],
-  }));
-
-  // ─── Mode Transition ───
-  const handleEnterAddMode = useCallback(() => {
-    hideMenu(() => {
-      setMode('add');
-      setAddSelectedBrandIds([]);
-    });
-  }, [hideMenu]);
-
-  const handleEnterRemoveMode = useCallback(() => {
-    hideMenu(() => {
-      setMode('remove');
-      setSelectedBrandIds([]);
-    });
-  }, [hideMenu]);
-
-  const handleExitMode = useCallback(() => {
-    setMode('default');
-    setSelectedBrandIds([]);
-    setAddSelectedBrandIds([]);
-  }, []);
-
-  // ─── Remove Mode Handlers ───
-  const handleResetSelection = useCallback(() => {
-    setSelectedBrandIds([]);
-  }, []);
-
-  const handleToggleRemoveSelect = useCallback((brandId: string) => {
-    setSelectedBrandIds(prev =>
-      prev.includes(brandId)
-        ? prev.filter(id => id !== brandId)
-        : [...prev, brandId],
-    );
-  }, []);
-
-  const handleConfirmRemove = useCallback(() => {
-    if (selectedBrandIds.length === 0) {
-      showToast('찜 해제할 브랜드를 골라주세요');
-      return;
-    }
-
-    selectedBrandIds.forEach(brandId => {
-      setOptimisticFavorite(brandId, false);
-      toggleFavorite(
-        { brandId, action: 'REMOVE' },
-        {
-          onError: () => {
-            setOptimisticFavorite(brandId, true);
-            showToast('찜 해제 중 오류가 발생했어요');
-          },
-        },
-      );
-    });
-    showToast(`${selectedBrandIds.length}개의 브랜드를 찜 해제 했어요`);
-    setMode('default');
-    setSelectedBrandIds([]);
-  }, [selectedBrandIds, setOptimisticFavorite, toggleFavorite, showToast]);
-
-  // ─── Add Mode Handlers ───
-  const handleToggleAddSelect = useCallback(
-    (brandId: string) => {
-      if (favoriteBrandIds.has(brandId)) {
-        return;
-      }
-      setAddSelectedBrandIds(prev =>
-        prev.includes(brandId)
-          ? prev.filter(id => id !== brandId)
-          : [...prev, brandId],
-      );
-    },
-    [favoriteBrandIds],
-  );
-
-  const handleConfirmAdd = useCallback(() => {
-    if (addSelectedBrandIds.length === 0) {
-      showToast('찜 추가할 브랜드를 골라주세요');
-      return;
-    }
-
-    addSelectedBrandIds.forEach(brandId => {
-      setOptimisticFavorite(brandId, true);
-      toggleFavorite(
-        { brandId, action: 'ADD' },
-        {
-          onError: () => {
-            setOptimisticFavorite(brandId, false);
-            showToast('브랜드 추가 중 오류가 발생했어요');
-          },
-        },
-      );
-    });
-    showToast(`${addSelectedBrandIds.length}개의 브랜드를 찜 추가했어요`);
-    setMode('default');
-    setAddSelectedBrandIds([]);
-  }, [addSelectedBrandIds, setOptimisticFavorite, toggleFavorite, showToast]);
-
-  // ─── Header Config ───
-  const headerTitle = useMemo(() => {
-    switch (mode) {
-      case 'remove':
-        return '찜한 브랜드 삭제';
-      case 'add':
-        return '찜 브랜드 추가';
-      default:
-        return '찜한 브랜드';
-    }
-  }, [mode]);
-
-  const headerRightElement = useMemo(() => {
-    switch (mode) {
-      case 'remove':
-        return selectedBrandIds.length > 0 ? (
-          <Pressable
-            onPress={handleResetSelection}
-            className="flex-row items-center">
-            <Text className="text-pink-500 headline-02">초기화</Text>
-            <ReplayIcons width={24} height={24} shape="true" />
-          </Pressable>
-        ) : undefined;
-      case 'add':
-        return (
-          <Pressable
-            onPress={() =>
-              navigation.navigate('BrandSearchScreen', { variant: 'mypage' })
-            }>
-            <SearchIcons shape="black" width={24} height={24} />
-          </Pressable>
-        );
-      default:
-        return <Kebab />;
-    }
-  }, [mode, selectedBrandIds.length, handleResetSelection, navigation]);
-
-  // ─── Render: Default / Remove 브랜드 그리드 ───
-  const renderFavoriteBrandGrid = useCallback(() => {
-    return chunkArray(favoriteBrands, 3).map((row, rowIndex) => (
-      <View key={rowIndex} className="mb-6 flex-row justify-between py-1">
-        {row.map(item => {
-          const isSelected = selectedBrandIds.includes(item.brandId);
-
-          return (
-            <View key={item.brandId} className="flex-1 items-center">
-              <View style={defaultShadow} className="mb-[7px] rounded-full">
-                <Pressable
-                  onPress={
-                    mode === 'remove'
-                      ? () => handleToggleRemoveSelect(item.brandId)
-                      : undefined
-                  }>
-                  <ImageBackground
-                    source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
-                    className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
-                    {mode === 'remove' && isSelected && (
-                      <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
-                        <CheckIcons shape="white" width={24} height={24} />
-                      </View>
-                    )}
-                  </ImageBackground>
-                </Pressable>
-              </View>
-              <Text
-                className="text-center text-gray-900 body-rg-02"
-                numberOfLines={1}
-                ellipsizeMode="tail">
-                {item.name}
-              </Text>
-            </View>
-          );
-        })}
-
-        {row.length < 3 &&
-          Array.from({ length: 3 - row.length }).map((_, i) => (
-            <View key={`empty-${i}`} className="flex-1" />
-          ))}
-      </View>
-    ));
-  }, [favoriteBrands, mode, selectedBrandIds, handleToggleRemoveSelect]);
-
-  // ─── Render: Add 모드 전체 브랜드 그리드 ───
-  const renderAddBrandGrid = useCallback(() => {
-    return chunkArray(allBrandsForAdd, 3).map((row, rowIndex) => (
-      <View
-        key={rowIndex}
-        className="-top-4 mb-6 flex-row justify-between py-1">
-        {row.map(item => {
-          const isFavorite = favoriteBrandIds.has(item.brandId);
-          const isSelected = addSelectedBrandIds.includes(item.brandId);
-
-          return (
-            <View
-              key={item.brandId}
-              className="flex-1 items-center"
-              style={isFavorite ? { opacity: 0.35 } : undefined}>
-              <View style={defaultShadow} className="mb-[7px] rounded-full">
-                <Pressable
-                  onPress={() => handleToggleAddSelect(item.brandId)}
-                  disabled={isFavorite}>
-                  <ImageBackground
-                    source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
-                    className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
-                    {isSelected && (
-                      <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
-                        <CheckIcons shape="white" width={24} height={24} />
-                      </View>
-                    )}
-                  </ImageBackground>
-                </Pressable>
-              </View>
-              <Text className="text-center text-gray-900 body-rg-02">
-                {item.name}
-              </Text>
-            </View>
-          );
-        })}
-
-        {row.length < 3 &&
-          Array.from({ length: 3 - row.length }).map((_, i) => (
-            <View key={`empty-${i}`} className="flex-1" />
-          ))}
-      </View>
-    ));
-  }, [
-    allBrandsForAdd,
-    favoriteBrandIds,
-    addSelectedBrandIds,
-    handleToggleAddSelect,
-  ]);
-
-  // ─── Render: Guide Text ───
-  const renderGuideText = useCallback(() => {
-    if (mode === 'remove' && favoriteBrands.length > 0) {
-      return (
-        <View className="-mb-3 flex items-center justify-center px-1 py-2">
-          <Text className="text-gray-500 headline-01">
-            <Text className="text-primary-pink headline-01">찜 해제</Text>할
-            브랜드를 골라주세요.
-          </Text>
-        </View>
-      );
-    }
-    if (mode === 'add') {
-      return (
-        <View className="flex items-center justify-center px-1 py-2">
-          <Text className="text-gray-500 headline-01">
-            <Text className="text-primary-pink headline-01">추가로 찜할</Text>{' '}
-            브랜드를 골라주세요.
-          </Text>
-        </View>
-      );
-    }
-    return null;
-  }, [mode, favoriteBrands.length]);
+  const hasFavorites = brand.favoriteBrands.length > 0;
 
   return (
     <ScreenLayout>
       <MypageHeader
-        title={headerTitle}
-        rightElement={headerRightElement}
-        rightIconPress={mode === 'default' ? handleToggleMenu : undefined}
-        onBackPress={mode !== 'default' ? handleExitMode : undefined}
+        title={HEADER_TITLES[brand.mode]}
+        rightElement={rightElement}
+        rightIconPress={brand.mode === 'default' ? dropdown.toggle : undefined}
+        onBackPress={brand.mode !== 'default' ? brand.exitMode : undefined}
       />
 
-      {/* Guide Text */}
-      {renderGuideText()}
+      <BrandGuideText mode={brand.mode} hasFavorites={hasFavorites} />
 
-      {/* Kebab Dropdown Menu */}
-      <Modal
-        transparent
-        visible={menuMounted}
-        animationType="none"
-        onRequestClose={() => hideMenu()}>
-        <TouchableWithoutFeedback onPress={() => hideMenu()}>
-          <View className="flex-1">
-            <Animated.View
-              className="absolute right-4"
-              style={[
-                menuAnimatedStyle,
-                {
-                  top: 115,
-                  backgroundColor: 'rgba(255, 255, 255, 0.962)',
-                  borderRadius: 12,
-                  boxShadow: '0 0 32px 0 rgba(0, 0, 0, 0.20)',
-                  minWidth: 250,
-                },
-              ]}>
-              {/* 찜 브랜드 추가 */}
-              <Pressable
-                className="flex-row items-center justify-between px-4 py-2.5"
-                onPress={handleEnterAddMode}>
-                <Text className="text-primary-black body-rg-04">
-                  찜 브랜드 추가
-                </Text>
-                <PlusIcon />
-              </Pressable>
+      <DropdownMenu
+        isMounted={dropdown.isMounted}
+        animatedStyle={dropdown.animatedStyle}
+        items={dropdownItems}
+        onClose={() => dropdown.hide()}
+      />
 
-              <View
-                className="h-2"
-                style={{
-                  backgroundColor: 'rgba(60, 60, 67, 0.12)',
-                }}
-              />
+      <BrandSettingContent
+        mode={brand.mode}
+        favoriteBrands={brand.favoriteBrands}
+        allBrandsForAdd={brand.allBrandsForAdd}
+        removeSelectedIds={brand.removeSelectedIds}
+        addSelectedIds={brand.addSelectedIds}
+        favoriteBrandIds={brand.favoriteBrandIds}
+        toggleRemoveSelect={brand.toggleRemoveSelect}
+        toggleAddSelect={brand.toggleAddSelect}
+        scrollViewRef={scroll.scrollViewRef}
+        onScroll={scroll.handleScroll}
+      />
 
-              {/* 찜 해제 */}
-              <Pressable
-                className="flex-row items-center justify-between px-4 py-2.5"
-                onPress={handleEnterRemoveMode}>
-                <Text className="text-semantic-error body-rg-04">찜 해제</Text>
-                <PicselActionIcons shape="delete" width={20} height={20} />
-              </Pressable>
-            </Animated.View>
-          </View>
-        </TouchableWithoutFeedback>
-      </Modal>
-
-      {/* ─── Content by Mode ─── */}
-      {mode === 'add' ? (
-        <ScrollView
-          ref={scrollViewRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          className="flex-1 px-2 pt-4"
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 10 }}>
-          {renderAddBrandGrid()}
-        </ScrollView>
-      ) : favoriteBrands.length === 0 ? (
-        <View className="flex-1 items-center justify-center">
-          <SparkleImages shape="bg-opacity" height={418} width={340} />
-          <Text className="absolute text-gray-900 headline-04">
-            찜한 브랜드가 없어요
-          </Text>
-        </View>
-      ) : (
-        <ScrollView
-          ref={scrollViewRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          className="flex-1 px-2 pt-4"
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 10 }}>
-          {renderFavoriteBrandGrid()}
-        </ScrollView>
-      )}
-
-      {/* ─── Floating Button ─── */}
-      {showFloatingButton && (
+      {scroll.showFloatingButton && (
         <Pressable
-          onPressIn={scrollToTop}
+          onPressIn={scroll.scrollToTop}
           style={{
             position: 'absolute',
             bottom: 90,
@@ -503,35 +75,14 @@ const BrandSettingScreen = () => {
         </Pressable>
       )}
 
-      {/* ─── Bottom Action ─── */}
-      {mode === 'remove' && favoriteBrands.length > 0 && (
-        <View className="flex-row">
-          <Pressable
-            className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
-            onPress={handleConfirmRemove}>
-            <PicselActionIcons shape="delete" width={24} height={24} />
-            <Text className="text-semantic-error headline-02">
-              {selectedBrandIds.length > 0
-                ? `${selectedBrandIds.length}개의 브랜드 찜 해제하기`
-                : '찜 해제하기'}
-            </Text>
-          </Pressable>
-        </View>
-      )}
-
-      {mode === 'add' && (
-        <View className="flex-row">
-          <Pressable
-            className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
-            onPress={handleConfirmAdd}>
-            <Text className="text-primary-pink headline-02">
-              {addSelectedBrandIds.length > 0
-                ? `${addSelectedBrandIds.length}개의 브랜드 찜 추가하기`
-                : '추가하기'}
-            </Text>
-          </Pressable>
-        </View>
-      )}
+      <BrandBottomAction
+        mode={brand.mode}
+        removeCount={brand.removeSelectedIds.length}
+        addCount={brand.addSelectedIds.length}
+        hasFavorites={hasFavorites}
+        onConfirmRemove={brand.confirmRemove}
+        onConfirmAdd={brand.confirmAdd}
+      />
     </ScreenLayout>
   );
 };

--- a/src/screens/mypage/editNickname/index.tsx
+++ b/src/screens/mypage/editNickname/index.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { KeyboardAvoidingView, Platform, View, Text } from 'react-native';
 
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { HighlightedText } from '@/shared/components/HighlightedText';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import {
@@ -16,9 +16,11 @@ import {
   updateNicknameApi,
 } from '@/shared/nickname';
 import { useUserStore } from '@/shared/store';
+import { useToastStore } from '@/shared/store/ui/toast';
 
 const EditNicknameScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
+  const { showToast } = useToastStore();
   const {
     userNickname: currentNickname,
     setUserNickname,
@@ -45,13 +47,11 @@ const EditNicknameScreen = () => {
       setUserNickname(response.data.userNickname);
       setEmail(response.data.email);
 
-      navigation.navigate('Mypage', {
-        toastMessage: '닉네임 변경을 완료했어요',
-      });
+      showToast('닉네임 변경을 완료했어요');
+      navigation.getParent()?.goBack();
     } catch (error) {
-      navigation.navigate('Mypage', {
-        toastMessage: '닉네임 변경에 실패했어요',
-      });
+      showToast('닉네임 변경에 실패했어요');
+      navigation.getParent()?.goBack();
     }
   };
 

--- a/src/screens/mypage/index.tsx
+++ b/src/screens/mypage/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
 
 import MypageTopBar from '@/feature/mypage/main/components/ui/atoms/MypageTopBar';
@@ -9,36 +9,35 @@ import MypageMenuItem from '@/feature/mypage/main/components/ui/molecules/Mypage
 import { useMypageMenu } from '@/feature/mypage/main/hooks/useMypageMenu';
 import { useGetUser } from '@/feature/mypage/main/queries/useGetUser';
 import ListGroup from '@/feature/mypage/shared/components/ui/organisms/ListGroup';
-import { MainNavigationProps } from '@/navigation';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import StarIcons from '@/shared/icons/StarIcons';
-import { useToastStore } from '@/shared/store/ui/toast';
 
 const MypageScreen = () => {
   const { data: user } = useGetUser();
   const { menuItems } = useMypageMenu();
   const navigation = useNavigation<RootStackNavigationProp>();
-  const route = useRoute<RouteProp<MainNavigationProps, 'Mypage'>>();
-  const { showToast } = useToastStore();
-
-  useEffect(() => {
-    if (route.params?.toastMessage) {
-      showToast(route.params.toastMessage);
-      navigation.setParams({ toastMessage: undefined });
-    }
-  }, [route.params?.toastMessage]);
 
   return (
     <ScreenLayout>
       <MypageTopBar
-        onPressNotification={() => navigation.navigate('NotificationScreen')}
-        onPressSetting={() => navigation.navigate('MypageSetting')}
+        onPressNotification={() =>
+          navigation.navigate('MypageRoute', {
+            screen: 'NotificationScreen',
+          })
+        }
+        onPressSetting={() =>
+          navigation.navigate('MypageRoute', { screen: 'MypageSetting' })
+        }
       />
 
       <NicknameSection
         nickname={user?.userNickname ?? null}
-        onPressEdit={() => navigation.navigate('EditNicknameScreen')}
+        onPressEdit={() =>
+          navigation.navigate('MypageRoute', {
+            screen: 'EditNicknameScreen',
+          })
+        }
       />
 
       <View className="mb-4 mt-4 px-4" style={{ gap: 12 }}>
@@ -47,7 +46,11 @@ const MypageScreen = () => {
           description="내가 찜한 브랜드를 한눈에 보고 관리해요"
           backgroundColor="bg-pink-100"
           icon={<StarIcons shape="empty" width={24} height={24} />}
-          onPress={() => navigation.navigate('BrandSettingScreen')}
+          onPress={() =>
+            navigation.navigate('MypageRoute', {
+              screen: 'BrandSettingScreen',
+            })
+          }
         />
 
         <MypageMenuItem

--- a/src/screens/mypage/notification/index.tsx
+++ b/src/screens/mypage/notification/index.tsx
@@ -8,12 +8,12 @@ import {
   MOCK_NOTIFICATIONS,
 } from '@/feature/mypage/notification';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import MypageIcons from '@/shared/icons/MypageIcons';
 
 const NotificationScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
 
   // TODO: 실제 알림 데이터로 교체
   const notifications = MOCK_NOTIFICATIONS;

--- a/src/shared/components/ui/molecules/DropdownMenu.tsx
+++ b/src/shared/components/ui/molecules/DropdownMenu.tsx
@@ -1,0 +1,85 @@
+import React, { Fragment, ReactNode } from 'react';
+
+import {
+  Modal,
+  Pressable,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import Animated from 'react-native-reanimated';
+import { AnimatedStyle } from 'react-native-reanimated';
+
+export interface DropdownMenuItem {
+  label: string;
+  onPress: () => void;
+  icon?: ReactNode;
+  textClassName?: string;
+}
+
+interface Props {
+  isMounted: boolean;
+  animatedStyle: AnimatedStyle;
+  items: DropdownMenuItem[];
+  onClose: () => void;
+  top?: number;
+  minWidth?: number;
+}
+
+const DropdownMenu = ({
+  isMounted,
+  animatedStyle,
+  items,
+  onClose,
+  top = 115,
+  minWidth = 250,
+}: Props) => {
+  return (
+    <Modal
+      transparent
+      visible={isMounted}
+      animationType="none"
+      onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View className="flex-1">
+          <Animated.View
+            className="absolute right-4"
+            style={[
+              animatedStyle,
+              {
+                top,
+                backgroundColor: 'rgba(255, 255, 255, 0.962)',
+                borderRadius: 12,
+                boxShadow: '0 0 32px 0 rgba(0, 0, 0, 0.20)',
+                minWidth,
+              },
+            ]}>
+            {items.map((item, index) => (
+              <Fragment key={index}>
+                {index === items.length - 1 && items.length > 1 && (
+                  <View
+                    className="h-2"
+                    style={{ backgroundColor: 'rgba(59, 62, 70, 0.08)' }}
+                  />
+                )}
+                <Pressable
+                  className="flex-row items-center justify-between px-4 py-2.5"
+                  onPress={item.onPress}>
+                  <Text
+                    className={
+                      item.textClassName ?? 'text-primary-black body-rg-04'
+                    }>
+                    {item.label}
+                  </Text>
+                  {item.icon}
+                </Pressable>
+              </Fragment>
+            ))}
+          </Animated.View>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+export default DropdownMenu;

--- a/src/shared/hooks/useDropdownMenu.ts
+++ b/src/shared/hooks/useDropdownMenu.ts
@@ -1,0 +1,71 @@
+import { useState, useCallback } from 'react';
+
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+  Easing,
+} from 'react-native-reanimated';
+
+const SHOW_DURATION = 180;
+const HIDE_DURATION = 150;
+const INITIAL_SCALE = 0.95;
+
+export const useDropdownMenu = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(INITIAL_SCALE);
+
+  const show = useCallback(() => {
+    setIsMounted(true);
+    setIsVisible(true);
+    opacity.value = withTiming(1, {
+      duration: SHOW_DURATION,
+      easing: Easing.out(Easing.ease),
+    });
+    scale.value = withTiming(1, {
+      duration: SHOW_DURATION,
+      easing: Easing.out(Easing.ease),
+    });
+  }, [opacity, scale]);
+
+  const hide = useCallback(
+    (onComplete?: () => void) => {
+      setIsVisible(false);
+      opacity.value = withTiming(
+        0,
+        { duration: HIDE_DURATION, easing: Easing.in(Easing.ease) },
+        finished => {
+          if (finished) {
+            runOnJS(setIsMounted)(false);
+            if (onComplete) {
+              runOnJS(onComplete)();
+            }
+          }
+        },
+      );
+      scale.value = withTiming(INITIAL_SCALE, {
+        duration: HIDE_DURATION,
+        easing: Easing.in(Easing.ease),
+      });
+    },
+    [opacity, scale],
+  );
+
+  const toggle = useCallback(() => {
+    if (isVisible) {
+      hide();
+    } else {
+      show();
+    }
+  }, [isVisible, show, hide]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return { isMounted, animatedStyle, show, hide, toggle };
+};


### PR DESCRIPTION
## 이슈 번호

> close #107, close #114, #113 

## 작업 내용 및 테스트 방법
### 1. 마이페이지 router 리팩토링
<p><strong>신규 파일</strong></p>
<ul>
<li><code>src/navigation/route/mypage/index.tsx</code> — <code>MypageNavigationProps</code> 타입 + 중첩 네비게이터 (11개 하위 화면)</li>
</ul>
<p><strong>수정된 파일</strong></p>

파일 | 변경 내용
-- | --
src/navigation/index.tsx | 마이페이지 import 11개 제거, MypageRoute 1개로 대체. NavigatorScreenParams<MypageNavigationProps> 타입 적용
src/navigation/types/navigateTypeUtil.ts | MypageNavigationProp 타입 추가
src/screens/mypage/index.tsx | navigate('MypageRoute', { screen: '...' }) 중첩 네비게이션으로 변경. toastMessage route params 제거
src/screens/mypage/editNickname/index.tsx | MypageNavigationProp 사용 + showToast() + getParent()?.goBack()으로 변경
src/feature/mypage/main/hooks/useMypageMenu.tsx | navigate('MypageRoute', { screen: '...' }) 형태로 변경
src/feature/mypage/setting/hooks/useSettingMenu.tsx | MypageNavigationProp으로 변경
src/feature/mypage/account/hooks/useAccountMenu.tsx | MypageNavigationProp으로 변경
src/feature/mypage/withdrawal/hooks/useWithdrawal.ts | MypageNavigationProp으로 변경
src/screens/mypage/notification/index.tsx | MypageNavigationProp으로 변경
src/screens/mypage/brand/index.tsx | MypageNavigationProp으로 변경


<p><strong>핵심 설계:</strong></p>
<ul>
<li><code>MypageScreen</code>과 <code>useMypageMenu</code>는 MainRoute 레벨(<code>RootStackNavigationProp</code>)에서 <code>MypageRoute</code>로 진입</li>
<li>마이페이지 하위 화면들은 <code>MypageNavigationProp</code> 사용</li>
<li><code>EditNicknameScreen</code>의 toastMessage는 global <code>useToastStore</code> + <code>getParent()?.goBack()</code>으로 처리</li>
</ul></body></html>

### 2. 마이페이지-브랜드 리팩토링
```
feature/mypage/brand/
├── components/ui/
│   ├── atoms/
│   │   ├── BrandGuideText.tsx          — 모드별 가이드 텍스트
│   │   └── BrandBottomAction.tsx       — 하단 액션 버튼
│   ├── molecules/
│   │   ├── BrandEmptyState.tsx         — 빈 상태 UI
│   │   └── BrandSettingContent.tsx     — 모드별 콘텐츠 (ScrollView + Grid)
│   └── organisms/
│       └── BrandSettingGrid.tsx        — 브랜드 3열 그리드 (통합)
├── constants/
│   └── brandSettingTexts.ts            — 모든 텍스트 상수
└── hooks/
    ├── useBrandSetting.ts             — 비즈니스 로직 (모드/선택/즐겨찾기)
    └── useBrandSettingHeader.tsx       — 헤더 UI (dropdownItems, rightElement)

shared/
├── components/ui/molecules/
│   └── DropdownMenu.tsx               — 전역 재사용 드롭다운 (N개 항목)
└── hooks/
    └── useDropdownMenu.ts             — 드롭다운 애니메이션 훅
```

## To reviewers
Context Menu 팝업 컴포넌트는 `DropdownMenu.tsx` 코드 확인해시면 됩니다 👍🏻 
옵션 메뉴 확장이 가능하게 구현해두어서 
```js
  const dropdownItems: DropdownMenuItem[] = useMemo(
    () => [
      {
        label: DROPDOWN_ITEMS.ADD,
        onPress: () => hideDropdown(enterAddMode),
        icon: <PlusIcon />,
      },
      {
        label: DROPDOWN_ITEMS.REMOVE,
        onPress: () => hideDropdown(enterRemoveMode),
        textClassName: 'text-semantic-error body-rg-04',
        icon: <PicselActionIcons shape="delete" width={20} height={20} />,
      },
    ],
    [hideDropdown, enterAddMode, enterRemoveMode],
  );
```
위의 예시 코드와 같이 사용하시면 됩니다 💯 