### PR TITLE
✨ Feat: 픽셀 issue 구현

### DIFF
--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { ImageBackground, Pressable, Text, View } from 'react-native';
-import Config from 'react-native-config';
 
 import { Brand } from '../../types';
 
@@ -9,6 +8,7 @@ import { chunkArray } from '@/feature/brand/utils/arrayUtils';
 import { HighlightedText } from '@/shared/components/HighlightedText';
 import CheckIcons from '@/shared/icons/CheckIcons';
 import { defaultShadow } from '@/shared/styles/shadows';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   brandList: Brand[];
@@ -55,7 +55,7 @@ const BrandGridList = ({
                     onPress={() => onPress(item.brandId, item.name)}
                     disabled={isDisabled}>
                     <ImageBackground
-                      source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
+                      source={{ uri: getImageUrl(item.iconImageUrl) }}
                       className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
                       {isSelected && !isDisabled && (
                         <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">

--- a/src/feature/map/ui/atoms/BrandImage.tsx
+++ b/src/feature/map/ui/atoms/BrandImage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { Image } from 'react-native';
-import Config from 'react-native-config';
+
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   imageUrl: string;
@@ -11,7 +12,7 @@ const BrandImage = ({ imageUrl }: Props) => {
   return (
     <Image
       className="h-[60px] w-[60px] rounded-full"
-      source={{ uri: Config.IMAGE_URL + imageUrl }}
+      source={{ uri: getImageUrl(imageUrl) }}
       resizeMode="cover"
     />
   );

--- a/src/feature/map/ui/atoms/BrandImage.tsx
+++ b/src/feature/map/ui/atoms/BrandImage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Image } from 'react-native';
-
+import CachedImage from '@/shared/components/CachedImage';
 import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
@@ -10,9 +9,9 @@ interface Props {
 
 const BrandImage = ({ imageUrl }: Props) => {
   return (
-    <Image
-      className="h-[60px] w-[60px] rounded-full"
-      source={{ uri: getImageUrl(imageUrl) }}
+    <CachedImage
+      uri={getImageUrl(imageUrl)}
+      style={{ width: 60, height: 60, borderRadius: 30 }}
       resizeMode="cover"
     />
   );

--- a/src/feature/map/ui/organisms/MapOverlay.tsx
+++ b/src/feature/map/ui/organisms/MapOverlay.tsx
@@ -8,12 +8,12 @@ import React, {
 } from 'react';
 
 import { NaverMapMarkerOverlay } from '@mj-studio/react-native-naver-map';
-import Config from 'react-native-config';
 
 import { BrandData, StoreData, StoreDetail } from '../../types';
 import { getFavoriteImageUrl } from '../../utils/imageUtils';
 
 import { useFavoriteStore, useMapLocationStore } from '@/shared/store';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   store?: StoreData[];
@@ -100,7 +100,7 @@ const MapOverlay = memo(
           if (shouldShowBrandImage) {
             const finalImageUrl = getFavoriteImageUrl(brandIconUrl, isFavorite);
             return {
-              imageConfig: { httpUri: `${Config.IMAGE_URL}${finalImageUrl}` },
+              imageConfig: { httpUri: getImageUrl(finalImageUrl) },
               size: 48,
               zIndex: 2000,
             };
@@ -108,7 +108,7 @@ const MapOverlay = memo(
 
           return {
             imageConfig: {
-              httpUri: `${Config.IMAGE_URL}/common/search-marker.png`,
+              httpUri: getImageUrl('/common/search-marker.png'),
             },
             size: 22,
             zIndex: 2000,
@@ -118,7 +118,7 @@ const MapOverlay = memo(
         // 일반 스토어인 경우
         const finalImageUrl = getFavoriteImageUrl(brandIconUrl, isFavorite);
         return {
-          imageConfig: { httpUri: `${Config.IMAGE_URL}${finalImageUrl}` },
+          imageConfig: { httpUri: getImageUrl(finalImageUrl) },
           size: isSelected ? 48 : 28,
           zIndex: isSelected ? 1000 : 0,
         };

--- a/src/feature/mypage/account/components/ui/molecules/AppVersionSection.tsx
+++ b/src/feature/mypage/account/components/ui/molecules/AppVersionSection.tsx
@@ -13,7 +13,7 @@ const AppVersionSection = ({ version, isLatest = true }: Props) => {
       <Text className="pb-2 text-gray-900 headline-02">앱 버전</Text>
       <View className="flex flex-row items-center justify-between self-stretch rounded-xl bg-gray-50 py-4 pl-5 pr-4">
         <Text className="text-gray-600 headline-01">
-          {version} {isLatest && '(최신버전)'}
+          {version} {isLatest ? '(최신버전)' : '(업데이트 필요)'}
         </Text>
       </View>
     </View>

--- a/src/feature/mypage/account/hooks/useAccountMenu.tsx
+++ b/src/feature/mypage/account/hooks/useAccountMenu.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { useUserStore } from '@/shared/store';
 
 export const useAccountMenu = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const { logout } = useUserStore();
 
   const executeLogout = useCallback(() => {

--- a/src/feature/mypage/brand/components/ui/atoms/BrandBottomAction.tsx
+++ b/src/feature/mypage/brand/components/ui/atoms/BrandBottomAction.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { Pressable, Text, View } from 'react-native';
+
+import {
+  BrandSettingMode,
+  ACTION_TEXTS,
+} from '../../../constants/brandSettingTexts';
+
+import PicselActionIcons from '@/shared/icons/PicselActionIcons';
+
+interface Props {
+  mode: BrandSettingMode;
+  removeCount: number;
+  addCount: number;
+  hasFavorites: boolean;
+  onConfirmRemove: () => void;
+  onConfirmAdd: () => void;
+}
+
+const BrandBottomAction = ({
+  mode,
+  removeCount,
+  addCount,
+  hasFavorites,
+  onConfirmRemove,
+  onConfirmAdd,
+}: Props) => {
+  if (mode === 'remove' && hasFavorites) {
+    return (
+      <View className="flex-row">
+        <Pressable
+          className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
+          onPress={onConfirmRemove}>
+          <PicselActionIcons shape="delete" width={24} height={24} />
+          <Text className="text-semantic-error headline-02">
+            {ACTION_TEXTS.REMOVE(removeCount)}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (mode === 'add') {
+    return (
+      <View className="flex-row">
+        <Pressable
+          className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
+          onPress={onConfirmAdd}>
+          <Text className="text-primary-pink headline-02">
+            {ACTION_TEXTS.ADD(addCount)}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return null;
+};
+
+export default BrandBottomAction;

--- a/src/feature/mypage/brand/components/ui/atoms/BrandGuideText.tsx
+++ b/src/feature/mypage/brand/components/ui/atoms/BrandGuideText.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Text, View } from 'react-native';
+
+import {
+  BrandSettingMode,
+  GUIDE_TEXTS,
+} from '../../../constants/brandSettingTexts';
+
+interface Props {
+  mode: BrandSettingMode;
+  hasFavorites: boolean;
+}
+
+const BrandGuideText = ({ mode, hasFavorites }: Props) => {
+  if (mode === 'default') {
+    return null;
+  }
+  if (mode === 'remove' && !hasFavorites) {
+    return null;
+  }
+
+  const { highlight, rest } = GUIDE_TEXTS[mode];
+
+  return (
+    <View
+      className={`flex items-center justify-center px-1 py-2 ${mode === 'remove' ? '-mb-3' : ''}`}>
+      <Text className="text-gray-500 headline-01">
+        <Text className="text-primary-pink headline-01">{highlight}</Text>
+        {rest}
+      </Text>
+    </View>
+  );
+};
+
+export default BrandGuideText;

--- a/src/feature/mypage/brand/components/ui/molecules/BrandEmptyState.tsx
+++ b/src/feature/mypage/brand/components/ui/molecules/BrandEmptyState.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Text, View } from 'react-native';
+
+import { EMPTY_TEXT } from '../../../constants/brandSettingTexts';
+
+import SparkleImages from '@/shared/images/Sparkle';
+
+const BrandEmptyState = () => {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SparkleImages shape="bg-opacity" height={418} width={340} />
+      <Text className="absolute text-gray-900 headline-04">{EMPTY_TEXT}</Text>
+    </View>
+  );
+};
+
+export default BrandEmptyState;

--- a/src/feature/mypage/brand/components/ui/molecules/BrandSettingContent.tsx
+++ b/src/feature/mypage/brand/components/ui/molecules/BrandSettingContent.tsx
@@ -1,0 +1,76 @@
+import React, { RefObject } from 'react';
+
+import { ScrollView } from 'react-native';
+
+import BrandEmptyState from '../molecules/BrandEmptyState';
+import BrandSettingGrid from '../organisms/BrandSettingGrid';
+
+import { Brand } from '@/feature/brand/types';
+import { BrandSettingMode } from '@/feature/mypage/brand/constants/brandSettingTexts';
+
+interface Props {
+  mode: BrandSettingMode;
+  favoriteBrands: Brand[];
+  allBrandsForAdd: Brand[];
+  removeSelectedIds: string[];
+  addSelectedIds: string[];
+  favoriteBrandIds: Set<string>;
+  toggleRemoveSelect: (brandId: string) => void;
+  toggleAddSelect: (brandId: string) => void;
+  scrollViewRef: RefObject<ScrollView | null>;
+  onScroll: (event: any) => void;
+}
+
+const BrandSettingContent = ({
+  mode,
+  favoriteBrands,
+  allBrandsForAdd,
+  removeSelectedIds,
+  addSelectedIds,
+  favoriteBrandIds,
+  toggleRemoveSelect,
+  toggleAddSelect,
+  scrollViewRef,
+  onScroll,
+}: Props) => {
+  if (mode === 'add') {
+    return (
+      <ScrollView
+        ref={scrollViewRef}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        className="flex-1 px-2"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 10 }}>
+        <BrandSettingGrid
+          brands={allBrandsForAdd}
+          selectedIds={addSelectedIds}
+          onPress={toggleAddSelect}
+          disabledBrandIds={favoriteBrandIds}
+        />
+      </ScrollView>
+    );
+  }
+
+  if (favoriteBrands.length === 0) {
+    return <BrandEmptyState />;
+  }
+
+  return (
+    <ScrollView
+      ref={scrollViewRef}
+      onScroll={onScroll}
+      scrollEventThrottle={16}
+      className="flex-1 px-2 pt-4"
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={{ paddingBottom: 10 }}>
+      <BrandSettingGrid
+        brands={favoriteBrands}
+        selectedIds={mode === 'remove' ? removeSelectedIds : []}
+        onPress={mode === 'remove' ? toggleRemoveSelect : undefined}
+      />
+    </ScrollView>
+  );
+};
+
+export default BrandSettingContent;

--- a/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
+++ b/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { ImageBackground, Pressable, Text, View } from 'react-native';
-import Config from 'react-native-config';
 
 import { Brand } from '@/feature/brand/types';
 import { chunkArray } from '@/feature/brand/utils/arrayUtils';
 import CheckIcons from '@/shared/icons/CheckIcons';
 import { defaultShadow } from '@/shared/styles/shadows';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   brands: Brand[];
@@ -41,7 +41,7 @@ const BrandSettingGrid = ({
                     onPress={onPress ? () => onPress(item.brandId) : undefined}
                     disabled={isDisabled}>
                     <ImageBackground
-                      source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
+                      source={{ uri: getImageUrl(item.iconImageUrl) }}
                       className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
                       {isSelected && !isDisabled && (
                         <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">

--- a/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
+++ b/src/feature/mypage/brand/components/ui/organisms/BrandSettingGrid.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { ImageBackground, Pressable, Text, View } from 'react-native';
+import Config from 'react-native-config';
+
+import { Brand } from '@/feature/brand/types';
+import { chunkArray } from '@/feature/brand/utils/arrayUtils';
+import CheckIcons from '@/shared/icons/CheckIcons';
+import { defaultShadow } from '@/shared/styles/shadows';
+
+interface Props {
+  brands: Brand[];
+  selectedIds: string[];
+  onPress?: (brandId: string) => void;
+  disabledBrandIds?: Set<string>;
+}
+
+const COLUMNS = 3;
+
+const BrandSettingGrid = ({
+  brands,
+  selectedIds,
+  onPress,
+  disabledBrandIds,
+}: Props) => {
+  return (
+    <>
+      {chunkArray(brands, COLUMNS).map((row, rowIndex) => (
+        <View key={rowIndex} className="mb-6 flex-row justify-between py-1">
+          {row.map(item => {
+            const isSelected = selectedIds.includes(item.brandId);
+            const isDisabled = disabledBrandIds?.has(item.brandId) ?? false;
+
+            return (
+              <View
+                key={item.brandId}
+                className="flex-1 items-center"
+                style={isDisabled ? { opacity: 0.35 } : undefined}>
+                <View style={defaultShadow} className="mb-[7px] rounded-full">
+                  <Pressable
+                    onPress={onPress ? () => onPress(item.brandId) : undefined}
+                    disabled={isDisabled}>
+                    <ImageBackground
+                      source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
+                      className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
+                      {isSelected && !isDisabled && (
+                        <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
+                          <CheckIcons shape="white" width={24} height={24} />
+                        </View>
+                      )}
+                    </ImageBackground>
+                  </Pressable>
+                </View>
+                <Text
+                  className="text-center text-gray-900 body-rg-02"
+                  numberOfLines={1}
+                  ellipsizeMode="tail">
+                  {item.name}
+                </Text>
+              </View>
+            );
+          })}
+
+          {row.length < COLUMNS &&
+            Array.from({ length: COLUMNS - row.length }).map((_, i) => (
+              <View key={`empty-${i}`} className="flex-1" />
+            ))}
+        </View>
+      ))}
+    </>
+  );
+};
+
+export default BrandSettingGrid;

--- a/src/feature/mypage/brand/constants/brandSettingTexts.ts
+++ b/src/feature/mypage/brand/constants/brandSettingTexts.ts
@@ -1,0 +1,38 @@
+export type BrandSettingMode = 'default' | 'remove' | 'add';
+
+export const HEADER_TITLES: Record<BrandSettingMode, string> = {
+  default: '찜한 브랜드',
+  remove: '찜한 브랜드 삭제',
+  add: '찜 브랜드 추가',
+} as const;
+
+export const GUIDE_TEXTS: Record<
+  'remove' | 'add',
+  { highlight: string; rest: string }
+> = {
+  remove: { highlight: '찜 해제', rest: '할 브랜드를 골라주세요.' },
+  add: { highlight: '추가로 찜할', rest: ' 브랜드를 골라주세요.' },
+} as const;
+
+export const TOAST_MESSAGES = {
+  REMOVE_EMPTY: '찜 해제할 브랜드를 골라주세요',
+  REMOVE_ERROR: '찜 해제 중 오류가 발생했어요',
+  REMOVE_SUCCESS: (count: number) => `${count}개의 브랜드를 찜 해제 했어요`,
+  ADD_EMPTY: '찜 추가할 브랜드를 골라주세요',
+  ADD_ERROR: '브랜드 추가 중 오류가 발생했어요',
+  ADD_SUCCESS: (count: number) => `${count}개의 브랜드를 찜 추가했어요`,
+} as const;
+
+export const ACTION_TEXTS = {
+  REMOVE: (count: number) =>
+    count > 0 ? `${count}개의 브랜드 찜 해제하기` : '찜 해제하기',
+  ADD: (count: number) =>
+    count > 0 ? `${count}개의 브랜드 찜 추가하기` : '추가하기',
+} as const;
+
+export const DROPDOWN_ITEMS = {
+  ADD: '찜 브랜드 추가',
+  REMOVE: '찜 해제',
+} as const;
+
+export const EMPTY_TEXT = '찜한 브랜드가 없어요';

--- a/src/feature/mypage/brand/hooks/useBrandSetting.ts
+++ b/src/feature/mypage/brand/hooks/useBrandSetting.ts
@@ -1,0 +1,168 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+
+import {
+  BrandSettingMode,
+  TOAST_MESSAGES,
+} from '../constants/brandSettingTexts';
+
+import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
+import {
+  useBrandListStore,
+  useFavoriteStore,
+  useSearchSelectedBrandsStore,
+} from '@/shared/store';
+import { useToastStore } from '@/shared/store/ui/toast';
+
+const toggleId = (ids: string[], id: string) =>
+  ids.includes(id) ? ids.filter(v => v !== id) : [...ids, id];
+
+export const useBrandSetting = () => {
+  const [mode, setMode] = useState<BrandSettingMode>('default');
+  const [removeSelectedIds, setRemoveSelectedIds] = useState<string[]>([]);
+  const [addSelectedIds, setAddSelectedIds] = useState<string[]>([]);
+
+  const { brandList } = useBrandListStore();
+  const { optimisticFavorites, setOptimisticFavorite } = useFavoriteStore();
+  const { searchSelectedBrandIds, clearSearchSelectedBrandIds } =
+    useSearchSelectedBrandsStore();
+  const { showToast } = useToastStore();
+  const { mutate: toggleFavorite } = useToggleFavoriteBrand();
+
+  useEffect(() => {
+    if (searchSelectedBrandIds.length > 0) {
+      setMode('add');
+      setAddSelectedIds(prev => {
+        const merged = new Set([...prev, ...searchSelectedBrandIds]);
+        return Array.from(merged);
+      });
+      clearSearchSelectedBrandIds();
+    }
+  }, [searchSelectedBrandIds, clearSearchSelectedBrandIds]);
+
+  const favoriteBrands = useMemo(
+    () =>
+      brandList.filter(brand => optimisticFavorites[brand.brandId] === true),
+    [brandList, optimisticFavorites],
+  );
+
+  const favoriteBrandIds = useMemo(
+    () => new Set(favoriteBrands.map(b => b.brandId)),
+    [favoriteBrands],
+  );
+
+  const allBrandsForAdd = useMemo(
+    () => brandList.filter(brand => brand.brandId !== 'NONE'),
+    [brandList],
+  );
+
+  const removeSelectedList = useMemo(
+    () => removeSelectedIds.map(id => ({ brandId: id, name: '' })),
+    [removeSelectedIds],
+  );
+
+  const addSelectedList = useMemo(
+    () => addSelectedIds.map(id => ({ brandId: id, name: '' })),
+    [addSelectedIds],
+  );
+
+  const toggleRemoveSelect = useCallback((brandId: string) => {
+    setRemoveSelectedIds(prev => toggleId(prev, brandId));
+  }, []);
+
+  const toggleAddSelect = useCallback(
+    (brandId: string) => {
+      if (favoriteBrandIds.has(brandId)) {
+        return;
+      }
+      setAddSelectedIds(prev => toggleId(prev, brandId));
+    },
+    [favoriteBrandIds],
+  );
+
+  const enterAddMode = useCallback(() => {
+    setMode('add');
+    setAddSelectedIds([]);
+  }, []);
+
+  const enterRemoveMode = useCallback(() => {
+    setMode('remove');
+    setRemoveSelectedIds([]);
+  }, []);
+
+  const exitMode = useCallback(() => {
+    setMode('default');
+    setRemoveSelectedIds([]);
+    setAddSelectedIds([]);
+  }, []);
+
+  const resetRemoveSelection = useCallback(() => {
+    setRemoveSelectedIds([]);
+  }, []);
+
+  const confirmRemove = useCallback(() => {
+    if (removeSelectedIds.length === 0) {
+      showToast(TOAST_MESSAGES.REMOVE_EMPTY);
+      return;
+    }
+
+    removeSelectedIds.forEach(brandId => {
+      setOptimisticFavorite(brandId, false);
+      toggleFavorite(
+        { brandId, action: 'REMOVE' },
+        {
+          onError: () => {
+            setOptimisticFavorite(brandId, true);
+            showToast(TOAST_MESSAGES.REMOVE_ERROR);
+          },
+        },
+      );
+    });
+
+    showToast(TOAST_MESSAGES.REMOVE_SUCCESS(removeSelectedIds.length));
+    setMode('default');
+    setRemoveSelectedIds([]);
+  }, [removeSelectedIds, setOptimisticFavorite, toggleFavorite, showToast]);
+
+  const confirmAdd = useCallback(() => {
+    if (addSelectedIds.length === 0) {
+      showToast(TOAST_MESSAGES.ADD_EMPTY);
+      return;
+    }
+
+    addSelectedIds.forEach(brandId => {
+      setOptimisticFavorite(brandId, true);
+      toggleFavorite(
+        { brandId, action: 'ADD' },
+        {
+          onError: () => {
+            setOptimisticFavorite(brandId, false);
+            showToast(TOAST_MESSAGES.ADD_ERROR);
+          },
+        },
+      );
+    });
+
+    showToast(TOAST_MESSAGES.ADD_SUCCESS(addSelectedIds.length));
+    setMode('default');
+    setAddSelectedIds([]);
+  }, [addSelectedIds, setOptimisticFavorite, toggleFavorite, showToast]);
+
+  return {
+    mode,
+    favoriteBrands,
+    favoriteBrandIds,
+    allBrandsForAdd,
+    removeSelectedIds,
+    addSelectedIds,
+    removeSelectedList,
+    addSelectedList,
+    toggleRemoveSelect,
+    toggleAddSelect,
+    enterAddMode,
+    enterRemoveMode,
+    exitMode,
+    resetRemoveSelection,
+    confirmRemove,
+    confirmAdd,
+  };
+};

--- a/src/feature/mypage/brand/hooks/useBrandSettingHeader.tsx
+++ b/src/feature/mypage/brand/hooks/useBrandSettingHeader.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+import { Pressable, Text } from 'react-native';
+
+import { DROPDOWN_ITEMS } from '../constants/brandSettingTexts';
+import type { BrandSettingMode } from '../constants/brandSettingTexts';
+
+import Kebab from '@/assets/icons/kebab/icon-kebab.svg';
+import PlusIcon from '@/assets/icons/plus/icon-plus-S.svg';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
+import PicselActionIcons from '@/shared/icons/PicselActionIcons';
+import ReplayIcons from '@/shared/icons/ReplayIcon';
+import SearchIcons from '@/shared/icons/SearchIcons';
+
+interface Params {
+  mode: BrandSettingMode;
+  removeSelectedCount: number;
+  resetRemoveSelection: () => void;
+  enterAddMode: () => void;
+  enterRemoveMode: () => void;
+  hideDropdown: (onComplete?: () => void) => void;
+}
+
+export const useBrandSettingHeader = ({
+  mode,
+  removeSelectedCount,
+  resetRemoveSelection,
+  enterAddMode,
+  enterRemoveMode,
+  hideDropdown,
+}: Params) => {
+  const navigation = useNavigation<MypageNavigationProp>();
+
+  const dropdownItems: DropdownMenuItem[] = useMemo(
+    () => [
+      {
+        label: DROPDOWN_ITEMS.ADD,
+        onPress: () => hideDropdown(enterAddMode),
+        icon: <PlusIcon />,
+      },
+
+      {
+        label: DROPDOWN_ITEMS.REMOVE,
+        onPress: () => hideDropdown(enterRemoveMode),
+        textClassName: 'text-semantic-error body-rg-04',
+        icon: <PicselActionIcons shape="delete" width={20} height={20} />,
+      },
+    ],
+    [hideDropdown, enterAddMode, enterRemoveMode],
+  );
+
+  const rightElement = useMemo(() => {
+    switch (mode) {
+      case 'remove':
+        return removeSelectedCount > 0 ? (
+          <Pressable
+            onPress={resetRemoveSelection}
+            className="flex-row items-center">
+            <Text className="text-pink-500 headline-02">초기화</Text>
+            <ReplayIcons width={24} height={24} shape="true" />
+          </Pressable>
+        ) : undefined;
+      case 'add':
+        return (
+          <Pressable
+            onPress={() =>
+              navigation.navigate('BrandSearchScreen', { variant: 'mypage' })
+            }>
+            <SearchIcons shape="black" width={24} height={24} />
+          </Pressable>
+        );
+      default:
+        return <Kebab />;
+    }
+  }, [mode, removeSelectedCount, resetRemoveSelection, navigation]);
+
+  return { dropdownItems, rightElement };
+};

--- a/src/feature/mypage/main/hooks/useMypageMenu.tsx
+++ b/src/feature/mypage/main/hooks/useMypageMenu.tsx
@@ -24,15 +24,15 @@ export const useMypageMenu = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
 
   const handleNotice = () => {
-    navigation.navigate('NoticeScreen');
+    navigation.navigate('MypageRoute', { screen: 'NoticeScreen' });
   };
 
   const handleInquiry = () => {
-    navigation.navigate('InquiryScreen');
+    navigation.navigate('MypageRoute', { screen: 'InquiryScreen' });
   };
 
   const handleTeamIntro = () => {
-    navigation.navigate('TeamIntro');
+    navigation.navigate('MypageRoute', { screen: 'TeamIntro' });
   };
 
   const menuItems = MYPAGE_MENU_ITEMS.map(item => {

--- a/src/feature/mypage/notification/constants/notificationSettingTexts.ts
+++ b/src/feature/mypage/notification/constants/notificationSettingTexts.ts
@@ -53,5 +53,3 @@ export const EVENT_AGREE_CONFIRM_ALERT = {
     `이벤트·혜택 등 마케팅 정보 수신에\n동의하셨습니다\n설정에서 언제든 변경할 수 있어요\n(동의 일자: ${dateStr})`,
   confirmText: '확인',
 } as const;
-
-export const CONSENT_SUB_TEXT_PREFIX = '수신동의 일자:' as const;

--- a/src/feature/mypage/notification/hooks/useSettingItems.ts
+++ b/src/feature/mypage/notification/hooks/useSettingItems.ts
@@ -1,10 +1,6 @@
 import { useMemo } from 'react';
 
-import {
-  NOTIFICATION_SETTING_ITEMS,
-  CONSENT_SUB_TEXT_PREFIX,
-} from '../constants/notificationSettingTexts';
-import { formatISOToDate } from '../utils/formatDate';
+import { NOTIFICATION_SETTING_ITEMS } from '../constants/notificationSettingTexts';
 
 import { useNotificationSetting } from './useNotificationSetting';
 
@@ -28,10 +24,6 @@ export const useSettingItems = () => {
         ...NOTIFICATION_SETTING_ITEMS[1],
         value: isEventNewsEnabled,
         onValueChange: handleEventNewsToggle,
-        subText:
-          isEventNewsEnabled && marketingConsentedAt
-            ? `${CONSENT_SUB_TEXT_PREFIX} ${formatISOToDate(marketingConsentedAt)}`
-            : undefined,
       },
     ],
     [

--- a/src/feature/mypage/setting/hooks/useSettingMenu.tsx
+++ b/src/feature/mypage/setting/hooks/useSettingMenu.tsx
@@ -9,7 +9,7 @@ import {
   SETTING_MENU_ITEMS,
 } from '../constants/settingMenuItems';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import BellIcons from '@/shared/icons/BellIcons';
 import MypageIcons from '@/shared/icons/MypageIcons';
@@ -30,7 +30,7 @@ const getIconByType = (iconType?: string) => {
 };
 
 export const useSettingMenu = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
 
   const handleAccountManage = useCallback(() => {
     navigation.navigate('MypageAccount');

--- a/src/feature/mypage/withdrawal/hooks/useWithdrawal.ts
+++ b/src/feature/mypage/withdrawal/hooks/useWithdrawal.ts
@@ -6,11 +6,11 @@ import { Keyboard } from 'react-native';
 import { withdrawApi } from '../api/withdrawApi';
 import { ETC_REASON_ID } from '../constants/withdrawalText';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 
 export const useWithdrawal = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
   const [etcReason, setEtcReason] = useState('');
 

--- a/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
@@ -6,6 +6,7 @@ import {
   NativeSyntheticEvent,
   Pressable,
   ScrollView,
+  StyleSheet,
   Text,
   View,
 } from 'react-native';
@@ -16,6 +17,7 @@ import { MonthGroup, YearGroup } from '../../../types';
 import PhotoCard from '@/feature/picsel/shared/components/ui/molecules/PhotoCard';
 import FilterViewSkeleton from '@/feature/picsel/shared/components/ui/molecules/Skeleton/FilterViewSkeleton';
 import { useImageDimensions } from '@/feature/picsel/shared/hooks/photo/useImageDimensions';
+import { useImagePreload } from '@/shared/hooks/useImagePreload';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 
 interface FlattenedMonthItem {
@@ -52,9 +54,20 @@ const MonthFilterView = forwardRef<FlatList, Props>(
       return items;
     }, [yearGroups]);
 
-    if (isLoading) {
-      return <FilterViewSkeleton type="month" />;
-    }
+    // 모든 사진 URI 추출
+    const allPhotoUris = useMemo(
+      () =>
+        flattenedData.flatMap(item =>
+          item.monthGroup.photos.map(photo => photo.uri),
+        ),
+      [flattenedData],
+    );
+
+    const { isImagesLoaded, handleImageLoad, handleImageError } =
+      useImagePreload(allPhotoUris);
+
+    const showSkeleton =
+      isLoading || (!isImagesLoaded && flattenedData.length > 0);
 
     const renderMonthSection = ({ item }: { item: FlattenedMonthItem }) => (
       <View className="mb-6">
@@ -78,6 +91,8 @@ const MonthFilterView = forwardRef<FlatList, Props>(
                   imageWidth={imageWidth}
                   imageHeight={imageHeight}
                   showYear={false}
+                  onImageLoad={handleImageLoad}
+                  onImageError={handleImageError}
                 />
               </View>
             ))}
@@ -87,25 +102,41 @@ const MonthFilterView = forwardRef<FlatList, Props>(
     );
 
     return (
-      <FlatList
-        ref={ref}
-        data={flattenedData}
-        renderItem={renderMonthSection}
-        keyExtractor={(item, index) =>
-          `${item.year}-${item.monthGroup.month}-${index}`
-        }
-        showsVerticalScrollIndicator={false}
-        onScroll={onScroll}
-        scrollEventThrottle={16}
-        contentContainerStyle={{
-          paddingHorizontal: HORIZONTAL_PADDING,
-          paddingBottom: 40,
-          paddingTop: 12,
-        }}
-      />
+      <View style={styles.container}>
+        {flattenedData.length > 0 && (
+          <FlatList
+            style={{ opacity: showSkeleton ? 0 : 1 }}
+            ref={ref}
+            data={flattenedData}
+            renderItem={renderMonthSection}
+            keyExtractor={(item, index) =>
+              `${item.year}-${item.monthGroup.month}-${index}`
+            }
+            showsVerticalScrollIndicator={false}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            contentContainerStyle={{
+              paddingHorizontal: HORIZONTAL_PADDING,
+              paddingBottom: 40,
+              paddingTop: 12,
+            }}
+          />
+        )}
+        {showSkeleton && (
+          <View style={StyleSheet.absoluteFill}>
+            <FilterViewSkeleton type="month" />
+          </View>
+        )}
+      </View>
     );
   },
 );
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 MonthFilterView.displayName = 'MonthFilterView';
 

--- a/src/feature/picsel/myPicsel/components/ui/organisms/PhotoListView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/PhotoListView.tsx
@@ -1,9 +1,10 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 
 import {
   FlatList,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  StyleSheet,
   View,
 } from 'react-native';
 
@@ -12,6 +13,7 @@ import { HORIZONTAL_PADDING, ITEM_SPACING } from '../../../constants/photoGrid';
 import GridPhotoSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/GridPhotoSkeleton';
 import SelectablePhotoCard from '@/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard';
 import { useImageDimensions } from '@/feature/picsel/shared/hooks/photo/useImageDimensions';
+import { useImagePreload } from '@/shared/hooks/useImagePreload';
 
 export interface Photo {
   id: string;
@@ -50,18 +52,11 @@ const PhotoListView = forwardRef<FlatList, Props>(
       aspectRatio: 1.5,
     });
 
-    if (isLoading) {
-      return (
-        <GridPhotoSkeleton
-          imageWidth={imageWidth}
-          imageHeight={imageHeight}
-          columns={2}
-          itemSpacing={ITEM_SPACING}
-          count={6}
-          horizontalPadding={HORIZONTAL_PADDING}
-        />
-      );
-    }
+    const uris = useMemo(() => data.map(p => p.uri), [data]);
+    const { isImagesLoaded, handleImageLoad, handleImageError } =
+      useImagePreload(uris);
+
+    const showSkeleton = isLoading || (!isImagesLoaded && data.length > 0);
 
     const renderPhoto = ({
       item: photo,
@@ -88,29 +83,54 @@ const PhotoListView = forwardRef<FlatList, Props>(
             isSelected={isSelected}
             showYear={showYear}
             onToggleSelection={onToggleSelection}
+            onImageLoad={handleImageLoad}
+            onImageError={handleImageError}
           />
         </View>
       );
     };
 
     return (
-      <FlatList
-        showsVerticalScrollIndicator={false}
-        ref={ref}
-        data={data}
-        renderItem={renderPhoto}
-        keyExtractor={item => item.id}
-        numColumns={2}
-        onScroll={onScroll}
-        scrollEventThrottle={16}
-        contentContainerStyle={{
-          paddingHorizontal: HORIZONTAL_PADDING,
-          paddingBottom: 40,
-        }}
-      />
+      <View style={styles.container}>
+        {data.length > 0 && (
+          <FlatList
+            style={{ opacity: showSkeleton ? 0 : 1 }}
+            showsVerticalScrollIndicator={false}
+            ref={ref}
+            data={data}
+            renderItem={renderPhoto}
+            keyExtractor={item => item.id}
+            numColumns={2}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            contentContainerStyle={{
+              paddingHorizontal: HORIZONTAL_PADDING,
+              paddingBottom: 40,
+            }}
+          />
+        )}
+        {showSkeleton && (
+          <View style={StyleSheet.absoluteFill}>
+            <GridPhotoSkeleton
+              imageWidth={imageWidth}
+              imageHeight={imageHeight}
+              columns={2}
+              itemSpacing={ITEM_SPACING}
+              count={6}
+              horizontalPadding={HORIZONTAL_PADDING}
+            />
+          </View>
+        )}
+      </View>
     );
   },
 );
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 PhotoListView.displayName = 'PhotoListView';
 

--- a/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
@@ -6,6 +6,7 @@ import {
   NativeSyntheticEvent,
   Pressable,
   ScrollView,
+  StyleSheet,
   Text,
   View,
 } from 'react-native';
@@ -16,6 +17,7 @@ import { MonthGroup, YearGroup } from '../../../types';
 import PhotoCard from '@/feature/picsel/shared/components/ui/molecules/PhotoCard';
 import FilterViewSkeleton from '@/feature/picsel/shared/components/ui/molecules/Skeleton/FilterViewSkeleton';
 import { useImageDimensions } from '@/feature/picsel/shared/hooks/photo/useImageDimensions';
+import { useImagePreload } from '@/shared/hooks/useImagePreload';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 
 type FlattenedItem =
@@ -54,9 +56,22 @@ const YearFilterView = forwardRef<FlatList, Props>(
       return items;
     }, [yearGroups]);
 
-    if (isLoading) {
-      return <FilterViewSkeleton type="year" />;
-    }
+    // 모든 사진 URI 추출
+    const allPhotoUris = useMemo(
+      () =>
+        flattenedData.flatMap(item =>
+          item.type === 'month'
+            ? item.monthGroup.photos.map(photo => photo.uri)
+            : [],
+        ),
+      [flattenedData],
+    );
+
+    const { isImagesLoaded, handleImageLoad, handleImageError } =
+      useImagePreload(allPhotoUris);
+
+    const showSkeleton =
+      isLoading || (!isImagesLoaded && flattenedData.length > 0);
 
     const renderItem = ({ item }: { item: FlattenedItem }) => {
       if (item.type === 'yearHeader') {
@@ -96,6 +111,8 @@ const YearFilterView = forwardRef<FlatList, Props>(
                     imageWidth={imageWidth}
                     imageHeight={imageHeight}
                     showYear={false}
+                    onImageLoad={handleImageLoad}
+                    onImageError={handleImageError}
                   />
                 </View>
               ))}
@@ -106,27 +123,43 @@ const YearFilterView = forwardRef<FlatList, Props>(
     };
 
     return (
-      <FlatList
-        ref={ref}
-        data={flattenedData}
-        renderItem={renderItem}
-        keyExtractor={(item, index) =>
-          item.type === 'yearHeader'
-            ? `year-${item.year}-${index}`
-            : `month-${item.year}-${item.monthGroup.month}-${index}`
-        }
-        showsVerticalScrollIndicator={false}
-        onScroll={onScroll}
-        scrollEventThrottle={16}
-        contentContainerStyle={{
-          paddingHorizontal: HORIZONTAL_PADDING,
-          paddingBottom: 40,
-          paddingTop: 12,
-        }}
-      />
+      <View style={styles.container}>
+        {flattenedData.length > 0 && (
+          <FlatList
+            style={{ opacity: showSkeleton ? 0 : 1 }}
+            ref={ref}
+            data={flattenedData}
+            renderItem={renderItem}
+            keyExtractor={(item, index) =>
+              item.type === 'yearHeader'
+                ? `year-${item.year}-${index}`
+                : `month-${item.year}-${item.monthGroup.month}-${index}`
+            }
+            showsVerticalScrollIndicator={false}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            contentContainerStyle={{
+              paddingHorizontal: HORIZONTAL_PADDING,
+              paddingBottom: 40,
+              paddingTop: 12,
+            }}
+          />
+        )}
+        {showSkeleton && (
+          <View style={StyleSheet.absoluteFill}>
+            <FilterViewSkeleton type="year" />
+          </View>
+        )}
+      </View>
     );
   },
 );
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 YearFilterView.displayName = 'YearFilterView';
 

--- a/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
@@ -48,6 +48,8 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
     handleMove,
   } = useMonthFolder({ year, month });
 
+  console.log(photoData);
+
   return (
     <ScreenLayout>
       <FolderHeader title={`${year}년 ${month}`} onBack={onBack} />

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -62,8 +62,8 @@ const MyPicselTemplate = () => {
       <EmptyStateLayout
         floatingButton={
           <>
-            <UploadTooltip />
-            <View className="absolute bottom-1 right-1">
+            <View className="absolute bottom-8 right-0.5">
+              <UploadTooltip />
               {showFunctionButtons ? (
                 <FunctionButton
                   onAlbumPress={handleAlbumPress}

--- a/src/feature/picsel/myPicsel/hooks/useFolderView.ts
+++ b/src/feature/picsel/myPicsel/hooks/useFolderView.ts
@@ -11,6 +11,7 @@ import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoAct
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { useMyPicselStore } from '@/shared/store';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface UseFolderViewOptions {
   filterType: 'year' | 'month';
@@ -63,7 +64,7 @@ export const useFolderView = ({
 
     return filtered.map(item => ({
       id: item.picselId,
-      uri: item.imagePath,
+      uri: getImageUrl(item.imagePath),
       date: item.takenDate,
       storeName: item.storeName,
     }));

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -15,6 +15,7 @@ import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoS
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { useMyPicselStore } from '@/shared/store';
+import { getImageUrl } from '@/shared/utils/image';
 
 /**
  * MyPicsel 템플릿을 위한 통합 hook
@@ -48,7 +49,7 @@ export const useMyPicsel = () => {
     }
     return myPicselsData.content.map(item => ({
       id: item.picselId,
-      uri: item.imagePath,
+      uri: getImageUrl(item.imagePath),
       date: item.takenDate,
       storeName: item.storeName,
     }));

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -14,6 +14,7 @@ import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoAct
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { useImagePrefetch } from '@/shared/hooks/useImagePrefetch';
 import { useMyPicselStore } from '@/shared/store';
 import { getImageUrl } from '@/shared/utils/image';
 
@@ -54,6 +55,10 @@ export const useMyPicsel = () => {
       storeName: item.storeName,
     }));
   }, [myPicselsData]);
+
+  // 전체 탭에서 로드된 이미지를 메모리에 prefetch (월/년 탭 전환 시 즉시 렌더링)
+  const photoUris = useMemo(() => photoData.map(p => p.uri), [photoData]);
+  useImagePrefetch(photoUris);
 
   // 년/월별 그룹 데이터
   const yearGroups: YearGroup[] = useMemo(() => {

--- a/src/feature/picsel/myPicsel/utils/groupByDate.ts
+++ b/src/feature/picsel/myPicsel/utils/groupByDate.ts
@@ -2,9 +2,11 @@ import { GroupPhoto, MyPicselItem, YearGroup } from '../types';
 
 import { getMonthFromDate, getYearFromDate } from './dateUtils';
 
+import { getImageUrl } from '@/shared/utils/image';
+
 const toGroupPhoto = (item: MyPicselItem): GroupPhoto => ({
   id: item.picselId,
-  uri: item.imagePath,
+  uri: getImageUrl(item.imagePath),
   date: item.takenDate,
   storeName: item.storeName,
 });

--- a/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
+++ b/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
@@ -18,6 +18,8 @@ interface Props {
   onEdit?: (id: string, title: string) => void;
   onChangeCover?: (id: string) => void;
   onDelete?: (id: string, title: string) => void;
+  onImageLoad?: () => void;
+  onImageError?: () => void;
 }
 
 const PicselBookCard = ({
@@ -31,6 +33,8 @@ const PicselBookCard = ({
   onEdit,
   onChangeCover,
   onDelete,
+  onImageLoad,
+  onImageError,
 }: Props) => {
   const handlePress = () => {
     onPress?.(id, title);
@@ -51,6 +55,8 @@ const PicselBookCard = ({
           height={72}
           imageUri={coverImage}
           opacity={isSelecting && coverImage ? 0.3 : 1}
+          onImageLoad={onImageLoad}
+          onImageError={onImageError}
         />
 
         {/* 선택 모드 체크박스 */}

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
@@ -15,6 +15,7 @@ import { usePhotoFormat } from '@/feature/picsel/shared/utils/usePhotoFormat';
 import CheckRoundIcons from '@/shared/icons/CheckRound';
 import SparkleImages from '@/shared/images/Sparkle';
 import { cn } from '@/shared/lib/cn';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   picsel: PicselBookPicselItem;
@@ -56,7 +57,9 @@ const PhotoTextListItem = ({
       {/* 이미지 */}
       <View className="relative flex-shrink-0">
         <Image
-          source={{ uri: picsel.representativeImagePath }}
+          source={{
+            uri: getImageUrl(picsel.representativeImagePath),
+          }}
           style={{
             width: TEXT_LIST_CARD.IMAGE_WIDTH,
             height: TEXT_LIST_CARD.IMAGE_HEIGHT,

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Image, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 import {
   CONTENT_MAX_LINES,
@@ -12,6 +12,7 @@ import { CARD_SHADOW, TEXT_LIST_CARD } from '../../../constants/styles';
 
 import { PicselBookPicselItem } from '@/feature/picsel/picselBook/types';
 import { usePhotoFormat } from '@/feature/picsel/shared/utils/usePhotoFormat';
+import CachedImage from '@/shared/components/CachedImage';
 import CheckRoundIcons from '@/shared/icons/CheckRound';
 import SparkleImages from '@/shared/images/Sparkle';
 import { cn } from '@/shared/lib/cn';
@@ -23,6 +24,8 @@ interface Props {
   isSelected: boolean;
   onToggleSelection: (photoId: string) => void;
   onPress?: (photoId: string) => void;
+  onImageLoad?: (uri: string) => void;
+  onImageError?: (uri: string) => void;
 }
 
 const PhotoTextListItem = ({
@@ -31,6 +34,8 @@ const PhotoTextListItem = ({
   isSelected,
   onToggleSelection,
   onPress,
+  onImageLoad,
+  onImageError,
 }: Props) => {
   const { formatDate } = usePhotoFormat();
 
@@ -56,15 +61,15 @@ const PhotoTextListItem = ({
       }}>
       {/* 이미지 */}
       <View className="relative flex-shrink-0">
-        <Image
-          source={{
-            uri: getImageUrl(picsel.representativeImagePath),
-          }}
+        <CachedImage
+          uri={getImageUrl(picsel.representativeImagePath)}
           style={{
             width: TEXT_LIST_CARD.IMAGE_WIDTH,
             height: TEXT_LIST_CARD.IMAGE_HEIGHT,
           }}
           resizeMode="cover"
+          onLoad={() => onImageLoad?.(picsel.picselId)}
+          onError={() => onImageError?.(picsel.picselId)}
         />
       </View>
 

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
@@ -1,15 +1,19 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 
 import {
   FlatList,
   NativeScrollEvent,
   NativeSyntheticEvent,
+  StyleSheet,
+  View,
 } from 'react-native';
 
 import PhotoTextListItem from './PhotoTextListItem';
 
 import { PicselBookPicselItem } from '@/feature/picsel/picselBook/types';
 import PhotoTextListSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PhotoTextListItemSkeleton';
+import { useImagePreload } from '@/shared/hooks/useImagePreload';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   data: PicselBookPicselItem[];
@@ -34,9 +38,14 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
     },
     ref,
   ) => {
-    if (isLoading) {
-      return <PhotoTextListSkeleton count={4} />;
-    }
+    const uris = useMemo(
+      () => data.map(d => getImageUrl(d.representativeImagePath)),
+      [data],
+    );
+    const { isImagesLoaded, handleImageLoad, handleImageError } =
+      useImagePreload(uris);
+
+    const showSkeleton = isLoading || (!isImagesLoaded && data.length > 0);
 
     const renderItem = ({ item }: { item: PicselBookPicselItem }) => {
       const isSelected = selectedPhotos.includes(item.picselId);
@@ -48,29 +57,47 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
           isSelected={isSelected}
           onToggleSelection={onToggleSelection}
           onPress={onPhotoPress}
+          onImageLoad={handleImageLoad}
+          onImageError={handleImageError}
         />
       );
     };
 
     return (
-      <FlatList
-        ref={ref}
-        data={data}
-        renderItem={renderItem}
-        keyExtractor={item => item.picselId}
-        contentContainerStyle={{
-          alignItems: 'center',
-          paddingHorizontal: 16,
-          paddingTop: 8,
-          paddingBottom: 30,
-        }}
-        showsVerticalScrollIndicator={false}
-        onScroll={onScroll}
-        scrollEventThrottle={16}
-      />
+      <View style={styles.container}>
+        {data.length > 0 && (
+          <FlatList
+            style={{ opacity: showSkeleton ? 0 : 1 }}
+            ref={ref}
+            data={data}
+            renderItem={renderItem}
+            keyExtractor={item => item.picselId}
+            contentContainerStyle={{
+              alignItems: 'center',
+              paddingHorizontal: 16,
+              paddingTop: 8,
+              paddingBottom: 30,
+            }}
+            showsVerticalScrollIndicator={false}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+          />
+        )}
+        {showSkeleton && (
+          <View style={StyleSheet.absoluteFill}>
+            <PhotoTextListSkeleton count={4} />
+          </View>
+        )}
+      </View>
     );
   },
 );
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 PhotoTextListView.displayName = 'PhotoTextListView';
 

--- a/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { FlatList, View, useWindowDimensions } from 'react-native';
+import { FlatList, StyleSheet, View, useWindowDimensions } from 'react-native';
 
 import {
   CARD_WIDTH,
@@ -14,6 +14,7 @@ import PicselBookCard from '../molecules/PicselBookCard';
 import AddBookButton from './AddBookButton';
 
 import PicselBookSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PicselBookSkeleton';
+import { useImagePreload } from '@/shared/hooks/useImagePreload';
 import { cn } from '@/shared/lib/cn';
 import { getImageUrl } from '@/shared/utils/image';
 
@@ -59,77 +60,147 @@ const PicselBookList = ({
     return totalItems - 1; // AddButton 제외
   }, [screenHeight]);
 
-  const allItems = isLoading
-    ? [
-        { id: 'add-button', type: 'add' },
-        ...Array.from({ length: skeletonCount }, (_, i) => ({
-          id: `skeleton-${i}`,
-          type: 'skeleton',
-        })),
-      ]
-    : [
-        { id: 'add-button', type: 'add' },
-        ...books.map(book => ({
-          ...book,
-          id: book.picselbookId,
-          type: 'book',
-        })),
-      ];
+  // 커버 이미지가 있는 책들의 URI 추출
+  const coverImageUris = useMemo(
+    () =>
+      books
+        .filter(book => book.coverImagePath)
+        .map(book => getImageUrl(book.coverImagePath)),
+    [books],
+  );
+
+  const { isImagesLoaded, handleImageLoad, handleImageError } =
+    useImagePreload(coverImageUris);
+
+  const showSkeleton = isLoading || (!isImagesLoaded && books.length > 0);
+
+  const bookItems = useMemo(
+    () => [
+      { id: 'add-button', type: 'add' as const },
+      ...books.map(book => ({
+        ...book,
+        id: book.picselbookId,
+        type: 'book' as const,
+      })),
+    ],
+    [books],
+  );
+
+  const skeletonItems = useMemo(
+    () => [
+      { id: 'add-button', type: 'add' as const },
+      ...Array.from({ length: skeletonCount }, (_, i) => ({
+        id: `skeleton-${i}`,
+        type: 'skeleton' as const,
+      })),
+    ],
+    [skeletonCount],
+  );
+
+  const contentContainerStyle = useMemo(
+    () => ({
+      paddingHorizontal: horizontalPadding,
+      paddingTop: 8,
+    }),
+    [horizontalPadding],
+  );
+
+  const columnWrapperStyle = useMemo(() => ({ gap: GAP }), []);
 
   return (
-    <FlatList
-      data={allItems}
-      numColumns={NUM_COLUMNS}
-      keyExtractor={item => item.id}
-      showsVerticalScrollIndicator={false}
-      contentContainerStyle={{
-        paddingHorizontal: horizontalPadding,
-        paddingTop: 8,
-      }}
-      columnWrapperStyle={{ gap: GAP }}
-      renderItem={({ item }) => {
-        if (item.type === 'add') {
-          return (
-            <View
-              className={cn(
-                !isUploadStep && isSelecting && 'opacity-40',
-                'mb-7',
-              )}>
-              <AddBookButton onPress={onAddBook} />
-            </View>
-          );
-        }
+    <View style={styles.container}>
+      {/* 실제 리스트 - 스켈레톤 중에는 숨김 (이미지 다운로드는 진행) */}
+      {books.length > 0 && (
+        <FlatList
+          data={bookItems}
+          numColumns={NUM_COLUMNS}
+          keyExtractor={item => item.id}
+          showsVerticalScrollIndicator={false}
+          style={{ opacity: showSkeleton ? 0 : 1 }}
+          contentContainerStyle={contentContainerStyle}
+          columnWrapperStyle={columnWrapperStyle}
+          renderItem={({ item }) => {
+            if (item.type === 'add') {
+              return (
+                <View
+                  className={cn(
+                    !isUploadStep && isSelecting && 'opacity-40',
+                    'mb-7',
+                  )}>
+                  <AddBookButton onPress={onAddBook} />
+                </View>
+              );
+            }
 
-        if (item.type === 'skeleton') {
-          return (
-            <View className="mb-7">
-              <PicselBookSkeleton />
-            </View>
-          );
-        }
+            const book = item as PicselBookItem & { type: string };
+            const coverUri = getImageUrl(book.coverImagePath) || undefined;
 
-        const book = item as PicselBookItem & { type: string };
+            return (
+              <View className="mb-7">
+                <PicselBookCard
+                  id={book.picselbookId}
+                  title={book.bookName}
+                  coverImage={coverUri}
+                  isSelecting={isSelecting}
+                  isSelected={selectedBookIds.includes(book.picselbookId)}
+                  onPress={onBookPress}
+                  onEdit={onEdit}
+                  onChangeCover={onChangeCover}
+                  onDelete={onDelete}
+                  onImageLoad={
+                    coverUri ? () => handleImageLoad(coverUri) : undefined
+                  }
+                  onImageError={
+                    coverUri ? () => handleImageError(coverUri) : undefined
+                  }
+                />
+              </View>
+            );
+          }}
+        />
+      )}
 
-        console.log(book);
+      {/* 스켈레톤 오버레이 */}
+      {showSkeleton && (
+        <View style={StyleSheet.absoluteFill}>
+          <FlatList
+            data={skeletonItems}
+            numColumns={NUM_COLUMNS}
+            keyExtractor={item => item.id}
+            showsVerticalScrollIndicator={false}
+            scrollEnabled={false}
+            contentContainerStyle={contentContainerStyle}
+            columnWrapperStyle={columnWrapperStyle}
+            renderItem={({ item }) => {
+              if (item.type === 'add') {
+                return (
+                  <View
+                    className={cn(
+                      !isUploadStep && isSelecting && 'opacity-40',
+                      'mb-7',
+                    )}>
+                    <AddBookButton onPress={onAddBook} />
+                  </View>
+                );
+              }
 
-        return (
-          <View className="mb-7">
-            <PicselBookCard
-              id={book.picselbookId}
-              title={book.bookName}
-              coverImage={getImageUrl(book.coverImagePath) || undefined}
-              isSelecting={isSelecting}
-              isSelected={selectedBookIds.includes(book.picselbookId)}
-              onPress={onBookPress}
-              onEdit={onEdit}
-              onChangeCover={onChangeCover}
-              onDelete={onDelete}
-            />
-          </View>
-        );
-      }}
-    />
+              return (
+                <View className="mb-7">
+                  <PicselBookSkeleton />
+                </View>
+              );
+            }}
+          />
+        </View>
+      )}
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
 
 export default PicselBookList;

--- a/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PicselBookList.tsx
@@ -15,6 +15,7 @@ import AddBookButton from './AddBookButton';
 
 import PicselBookSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PicselBookSkeleton';
 import { cn } from '@/shared/lib/cn';
+import { getImageUrl } from '@/shared/utils/image';
 
 interface Props {
   books: PicselBookItem[];
@@ -109,12 +110,14 @@ const PicselBookList = ({
 
         const book = item as PicselBookItem & { type: string };
 
+        console.log(book);
+
         return (
           <View className="mb-7">
             <PicselBookCard
               id={book.picselbookId}
               title={book.bookName}
-              coverImage={book.coverImagePath}
+              coverImage={getImageUrl(book.coverImagePath) || undefined}
               isSelecting={isSelecting}
               isSelected={selectedBookIds.includes(book.picselbookId)}
               onPress={onBookPress}

--- a/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
@@ -56,8 +56,6 @@ export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
     }));
   }, [data]);
 
-  console.log(data);
-
   // 원본 데이터 (텍스트 리스트 뷰용)
   const rawData: PicselBookPicselItem[] = data?.content ?? [];
 

--- a/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
@@ -13,6 +13,7 @@ import {
 import { usePhotoActions } from '@/feature/picsel/shared/hooks/photo/usePhotoActions';
 import { usePhotoSelection } from '@/feature/picsel/shared/hooks/photo/usePhotoSelection';
 import { useFunctionButtons } from '@/feature/picsel/shared/hooks/useFunctionButtons';
+import { getImageUrl } from '@/shared/utils/image';
 
 type ViewMode = 'list' | 'textList';
 
@@ -49,7 +50,7 @@ export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
     }
     return data.content.map((item: PicselBookPicselItem) => ({
       id: item.picselId,
-      uri: item.representativeImagePath,
+      uri: getImageUrl(item.representativeImagePath),
       date: item.takenDate,
       storeName: item.storeName,
     }));

--- a/src/feature/picsel/shared/components/ui/molecules/PhotoCard.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/PhotoCard.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { Image, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 import { formatDate } from '../../../../myPicsel/utils/dateUtils';
 
+import CachedImage from '@/shared/components/CachedImage';
 import SparkleImages from '@/shared/images/Sparkle';
 
 interface PhotoCardProps {
@@ -19,6 +20,8 @@ interface PhotoCardProps {
   showDate?: boolean;
   showStoreName?: boolean;
   onPress?: () => void;
+  onImageLoad?: (uri: string) => void;
+  onImageError?: (uri: string) => void;
 }
 
 const PhotoCard = ({
@@ -29,6 +32,8 @@ const PhotoCard = ({
   showDate = true,
   showStoreName = true,
   onPress,
+  onImageLoad,
+  onImageError,
 }: PhotoCardProps) => {
   return (
     <View style={{ width: imageWidth }}>
@@ -44,10 +49,12 @@ const PhotoCard = ({
         <View
           className="overflow-hidden"
           style={{ width: imageWidth, height: imageHeight }}>
-          <Image
-            source={{ uri: photo.uri }}
+          <CachedImage
+            uri={photo.uri}
             style={{ width: imageWidth, height: imageHeight }}
             resizeMode="cover"
+            onLoad={() => onImageLoad?.(photo.uri)}
+            onError={() => onImageError?.(photo.uri)}
           />
         </View>
 

--- a/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Image, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 import { formatDate } from '../../../../myPicsel/utils/dateUtils';
 
 import SelectionCheckbox from '@/feature/picsel/myPicsel/components/ui/atoms/SelectionCheckbox';
+import CachedImage from '@/shared/components/CachedImage';
 import SparkleImages from '@/shared/images/Sparkle';
 
 interface Props {
@@ -20,6 +21,8 @@ interface Props {
   isSelected: boolean;
   showYear?: boolean;
   onToggleSelection: (photoId: string) => void;
+  onImageLoad?: (uri: string) => void;
+  onImageError?: (uri: string) => void;
 }
 
 const SelectablePhotoCard = ({
@@ -30,6 +33,8 @@ const SelectablePhotoCard = ({
   isSelected,
   showYear = true,
   onToggleSelection,
+  onImageLoad,
+  onImageError,
 }: Props) => {
   return (
     <View style={{ width: imageWidth }}>
@@ -48,10 +53,12 @@ const SelectablePhotoCard = ({
         <View
           className="overflow-hidden"
           style={{ width: imageWidth, height: imageHeight }}>
-          <Image
-            source={{ uri: photo.uri }}
+          <CachedImage
+            uri={photo.uri}
             style={{ width: imageWidth, height: imageHeight }}
             resizeMode="cover"
+            onLoad={() => onImageLoad?.(photo.uri)}
+            onError={() => onImageError?.(photo.uri)}
           />
         </View>
 

--- a/src/feature/picsel/shared/components/ui/molecules/UploadTooltip.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/UploadTooltip.tsx
@@ -20,7 +20,7 @@ const UploadTooltip = ({ bottom = 70 }: UploadTooltipProps) => {
 
   return (
     <Animated.View
-      className="absolute right-1 items-center rounded-3xl bg-primary-pink px-3 py-2"
+      className="absolute right-0.5 items-center rounded-3xl bg-primary-pink px-3 py-2"
       style={{
         bottom,
         width: scale(155),

--- a/src/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet.tsx
+++ b/src/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet.tsx
@@ -66,21 +66,20 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
       setSelectedCover('default');
     };
 
-    const handleBackdropPress = () => {
-      // 키보드 먼저 닫기
-      Keyboard.dismiss();
+    const dismiss = () => {
+      if (ref && 'current' in ref) {
+        ref.current?.dismiss();
+      }
+    };
 
-      // 약간의 딜레이 후 바텀시트 닫기
-      setTimeout(() => {
-        // @ts-ignore
-        ref?.current?.dismiss();
-      }, 100);
+    const handleBackdropPress = () => {
+      Keyboard.dismiss();
+      setTimeout(dismiss, 100);
     };
 
     const handleComplete = () => {
       onSubmit(bookName.trim(), selectedCover);
-      // @ts-ignore
-      ref?.current?.dismiss();
+      dismiss();
     };
 
     const handleSelectedCover = () => {
@@ -89,8 +88,7 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
         variant: 'cover',
         bookName: bookName,
       });
-      // @ts-ignore
-      ref?.current?.dismiss();
+      dismiss();
     };
 
     const renderBackdrop = (props: any) => (

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,23 +1,12 @@
 import React from 'react';
 
+import { NavigatorScreenParams } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import MypageRoute, { MypageNavigationProps } from './route/mypage';
 import SignupRoute from './route/signup';
 import BottomTabBar from './tabs';
 
-import BrandSearchScreen from '@/screens/brandSearch';
-import MypageScreen from '@/screens/mypage';
-import MypageAccountScreen from '@/screens/mypage/account';
-import BrandSettingScreen from '@/screens/mypage/brand';
-import EditNicknameScreen from '@/screens/mypage/editNickname';
-import InquiryScreen from '@/screens/mypage/inquiry';
-import NoticeScreen from '@/screens/mypage/notice';
-import NotificationScreen from '@/screens/mypage/notification';
-import NotificationSettingScreen from '@/screens/mypage/notification/setting';
-import MypageSettingScreen from '@/screens/mypage/setting';
-import TeamIntroScreen from '@/screens/mypage/teamIntro';
-import WithdrawalScreen from '@/screens/mypage/withdrawal';
-import WithdrawalSuccessScreen from '@/screens/mypage/withdrawal/success';
 import PicselTabScreen from '@/screens/picsel';
 import MonthFolderScreen from '@/screens/picsel/myPicsel/monthFolder';
 import YearFolderScreen from '@/screens/picsel/myPicsel/yearFolder';
@@ -57,19 +46,7 @@ export type MainNavigationProps = {
   SelectBookCover: { variant: 'cover'; bookName: string };
 
   // Mypage
-  Mypage: { toastMessage?: string } | undefined;
-  MypageSetting: undefined;
-  MypageAccount: undefined;
-  MypageWithdrawal: undefined;
-  MypageWithdrawalSuccess: undefined;
-  EditNicknameScreen: undefined;
-  NotificationScreen: undefined;
-  NotificationSettingScreen: undefined;
-  BrandSettingScreen: undefined;
-  BrandSearchScreen: { variant: 'signup' | 'mypage' };
-  NoticeScreen: undefined;
-  InquiryScreen: undefined;
-  TeamIntro: undefined;
+  MypageRoute: NavigatorScreenParams<MypageNavigationProps>;
 };
 
 const MainRoute = () => {
@@ -127,29 +104,7 @@ const MainRoute = () => {
       />
 
       {/* Mypage */}
-      <Stack.Screen name="Mypage" component={MypageScreen} />
-      <Stack.Screen name="MypageSetting" component={MypageSettingScreen} />
-      <Stack.Screen name="MypageAccount" component={MypageAccountScreen} />
-      <Stack.Screen name="MypageWithdrawal" component={WithdrawalScreen} />
-      <Stack.Screen
-        name="MypageWithdrawalSuccess"
-        component={WithdrawalSuccessScreen}
-      />
-      <Stack.Screen name="EditNicknameScreen" component={EditNicknameScreen} />
-      <Stack.Screen name="NotificationScreen" component={NotificationScreen} />
-      <Stack.Screen
-        name="NotificationSettingScreen"
-        component={NotificationSettingScreen}
-      />
-      <Stack.Screen name="BrandSettingScreen" component={BrandSettingScreen} />
-      <Stack.Screen
-        name="BrandSearchScreen"
-        component={BrandSearchScreen}
-        initialParams={{ variant: 'mypage' }}
-      />
-      <Stack.Screen name="NoticeScreen" component={NoticeScreen} />
-      <Stack.Screen name="InquiryScreen" component={InquiryScreen} />
-      <Stack.Screen name="TeamIntro" component={TeamIntroScreen} />
+      <Stack.Screen name="MypageRoute" component={MypageRoute} />
     </Stack.Navigator>
   );
 };

--- a/src/navigation/route/mypage/index.tsx
+++ b/src/navigation/route/mypage/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import BrandSearchScreen from '@/screens/brandSearch';
+import MypageAccountScreen from '@/screens/mypage/account';
+import BrandSettingScreen from '@/screens/mypage/brand';
+import EditNicknameScreen from '@/screens/mypage/editNickname';
+import InquiryScreen from '@/screens/mypage/inquiry';
+import NoticeScreen from '@/screens/mypage/notice';
+import NotificationScreen from '@/screens/mypage/notification';
+import NotificationSettingScreen from '@/screens/mypage/notification/setting';
+import MypageSettingScreen from '@/screens/mypage/setting';
+import TeamIntroScreen from '@/screens/mypage/teamIntro';
+import WithdrawalScreen from '@/screens/mypage/withdrawal';
+import WithdrawalSuccessScreen from '@/screens/mypage/withdrawal/success';
+
+export type MypageNavigationProps = {
+  MypageSetting: undefined;
+  MypageAccount: undefined;
+  MypageWithdrawal: undefined;
+  MypageWithdrawalSuccess: undefined;
+  EditNicknameScreen: undefined;
+  NotificationScreen: undefined;
+  NotificationSettingScreen: undefined;
+  BrandSettingScreen: undefined;
+  BrandSearchScreen: { variant: 'signup' | 'mypage' };
+  NoticeScreen: undefined;
+  InquiryScreen: undefined;
+  TeamIntro: undefined;
+};
+
+const MypageRoute = () => {
+  const Stack = createNativeStackNavigator<MypageNavigationProps>();
+
+  return (
+    <Stack.Navigator
+      id={undefined}
+      initialRouteName="MypageSetting"
+      screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="MypageSetting" component={MypageSettingScreen} />
+      <Stack.Screen name="MypageAccount" component={MypageAccountScreen} />
+      <Stack.Screen name="MypageWithdrawal" component={WithdrawalScreen} />
+      <Stack.Screen
+        name="MypageWithdrawalSuccess"
+        component={WithdrawalSuccessScreen}
+      />
+      <Stack.Screen name="EditNicknameScreen" component={EditNicknameScreen} />
+      <Stack.Screen name="NotificationScreen" component={NotificationScreen} />
+      <Stack.Screen
+        name="NotificationSettingScreen"
+        component={NotificationSettingScreen}
+      />
+      <Stack.Screen name="BrandSettingScreen" component={BrandSettingScreen} />
+      <Stack.Screen
+        name="BrandSearchScreen"
+        component={BrandSearchScreen}
+        initialParams={{ variant: 'mypage' }}
+      />
+      <Stack.Screen name="NoticeScreen" component={NoticeScreen} />
+      <Stack.Screen name="InquiryScreen" component={InquiryScreen} />
+      <Stack.Screen name="TeamIntro" component={TeamIntroScreen} />
+    </Stack.Navigator>
+  );
+};
+
+export default MypageRoute;

--- a/src/navigation/types/navigateTypeUtil.ts
+++ b/src/navigation/types/navigateTypeUtil.ts
@@ -1,9 +1,12 @@
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 import { MainNavigationProps } from '@/navigation';
+import { MypageNavigationProps } from '@/navigation/route/mypage';
 import { SignupNavigationProps } from '@/navigation/route/signup';
 
 export type RootStackNavigationProp =
   NativeStackNavigationProp<MainNavigationProps>;
+export type MypageNavigationProp =
+  NativeStackNavigationProp<MypageNavigationProps>;
 export type SignupNavigationProp =
   NativeStackNavigationProp<SignupNavigationProps>;

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -15,10 +15,12 @@ import EmptyBottomSheet from '@/feature/map/ui/organisms/EmptyBottomSheet';
 import MapActionButton from '@/feature/map/ui/organisms/MapActionButton';
 import MapOverlay from '@/feature/map/ui/organisms/MapOverlay';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
+import { useRequestNotificationPermission } from '@/shared/hooks/useRequestNotificationPermission';
 import { useMapLocationStore } from '@/shared/store';
 import Input from '@/shared/ui/atoms/Input';
 
 const HomeScreen = () => {
+  useRequestNotificationPermission();
   const { showBrandTooltip, fadeAnim } = useBrandTooltipOnce();
 
   const {

--- a/src/screens/mypage/account/index.tsx
+++ b/src/screens/mypage/account/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { View } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 
 import AppVersionSection from '@/feature/mypage/account/components/ui/molecules/AppVersionSection';
 import LoginInfoSection from '@/feature/mypage/account/components/ui/molecules/LoginInfoSection';
@@ -10,11 +11,12 @@ import { useGetUser } from '@/feature/mypage/main/queries/useGetUser';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
 import ListGroup from '@/feature/mypage/shared/components/ui/organisms/ListGroup';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
-const APP_VER = '1.4.9';
+import { useAppConfigStore } from '@/shared/store';
 
 const MypageAccountScreen = () => {
   const { data: user } = useGetUser();
   const { accountMenuItems, handleEditNickname } = useAccountMenu();
+  const isLatest = useAppConfigStore(state => state.isLatest);
 
   return (
     <ScreenLayout>
@@ -28,7 +30,10 @@ const MypageAccountScreen = () => {
         socialType={user?.socialType ?? null}
         email={user?.email ?? null}
       />
-      <AppVersionSection version={APP_VER} isLatest />
+      <AppVersionSection
+        version={DeviceInfo.getVersion()}
+        isLatest={isLatest}
+      />
 
       <View className="mb-3 mt-8 h-[6px] w-full bg-gray-50" />
 

--- a/src/screens/mypage/brand/index.tsx
+++ b/src/screens/mypage/brand/index.tsx
@@ -25,7 +25,7 @@ import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
 import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
 import { chunkArray } from '@/feature/brand/utils/arrayUtils';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import CheckIcons from '@/shared/icons/CheckIcons';
 import FloatingButton from '@/shared/icons/FloatingButton';
@@ -63,7 +63,7 @@ const BrandSettingScreen = () => {
     useSearchSelectedBrandsStore();
   const { showToast } = useToastStore();
   const { mutate: toggleFavorite } = useToggleFavoriteBrand();
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
   const { showFloatingButton, handleScroll, scrollToTop, scrollViewRef } =
     useHandleScroll();
 

--- a/src/screens/mypage/brand/index.tsx
+++ b/src/screens/mypage/brand/index.tsx
@@ -1,498 +1,70 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React from 'react';
 
-import { useNavigation } from '@react-navigation/native';
-import {
-  ImageBackground,
-  Modal,
-  Pressable,
-  ScrollView,
-  Text,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
-import Config from 'react-native-config';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-  runOnJS,
-  Easing,
-} from 'react-native-reanimated';
+import { Pressable } from 'react-native';
 
-import Kebab from '@/assets/icons/kebab/icon-kebab.svg';
-import PlusIcon from '@/assets/icons/plus/icon-plus-S.svg';
 import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
-import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
-import { chunkArray } from '@/feature/brand/utils/arrayUtils';
+import BrandBottomAction from '@/feature/mypage/brand/components/ui/atoms/BrandBottomAction';
+import BrandGuideText from '@/feature/mypage/brand/components/ui/atoms/BrandGuideText';
+import BrandSettingContent from '@/feature/mypage/brand/components/ui/molecules/BrandSettingContent';
+import { HEADER_TITLES } from '@/feature/mypage/brand/constants/brandSettingTexts';
+import { useBrandSetting } from '@/feature/mypage/brand/hooks/useBrandSetting';
+import { useBrandSettingHeader } from '@/feature/mypage/brand/hooks/useBrandSettingHeader';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
-import CheckIcons from '@/shared/icons/CheckIcons';
+import DropdownMenu from '@/shared/components/ui/molecules/DropdownMenu';
+import { useDropdownMenu } from '@/shared/hooks/useDropdownMenu';
 import FloatingButton from '@/shared/icons/FloatingButton';
-import PicselActionIcons from '@/shared/icons/PicselActionIcons';
-import ReplayIcons from '@/shared/icons/ReplayIcon';
-import SearchIcons from '@/shared/icons/SearchIcons';
-import SparkleImages from '@/shared/images/Sparkle';
-import {
-  useBrandListStore,
-  useFavoriteStore,
-  useSearchSelectedBrandsStore,
-} from '@/shared/store';
-import { useToastStore } from '@/shared/store/ui/toast';
-import { defaultShadow } from '@/shared/styles/shadows';
-
-// ─── Screen Mode ───
-type ScreenMode = 'default' | 'remove' | 'add';
 
 const BrandSettingScreen = () => {
-  // ─── Menu State ───
-  const [menuVisible, setMenuVisible] = useState(false);
-  const [menuMounted, setMenuMounted] = useState(false);
-  const menuOpacity = useSharedValue(0);
-  const menuScale = useSharedValue(0.95);
+  const brand = useBrandSetting();
+  const dropdown = useDropdownMenu();
+  const scroll = useHandleScroll();
 
-  // ─── Mode & Selection State ───
-  const [mode, setMode] = useState<ScreenMode>('default');
-  const [selectedBrandIds, setSelectedBrandIds] = useState<string[]>([]);
-  const [addSelectedBrandIds, setAddSelectedBrandIds] = useState<string[]>([]);
+  const { dropdownItems, rightElement } = useBrandSettingHeader({
+    mode: brand.mode,
+    removeSelectedCount: brand.removeSelectedIds.length,
+    resetRemoveSelection: brand.resetRemoveSelection,
+    enterAddMode: brand.enterAddMode,
+    enterRemoveMode: brand.enterRemoveMode,
+    hideDropdown: dropdown.hide,
+  });
 
-  // ─── Store & Mutation ───
-  const { brandList } = useBrandListStore();
-  const { optimisticFavorites, setOptimisticFavorite } = useFavoriteStore();
-  const { searchSelectedBrandIds, clearSearchSelectedBrandIds } =
-    useSearchSelectedBrandsStore();
-  const { showToast } = useToastStore();
-  const { mutate: toggleFavorite } = useToggleFavoriteBrand();
-  const navigation = useNavigation<MypageNavigationProp>();
-  const { showFloatingButton, handleScroll, scrollToTop, scrollViewRef } =
-    useHandleScroll();
-
-  // ─── 검색 화면에서 전달받은 선택 브랜드 반영 ───
-  useEffect(() => {
-    if (searchSelectedBrandIds.length > 0) {
-      setMode('add');
-      setAddSelectedBrandIds(prev => {
-        const merged = new Set([...prev, ...searchSelectedBrandIds]);
-        return Array.from(merged);
-      });
-      clearSearchSelectedBrandIds();
-    }
-  }, [searchSelectedBrandIds, clearSearchSelectedBrandIds]);
-
-  // ─── Derived Data ───
-  const favoriteBrands = useMemo(
-    () =>
-      brandList.filter(brand => optimisticFavorites[brand.brandId] === true),
-    [brandList, optimisticFavorites],
-  );
-
-  const favoriteBrandIds = useMemo(
-    () => new Set(favoriteBrands.map(b => b.brandId)),
-    [favoriteBrands],
-  );
-
-  const allBrandsForAdd = useMemo(
-    () => brandList.filter(brand => brand.brandId !== 'NONE'),
-    [brandList],
-  );
-
-  // ─── Menu Animation ───
-  const showMenu = useCallback(() => {
-    setMenuMounted(true);
-    setMenuVisible(true);
-    menuOpacity.value = withTiming(1, {
-      duration: 180,
-      easing: Easing.out(Easing.ease),
-    });
-    menuScale.value = withTiming(1, {
-      duration: 180,
-      easing: Easing.out(Easing.ease),
-    });
-  }, [menuOpacity, menuScale]);
-
-  const hideMenu = useCallback(
-    (onComplete?: () => void) => {
-      setMenuVisible(false);
-      menuOpacity.value = withTiming(
-        0,
-        { duration: 150, easing: Easing.in(Easing.ease) },
-        finished => {
-          if (finished) {
-            runOnJS(setMenuMounted)(false);
-            if (onComplete) {
-              runOnJS(onComplete)();
-            }
-          }
-        },
-      );
-      menuScale.value = withTiming(0.95, {
-        duration: 150,
-        easing: Easing.in(Easing.ease),
-      });
-    },
-    [menuOpacity, menuScale],
-  );
-
-  const handleToggleMenu = useCallback(() => {
-    if (menuVisible) {
-      hideMenu();
-    } else {
-      showMenu();
-    }
-  }, [menuVisible, showMenu, hideMenu]);
-
-  const menuAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: menuOpacity.value,
-    transform: [{ scale: menuScale.value }],
-  }));
-
-  // ─── Mode Transition ───
-  const handleEnterAddMode = useCallback(() => {
-    hideMenu(() => {
-      setMode('add');
-      setAddSelectedBrandIds([]);
-    });
-  }, [hideMenu]);
-
-  const handleEnterRemoveMode = useCallback(() => {
-    hideMenu(() => {
-      setMode('remove');
-      setSelectedBrandIds([]);
-    });
-  }, [hideMenu]);
-
-  const handleExitMode = useCallback(() => {
-    setMode('default');
-    setSelectedBrandIds([]);
-    setAddSelectedBrandIds([]);
-  }, []);
-
-  // ─── Remove Mode Handlers ───
-  const handleResetSelection = useCallback(() => {
-    setSelectedBrandIds([]);
-  }, []);
-
-  const handleToggleRemoveSelect = useCallback((brandId: string) => {
-    setSelectedBrandIds(prev =>
-      prev.includes(brandId)
-        ? prev.filter(id => id !== brandId)
-        : [...prev, brandId],
-    );
-  }, []);
-
-  const handleConfirmRemove = useCallback(() => {
-    if (selectedBrandIds.length === 0) {
-      showToast('찜 해제할 브랜드를 골라주세요');
-      return;
-    }
-
-    selectedBrandIds.forEach(brandId => {
-      setOptimisticFavorite(brandId, false);
-      toggleFavorite(
-        { brandId, action: 'REMOVE' },
-        {
-          onError: () => {
-            setOptimisticFavorite(brandId, true);
-            showToast('찜 해제 중 오류가 발생했어요');
-          },
-        },
-      );
-    });
-    showToast(`${selectedBrandIds.length}개의 브랜드를 찜 해제 했어요`);
-    setMode('default');
-    setSelectedBrandIds([]);
-  }, [selectedBrandIds, setOptimisticFavorite, toggleFavorite, showToast]);
-
-  // ─── Add Mode Handlers ───
-  const handleToggleAddSelect = useCallback(
-    (brandId: string) => {
-      if (favoriteBrandIds.has(brandId)) {
-        return;
-      }
-      setAddSelectedBrandIds(prev =>
-        prev.includes(brandId)
-          ? prev.filter(id => id !== brandId)
-          : [...prev, brandId],
-      );
-    },
-    [favoriteBrandIds],
-  );
-
-  const handleConfirmAdd = useCallback(() => {
-    if (addSelectedBrandIds.length === 0) {
-      showToast('찜 추가할 브랜드를 골라주세요');
-      return;
-    }
-
-    addSelectedBrandIds.forEach(brandId => {
-      setOptimisticFavorite(brandId, true);
-      toggleFavorite(
-        { brandId, action: 'ADD' },
-        {
-          onError: () => {
-            setOptimisticFavorite(brandId, false);
-            showToast('브랜드 추가 중 오류가 발생했어요');
-          },
-        },
-      );
-    });
-    showToast(`${addSelectedBrandIds.length}개의 브랜드를 찜 추가했어요`);
-    setMode('default');
-    setAddSelectedBrandIds([]);
-  }, [addSelectedBrandIds, setOptimisticFavorite, toggleFavorite, showToast]);
-
-  // ─── Header Config ───
-  const headerTitle = useMemo(() => {
-    switch (mode) {
-      case 'remove':
-        return '찜한 브랜드 삭제';
-      case 'add':
-        return '찜 브랜드 추가';
-      default:
-        return '찜한 브랜드';
-    }
-  }, [mode]);
-
-  const headerRightElement = useMemo(() => {
-    switch (mode) {
-      case 'remove':
-        return selectedBrandIds.length > 0 ? (
-          <Pressable
-            onPress={handleResetSelection}
-            className="flex-row items-center">
-            <Text className="text-pink-500 headline-02">초기화</Text>
-            <ReplayIcons width={24} height={24} shape="true" />
-          </Pressable>
-        ) : undefined;
-      case 'add':
-        return (
-          <Pressable
-            onPress={() =>
-              navigation.navigate('BrandSearchScreen', { variant: 'mypage' })
-            }>
-            <SearchIcons shape="black" width={24} height={24} />
-          </Pressable>
-        );
-      default:
-        return <Kebab />;
-    }
-  }, [mode, selectedBrandIds.length, handleResetSelection, navigation]);
-
-  // ─── Render: Default / Remove 브랜드 그리드 ───
-  const renderFavoriteBrandGrid = useCallback(() => {
-    return chunkArray(favoriteBrands, 3).map((row, rowIndex) => (
-      <View key={rowIndex} className="mb-6 flex-row justify-between py-1">
-        {row.map(item => {
-          const isSelected = selectedBrandIds.includes(item.brandId);
-
-          return (
-            <View key={item.brandId} className="flex-1 items-center">
-              <View style={defaultShadow} className="mb-[7px] rounded-full">
-                <Pressable
-                  onPress={
-                    mode === 'remove'
-                      ? () => handleToggleRemoveSelect(item.brandId)
-                      : undefined
-                  }>
-                  <ImageBackground
-                    source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
-                    className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
-                    {mode === 'remove' && isSelected && (
-                      <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
-                        <CheckIcons shape="white" width={24} height={24} />
-                      </View>
-                    )}
-                  </ImageBackground>
-                </Pressable>
-              </View>
-              <Text
-                className="text-center text-gray-900 body-rg-02"
-                numberOfLines={1}
-                ellipsizeMode="tail">
-                {item.name}
-              </Text>
-            </View>
-          );
-        })}
-
-        {row.length < 3 &&
-          Array.from({ length: 3 - row.length }).map((_, i) => (
-            <View key={`empty-${i}`} className="flex-1" />
-          ))}
-      </View>
-    ));
-  }, [favoriteBrands, mode, selectedBrandIds, handleToggleRemoveSelect]);
-
-  // ─── Render: Add 모드 전체 브랜드 그리드 ───
-  const renderAddBrandGrid = useCallback(() => {
-    return chunkArray(allBrandsForAdd, 3).map((row, rowIndex) => (
-      <View
-        key={rowIndex}
-        className="-top-4 mb-6 flex-row justify-between py-1">
-        {row.map(item => {
-          const isFavorite = favoriteBrandIds.has(item.brandId);
-          const isSelected = addSelectedBrandIds.includes(item.brandId);
-
-          return (
-            <View
-              key={item.brandId}
-              className="flex-1 items-center"
-              style={isFavorite ? { opacity: 0.35 } : undefined}>
-              <View style={defaultShadow} className="mb-[7px] rounded-full">
-                <Pressable
-                  onPress={() => handleToggleAddSelect(item.brandId)}
-                  disabled={isFavorite}>
-                  <ImageBackground
-                    source={{ uri: Config.IMAGE_URL + item.iconImageUrl }}
-                    className="h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
-                    {isSelected && (
-                      <View className="w-full flex-1 items-center justify-center rounded-full bg-black/30">
-                        <CheckIcons shape="white" width={24} height={24} />
-                      </View>
-                    )}
-                  </ImageBackground>
-                </Pressable>
-              </View>
-              <Text className="text-center text-gray-900 body-rg-02">
-                {item.name}
-              </Text>
-            </View>
-          );
-        })}
-
-        {row.length < 3 &&
-          Array.from({ length: 3 - row.length }).map((_, i) => (
-            <View key={`empty-${i}`} className="flex-1" />
-          ))}
-      </View>
-    ));
-  }, [
-    allBrandsForAdd,
-    favoriteBrandIds,
-    addSelectedBrandIds,
-    handleToggleAddSelect,
-  ]);
-
-  // ─── Render: Guide Text ───
-  const renderGuideText = useCallback(() => {
-    if (mode === 'remove' && favoriteBrands.length > 0) {
-      return (
-        <View className="-mb-3 flex items-center justify-center px-1 py-2">
-          <Text className="text-gray-500 headline-01">
-            <Text className="text-primary-pink headline-01">찜 해제</Text>할
-            브랜드를 골라주세요.
-          </Text>
-        </View>
-      );
-    }
-    if (mode === 'add') {
-      return (
-        <View className="flex items-center justify-center px-1 py-2">
-          <Text className="text-gray-500 headline-01">
-            <Text className="text-primary-pink headline-01">추가로 찜할</Text>{' '}
-            브랜드를 골라주세요.
-          </Text>
-        </View>
-      );
-    }
-    return null;
-  }, [mode, favoriteBrands.length]);
+  const hasFavorites = brand.favoriteBrands.length > 0;
 
   return (
     <ScreenLayout>
       <MypageHeader
-        title={headerTitle}
-        rightElement={headerRightElement}
-        rightIconPress={mode === 'default' ? handleToggleMenu : undefined}
-        onBackPress={mode !== 'default' ? handleExitMode : undefined}
+        title={HEADER_TITLES[brand.mode]}
+        rightElement={rightElement}
+        rightIconPress={brand.mode === 'default' ? dropdown.toggle : undefined}
+        onBackPress={brand.mode !== 'default' ? brand.exitMode : undefined}
       />
 
-      {/* Guide Text */}
-      {renderGuideText()}
+      <BrandGuideText mode={brand.mode} hasFavorites={hasFavorites} />
 
-      {/* Kebab Dropdown Menu */}
-      <Modal
-        transparent
-        visible={menuMounted}
-        animationType="none"
-        onRequestClose={() => hideMenu()}>
-        <TouchableWithoutFeedback onPress={() => hideMenu()}>
-          <View className="flex-1">
-            <Animated.View
-              className="absolute right-4"
-              style={[
-                menuAnimatedStyle,
-                {
-                  top: 115,
-                  backgroundColor: 'rgba(255, 255, 255, 0.962)',
-                  borderRadius: 12,
-                  boxShadow: '0 0 32px 0 rgba(0, 0, 0, 0.20)',
-                  minWidth: 250,
-                },
-              ]}>
-              {/* 찜 브랜드 추가 */}
-              <Pressable
-                className="flex-row items-center justify-between px-4 py-2.5"
-                onPress={handleEnterAddMode}>
-                <Text className="text-primary-black body-rg-04">
-                  찜 브랜드 추가
-                </Text>
-                <PlusIcon />
-              </Pressable>
+      <DropdownMenu
+        isMounted={dropdown.isMounted}
+        animatedStyle={dropdown.animatedStyle}
+        items={dropdownItems}
+        onClose={() => dropdown.hide()}
+      />
 
-              <View
-                className="h-2"
-                style={{
-                  backgroundColor: 'rgba(60, 60, 67, 0.12)',
-                }}
-              />
+      <BrandSettingContent
+        mode={brand.mode}
+        favoriteBrands={brand.favoriteBrands}
+        allBrandsForAdd={brand.allBrandsForAdd}
+        removeSelectedIds={brand.removeSelectedIds}
+        addSelectedIds={brand.addSelectedIds}
+        favoriteBrandIds={brand.favoriteBrandIds}
+        toggleRemoveSelect={brand.toggleRemoveSelect}
+        toggleAddSelect={brand.toggleAddSelect}
+        scrollViewRef={scroll.scrollViewRef}
+        onScroll={scroll.handleScroll}
+      />
 
-              {/* 찜 해제 */}
-              <Pressable
-                className="flex-row items-center justify-between px-4 py-2.5"
-                onPress={handleEnterRemoveMode}>
-                <Text className="text-semantic-error body-rg-04">찜 해제</Text>
-                <PicselActionIcons shape="delete" width={20} height={20} />
-              </Pressable>
-            </Animated.View>
-          </View>
-        </TouchableWithoutFeedback>
-      </Modal>
-
-      {/* ─── Content by Mode ─── */}
-      {mode === 'add' ? (
-        <ScrollView
-          ref={scrollViewRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          className="flex-1 px-2 pt-4"
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 10 }}>
-          {renderAddBrandGrid()}
-        </ScrollView>
-      ) : favoriteBrands.length === 0 ? (
-        <View className="flex-1 items-center justify-center">
-          <SparkleImages shape="bg-opacity" height={418} width={340} />
-          <Text className="absolute text-gray-900 headline-04">
-            찜한 브랜드가 없어요
-          </Text>
-        </View>
-      ) : (
-        <ScrollView
-          ref={scrollViewRef}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          className="flex-1 px-2 pt-4"
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: 10 }}>
-          {renderFavoriteBrandGrid()}
-        </ScrollView>
-      )}
-
-      {/* ─── Floating Button ─── */}
-      {showFloatingButton && (
+      {scroll.showFloatingButton && (
         <Pressable
-          onPressIn={scrollToTop}
+          onPressIn={scroll.scrollToTop}
           style={{
             position: 'absolute',
             bottom: 90,
@@ -503,35 +75,14 @@ const BrandSettingScreen = () => {
         </Pressable>
       )}
 
-      {/* ─── Bottom Action ─── */}
-      {mode === 'remove' && favoriteBrands.length > 0 && (
-        <View className="flex-row">
-          <Pressable
-            className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
-            onPress={handleConfirmRemove}>
-            <PicselActionIcons shape="delete" width={24} height={24} />
-            <Text className="text-semantic-error headline-02">
-              {selectedBrandIds.length > 0
-                ? `${selectedBrandIds.length}개의 브랜드 찜 해제하기`
-                : '찜 해제하기'}
-            </Text>
-          </Pressable>
-        </View>
-      )}
-
-      {mode === 'add' && (
-        <View className="flex-row">
-          <Pressable
-            className="ml-2 mt-1 flex-1 flex-row items-center justify-center space-x-1 rounded-lg py-3"
-            onPress={handleConfirmAdd}>
-            <Text className="text-primary-pink headline-02">
-              {addSelectedBrandIds.length > 0
-                ? `${addSelectedBrandIds.length}개의 브랜드 찜 추가하기`
-                : '추가하기'}
-            </Text>
-          </Pressable>
-        </View>
-      )}
+      <BrandBottomAction
+        mode={brand.mode}
+        removeCount={brand.removeSelectedIds.length}
+        addCount={brand.addSelectedIds.length}
+        hasFavorites={hasFavorites}
+        onConfirmRemove={brand.confirmRemove}
+        onConfirmAdd={brand.confirmAdd}
+      />
     </ScreenLayout>
   );
 };

--- a/src/screens/mypage/editNickname/index.tsx
+++ b/src/screens/mypage/editNickname/index.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { KeyboardAvoidingView, Platform, View, Text } from 'react-native';
 
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { HighlightedText } from '@/shared/components/HighlightedText';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import {
@@ -16,9 +16,11 @@ import {
   updateNicknameApi,
 } from '@/shared/nickname';
 import { useUserStore } from '@/shared/store';
+import { useToastStore } from '@/shared/store/ui/toast';
 
 const EditNicknameScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
+  const { showToast } = useToastStore();
   const {
     userNickname: currentNickname,
     setUserNickname,
@@ -45,13 +47,11 @@ const EditNicknameScreen = () => {
       setUserNickname(response.data.userNickname);
       setEmail(response.data.email);
 
-      navigation.navigate('Mypage', {
-        toastMessage: '닉네임 변경을 완료했어요',
-      });
+      showToast('닉네임 변경을 완료했어요');
+      navigation.getParent()?.goBack();
     } catch (error) {
-      navigation.navigate('Mypage', {
-        toastMessage: '닉네임 변경에 실패했어요',
-      });
+      showToast('닉네임 변경에 실패했어요');
+      navigation.getParent()?.goBack();
     }
   };
 

--- a/src/screens/mypage/index.tsx
+++ b/src/screens/mypage/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
 
 import MypageTopBar from '@/feature/mypage/main/components/ui/atoms/MypageTopBar';
@@ -9,36 +9,35 @@ import MypageMenuItem from '@/feature/mypage/main/components/ui/molecules/Mypage
 import { useMypageMenu } from '@/feature/mypage/main/hooks/useMypageMenu';
 import { useGetUser } from '@/feature/mypage/main/queries/useGetUser';
 import ListGroup from '@/feature/mypage/shared/components/ui/organisms/ListGroup';
-import { MainNavigationProps } from '@/navigation';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import StarIcons from '@/shared/icons/StarIcons';
-import { useToastStore } from '@/shared/store/ui/toast';
 
 const MypageScreen = () => {
   const { data: user } = useGetUser();
   const { menuItems } = useMypageMenu();
   const navigation = useNavigation<RootStackNavigationProp>();
-  const route = useRoute<RouteProp<MainNavigationProps, 'Mypage'>>();
-  const { showToast } = useToastStore();
-
-  useEffect(() => {
-    if (route.params?.toastMessage) {
-      showToast(route.params.toastMessage);
-      navigation.setParams({ toastMessage: undefined });
-    }
-  }, [route.params?.toastMessage]);
 
   return (
     <ScreenLayout>
       <MypageTopBar
-        onPressNotification={() => navigation.navigate('NotificationScreen')}
-        onPressSetting={() => navigation.navigate('MypageSetting')}
+        onPressNotification={() =>
+          navigation.navigate('MypageRoute', {
+            screen: 'NotificationScreen',
+          })
+        }
+        onPressSetting={() =>
+          navigation.navigate('MypageRoute', { screen: 'MypageSetting' })
+        }
       />
 
       <NicknameSection
         nickname={user?.userNickname ?? null}
-        onPressEdit={() => navigation.navigate('EditNicknameScreen')}
+        onPressEdit={() =>
+          navigation.navigate('MypageRoute', {
+            screen: 'EditNicknameScreen',
+          })
+        }
       />
 
       <View className="mb-4 mt-4 px-4" style={{ gap: 12 }}>
@@ -47,7 +46,11 @@ const MypageScreen = () => {
           description="내가 찜한 브랜드를 한눈에 보고 관리해요"
           backgroundColor="bg-pink-100"
           icon={<StarIcons shape="empty" width={24} height={24} />}
-          onPress={() => navigation.navigate('BrandSettingScreen')}
+          onPress={() =>
+            navigation.navigate('MypageRoute', {
+              screen: 'BrandSettingScreen',
+            })
+          }
         />
 
         <MypageMenuItem

--- a/src/screens/mypage/notification/index.tsx
+++ b/src/screens/mypage/notification/index.tsx
@@ -8,12 +8,12 @@ import {
   MOCK_NOTIFICATIONS,
 } from '@/feature/mypage/notification';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import MypageIcons from '@/shared/icons/MypageIcons';
 
 const NotificationScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<MypageNavigationProp>();
 
   // TODO: 실제 알림 데이터로 교체
   const notifications = MOCK_NOTIFICATIONS;

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
+import { Platform } from 'react-native';
 import Config from 'react-native-config';
+import DeviceInfo from 'react-native-device-info';
 
 import { useUserStore } from '../store';
 
@@ -10,21 +12,36 @@ export const axiosInstance = axios.create({
   withCredentials: true,
 });
 
-// accessToken Header interceptor
+// User-Agent 캐싱
+let cachedUserAgent: string | null = null;
+
+const getUserAgent = async (): Promise<string> => {
+  if (cachedUserAgent) {
+    return cachedUserAgent;
+  }
+  const appVersion = DeviceInfo.getVersion();
+  const platform = Platform.OS === 'ios' ? 'iOS' : 'Android';
+  const deviceModel = DeviceInfo.getModel();
+  const deviceUUID = await DeviceInfo.getUniqueId();
+  cachedUserAgent = `PICSEL/${appVersion} (${platform}; ${deviceModel}; ${deviceUUID})`;
+  return cachedUserAgent;
+};
+
+// accessToken + User-Agent Header interceptor
 axiosInstance.interceptors.request.use(
-  config => {
+  async config => {
     const accessToken = useUserStore.getState().accessToken;
 
     if (accessToken) {
       config.headers['Access-Token'] = accessToken;
     }
-    console.log('axios config : ', config);
+
+    config.headers['User-Agent'] = await getUserAgent();
 
     return config;
   },
 
   error => {
-    console.log('axios config : ', error);
     return Promise.reject(error);
   },
 );

--- a/src/shared/api/images/getPresignedUrlApi.ts
+++ b/src/shared/api/images/getPresignedUrlApi.ts
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 
 import { axiosInstance } from '../axiosInstance';
@@ -10,12 +9,7 @@ import { ImageType, PresignedUrlResponse } from './types';
  * @param type 이미지 타입
  */
 export const getPresignedUrlApi = async (type: ImageType) => {
-  const appVersion = DeviceInfo.getVersion();
-  const platform = Platform.OS === 'ios' ? 'iOS' : 'Android';
-  const deviceModel = DeviceInfo.getModel();
   const deviceUUID = await DeviceInfo.getUniqueId();
-
-  const userAgent = `PICSEL/${appVersion} (${platform}; ${deviceModel}; ${deviceUUID})`;
 
   const response = await axiosInstance.get<PresignedUrlResponse>(
     '/images/presigned',
@@ -23,9 +17,6 @@ export const getPresignedUrlApi = async (type: ImageType) => {
       params: {
         uuid: deviceUUID,
         type: type,
-      },
-      headers: {
-        'User-Agent': userAgent,
       },
     },
   );

--- a/src/shared/api/user/fetchConfigApi.ts
+++ b/src/shared/api/user/fetchConfigApi.ts
@@ -1,23 +1,9 @@
-import { Platform } from 'react-native';
-import DeviceInfo from 'react-native-device-info';
-
 import { axiosInstance } from '../axiosInstance';
 
 import { UserConfigResponse } from './types';
 
 export const fetchUserConfig = async () => {
-  const appVersion = DeviceInfo.getVersion();
-  const platform = Platform.OS === 'ios' ? 'iOS' : 'Android';
-  const deviceModel = DeviceInfo.getModel();
-  const deviceUUID = await DeviceInfo.getUniqueId();
-
-  const userAgent = `PICSEL/${appVersion} (${platform}; ${deviceModel}; ${deviceUUID})`;
-
-  const response = await axiosInstance.get<UserConfigResponse>('/app/config', {
-    headers: {
-      'User-Agent': userAgent,
-    },
-  });
+  const response = await axiosInstance.get<UserConfigResponse>('/app/config');
 
   return response.data;
 };

--- a/src/shared/components/CachedImage.tsx
+++ b/src/shared/components/CachedImage.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { Image, ImageStyle, StyleProp } from 'react-native';
+
+interface Props {
+  uri: string;
+  style?: StyleProp<ImageStyle>;
+  resizeMode?: 'cover' | 'contain' | 'stretch' | 'center';
+  onLoad?: () => void;
+  onError?: () => void;
+  className?: string;
+}
+
+const CachedImage = ({
+  uri,
+  style,
+  resizeMode = 'cover',
+  onLoad,
+  onError,
+  className,
+}: Props) => {
+  if (!uri) {
+    return null;
+  }
+
+  return (
+    <Image
+      className={className}
+      style={style}
+      source={{ uri, cache: 'default' }}
+      resizeMode={resizeMode}
+      onLoad={onLoad}
+      onError={onError}
+    />
+  );
+};
+
+export default CachedImage;

--- a/src/shared/components/ui/molecules/DropdownMenu.tsx
+++ b/src/shared/components/ui/molecules/DropdownMenu.tsx
@@ -1,0 +1,85 @@
+import React, { Fragment, ReactNode } from 'react';
+
+import {
+  Modal,
+  Pressable,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import Animated from 'react-native-reanimated';
+import { AnimatedStyle } from 'react-native-reanimated';
+
+export interface DropdownMenuItem {
+  label: string;
+  onPress: () => void;
+  icon?: ReactNode;
+  textClassName?: string;
+}
+
+interface Props {
+  isMounted: boolean;
+  animatedStyle: AnimatedStyle;
+  items: DropdownMenuItem[];
+  onClose: () => void;
+  top?: number;
+  minWidth?: number;
+}
+
+const DropdownMenu = ({
+  isMounted,
+  animatedStyle,
+  items,
+  onClose,
+  top = 115,
+  minWidth = 250,
+}: Props) => {
+  return (
+    <Modal
+      transparent
+      visible={isMounted}
+      animationType="none"
+      onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View className="flex-1">
+          <Animated.View
+            className="absolute right-4"
+            style={[
+              animatedStyle,
+              {
+                top,
+                backgroundColor: 'rgba(255, 255, 255, 0.962)',
+                borderRadius: 12,
+                boxShadow: '0 0 32px 0 rgba(0, 0, 0, 0.20)',
+                minWidth,
+              },
+            ]}>
+            {items.map((item, index) => (
+              <Fragment key={index}>
+                {index === items.length - 1 && items.length > 1 && (
+                  <View
+                    className="h-2"
+                    style={{ backgroundColor: 'rgba(59, 62, 70, 0.08)' }}
+                  />
+                )}
+                <Pressable
+                  className="flex-row items-center justify-between px-4 py-2.5"
+                  onPress={item.onPress}>
+                  <Text
+                    className={
+                      item.textClassName ?? 'text-primary-black body-rg-04'
+                    }>
+                    {item.label}
+                  </Text>
+                  {item.icon}
+                </Pressable>
+              </Fragment>
+            ))}
+          </Animated.View>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+export default DropdownMenu;

--- a/src/shared/hooks/useDropdownMenu.ts
+++ b/src/shared/hooks/useDropdownMenu.ts
@@ -1,0 +1,71 @@
+import { useState, useCallback } from 'react';
+
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+  Easing,
+} from 'react-native-reanimated';
+
+const SHOW_DURATION = 180;
+const HIDE_DURATION = 150;
+const INITIAL_SCALE = 0.95;
+
+export const useDropdownMenu = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(INITIAL_SCALE);
+
+  const show = useCallback(() => {
+    setIsMounted(true);
+    setIsVisible(true);
+    opacity.value = withTiming(1, {
+      duration: SHOW_DURATION,
+      easing: Easing.out(Easing.ease),
+    });
+    scale.value = withTiming(1, {
+      duration: SHOW_DURATION,
+      easing: Easing.out(Easing.ease),
+    });
+  }, [opacity, scale]);
+
+  const hide = useCallback(
+    (onComplete?: () => void) => {
+      setIsVisible(false);
+      opacity.value = withTiming(
+        0,
+        { duration: HIDE_DURATION, easing: Easing.in(Easing.ease) },
+        finished => {
+          if (finished) {
+            runOnJS(setIsMounted)(false);
+            if (onComplete) {
+              runOnJS(onComplete)();
+            }
+          }
+        },
+      );
+      scale.value = withTiming(INITIAL_SCALE, {
+        duration: HIDE_DURATION,
+        easing: Easing.in(Easing.ease),
+      });
+    },
+    [opacity, scale],
+  );
+
+  const toggle = useCallback(() => {
+    if (isVisible) {
+      hide();
+    } else {
+      show();
+    }
+  }, [isVisible, show, hide]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return { isMounted, animatedStyle, show, hide, toggle };
+};

--- a/src/shared/hooks/useImagePrefetch.ts
+++ b/src/shared/hooks/useImagePrefetch.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+
+import { Image } from 'react-native';
+
+/**
+ * 이미지 URI 배열을 메모리에 prefetch하는 훅
+ * - 전체 탭에서 이미지가 로드된 후 호출하면
+ *   월/년 탭 전환 시 메모리 캐시에서 즉시 렌더링됨
+ */
+
+export const useImagePrefetch = (uris: string[]) => {
+  const prefetchedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    uris.forEach(uri => {
+      if (uri && !prefetchedRef.current.has(uri)) {
+        prefetchedRef.current.add(uri);
+        Image.prefetch(uri).catch(() => {
+          // force-cache fallback
+        });
+      }
+    });
+  }, [uris]);
+};

--- a/src/shared/hooks/useImagePreload.ts
+++ b/src/shared/hooks/useImagePreload.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const TIMEOUT_MS = 8000;
+
+interface UseImagePreloadResult {
+  isImagesLoaded: boolean;
+  handleImageLoad: (uri: string) => void;
+  handleImageError: (uri: string) => void;
+}
+
+export const useImagePreload = (uris: string[]): UseImagePreloadResult => {
+  const [isImagesLoaded, setIsImagesLoaded] = useState(uris.length === 0);
+  const loadedSetRef = useRef<Set<string>>(new Set());
+  const totalRef = useRef(uris.length);
+  const prevKeyRef = useRef<string>(uris.join(','));
+
+  const stableKey = uris.join(',');
+
+  // 렌더 중 동기적으로 key 변경 감지 → 1프레임 깜빡임 방지
+  if (prevKeyRef.current !== stableKey) {
+    prevKeyRef.current = stableKey;
+    loadedSetRef.current = new Set();
+    totalRef.current = uris.length;
+
+    if (uris.length === 0) {
+      if (!isImagesLoaded) {
+        setIsImagesLoaded(true);
+      }
+    } else {
+      if (isImagesLoaded) {
+        setIsImagesLoaded(false);
+      }
+    }
+  }
+
+  // 안전 타임아웃: 이미지 로드 실패해도 UI가 스켈레톤에 머물지 않도록
+  useEffect(() => {
+    if (uris.length === 0) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsImagesLoaded(true);
+    }, TIMEOUT_MS);
+
+    return () => clearTimeout(timer);
+  }, [stableKey]);
+
+  const handleComplete = useCallback((uri: string) => {
+    if (loadedSetRef.current.has(uri)) {
+      return;
+    }
+
+    loadedSetRef.current.add(uri);
+
+    if (loadedSetRef.current.size >= totalRef.current) {
+      setIsImagesLoaded(true);
+    }
+  }, []);
+
+  return {
+    isImagesLoaded,
+    handleImageLoad: handleComplete,
+    handleImageError: handleComplete,
+  };
+};

--- a/src/shared/hooks/useRequestNotificationPermission.ts
+++ b/src/shared/hooks/useRequestNotificationPermission.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+import { requestNotifications, RESULTS } from 'react-native-permissions';
+
+import { patchNotificationSettingApi } from '@/feature/mypage/notification/api/notificationSettingApi';
+import { useNotificationPromptStore } from '@/shared/store';
+
+export const useRequestNotificationPermission = () => {
+  const hasRequested = useNotificationPromptStore(
+    state => state.hasRequestedNotification,
+  );
+  const setHasRequested = useNotificationPromptStore(
+    state => state.setHasRequestedNotification,
+  );
+
+  useEffect(() => {
+    if (hasRequested) {
+      return;
+    }
+
+    const requestPermission = async () => {
+      try {
+        const { status } = await requestNotifications([
+          'alert',
+          'sound',
+          'badge',
+        ]);
+
+        setHasRequested(true);
+
+        if (status === RESULTS.GRANTED) {
+          await patchNotificationSettingApi({
+            isPicselNewsEnabled: true,
+            isEventNewsEnabled: true,
+          });
+        }
+      } catch (error) {
+        console.warn('푸시 알림 권한 요청 실패:', error);
+      }
+    };
+
+    requestPermission();
+  }, [hasRequested, setHasRequested]);
+};

--- a/src/shared/hooks/useRequestNotificationPermission.ts
+++ b/src/shared/hooks/useRequestNotificationPermission.ts
@@ -9,12 +9,13 @@ export const useRequestNotificationPermission = () => {
   const hasRequested = useNotificationPromptStore(
     state => state.hasRequestedNotification,
   );
+  const hasHydrated = useNotificationPromptStore(state => state._hasHydrated);
   const setHasRequested = useNotificationPromptStore(
     state => state.setHasRequestedNotification,
   );
 
   useEffect(() => {
-    if (hasRequested) {
+    if (!hasHydrated || hasRequested) {
       return;
     }
 
@@ -40,5 +41,5 @@ export const useRequestNotificationPermission = () => {
     };
 
     requestPermission();
-  }, [hasRequested, setHasRequested]);
+  }, [hasHydrated, hasRequested, setHasRequested]);
 };

--- a/src/shared/hooks/useUserConfig.ts
+++ b/src/shared/hooks/useUserConfig.ts
@@ -1,13 +1,24 @@
 import { useEffect } from 'react';
 
+import DeviceInfo from 'react-native-device-info';
+
 import { fetchUserConfig } from '../api/user/fetchConfigApi';
+import { useAppConfigStore } from '../store';
 
 export const useUserConfig = () => {
   useEffect(() => {
     const init = async () => {
-      const response = await fetchUserConfig();
+      try {
+        const response = await fetchUserConfig();
+        const latestVersion = response.data.version.latest;
+        const currentVersion = DeviceInfo.getVersion();
 
-      console.log(response.data.version);
+        useAppConfigStore
+          .getState()
+          .setIsLatest(currentVersion >= latestVersion);
+      } catch (e) {
+        console.warn('앱 설정 정보를 불러올 수 없습니다.', e);
+      }
     };
     init();
   }, []);

--- a/src/shared/icons/PicselBookIcons/index.tsx
+++ b/src/shared/icons/PicselBookIcons/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Image, View } from 'react-native';
+import { View } from 'react-native';
 
 import BookAdd from '@/assets/icons/picselBook/picselBook-add.svg';
 import BookCoverSelected from '@/assets/icons/picselBook/picselBook-cover-selected.svg';
 import BookDefault from '@/assets/icons/picselBook/picselBook-default.svg';
 import Spring from '@/assets/icons/picselBook/spring.svg';
+import CachedImage from '@/shared/components/CachedImage';
 
 interface Props {
   shape: 'default' | 'add' | 'cover-selected';
@@ -13,6 +14,8 @@ interface Props {
   height: number;
   imageUri?: string;
   opacity?: number;
+  onImageLoad?: () => void;
+  onImageError?: () => void;
 }
 
 const PicselBookIcons = ({
@@ -21,6 +24,8 @@ const PicselBookIcons = ({
   height,
   imageUri,
   opacity,
+  onImageLoad,
+  onImageError,
 }: Props) => {
   const renderIcon = () => {
     switch (shape) {
@@ -35,14 +40,13 @@ const PicselBookIcons = ({
     }
   };
 
-  // 커버 사진이 있을 경우 custom picsel-book
   if (imageUri) {
     return (
       <View style={{ width, height, position: 'relative' }}>
         {renderIcon()}
         <Spring className="absolute z-50" />
-        <Image
-          source={{ uri: imageUri }}
+        <CachedImage
+          uri={imageUri}
           style={{
             position: 'absolute',
             left: '7%',
@@ -51,6 +55,8 @@ const PicselBookIcons = ({
             borderRadius: 5,
           }}
           resizeMode="cover"
+          onLoad={onImageLoad}
+          onError={onImageError}
         />
         {opacity < 1 && (
           <View

--- a/src/shared/store/appConfig/index.ts
+++ b/src/shared/store/appConfig/index.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface AppConfigState {
+  isLatest: boolean;
+  setIsLatest: (isLatest: boolean) => void;
+}
+
+export const useAppConfigStore = create<AppConfigState>(set => ({
+  isLatest: true,
+  setIsLatest: (isLatest: boolean) => set({ isLatest }),
+}));

--- a/src/shared/store/index.tsx
+++ b/src/shared/store/index.tsx
@@ -10,3 +10,4 @@ export { useConfirmModalStore } from './ui/confirmModal';
 export { useActionSheetStore } from './ui/actionSheet';
 export { useMyPicselStore } from './myPicsel';
 export { usePicselBookStore } from './picselBook';
+export { useAppConfigStore } from './appConfig';

--- a/src/shared/store/index.tsx
+++ b/src/shared/store/index.tsx
@@ -11,3 +11,4 @@ export { useActionSheetStore } from './ui/actionSheet';
 export { useMyPicselStore } from './myPicsel';
 export { usePicselBookStore } from './picselBook';
 export { useAppConfigStore } from './appConfig';
+export { useNotificationPromptStore } from './notification';

--- a/src/shared/store/notification/index.ts
+++ b/src/shared/store/notification/index.ts
@@ -4,19 +4,29 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 
 interface NotificationPromptState {
   hasRequestedNotification: boolean;
+  _hasHydrated: boolean;
   setHasRequestedNotification: (value: boolean) => void;
+  setHasHydrated: (value: boolean) => void;
 }
 
 export const useNotificationPromptStore = create<NotificationPromptState>()(
   persist(
     set => ({
       hasRequestedNotification: false,
+      _hasHydrated: false,
       setHasRequestedNotification: (hasRequestedNotification: boolean) =>
         set({ hasRequestedNotification }),
+      setHasHydrated: (value: boolean) => set({ _hasHydrated: value }),
     }),
     {
       name: 'notification-prompt-storage',
       storage: createJSONStorage(() => AsyncStorage),
+      onRehydrateStorage: () => state => {
+        state?.setHasHydrated(true);
+      },
+      partialize: state => ({
+        hasRequestedNotification: state.hasRequestedNotification,
+      }),
     },
   ),
 );

--- a/src/shared/store/notification/index.ts
+++ b/src/shared/store/notification/index.ts
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface NotificationPromptState {
+  hasRequestedNotification: boolean;
+  setHasRequestedNotification: (value: boolean) => void;
+}
+
+export const useNotificationPromptStore = create<NotificationPromptState>()(
+  persist(
+    set => ({
+      hasRequestedNotification: false,
+      setHasRequestedNotification: (hasRequestedNotification: boolean) =>
+        set({ hasRequestedNotification }),
+    }),
+    {
+      name: 'notification-prompt-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+);

--- a/src/shared/utils/image.ts
+++ b/src/shared/utils/image.ts
@@ -1,0 +1,27 @@
+import Config from 'react-native-config';
+
+/**
+ * 서버에서 받은 이미지 경로에 IMAGE_URL을 붙여 완전한 URL을 생성
+ *
+ * 서버 응답이 `/img/...` 또는 `img/...` 등 일관적이지 않을 수 있으므로
+ * 슬래시 중복/누락을 방어하여 안전하게 URL을 조합
+ *
+ * @param path - 서버에서 받은 이미지 상대 경로
+ * @returns 완전한 이미지 URL (path가 falsy하면 빈 문자열 반환)
+ *
+ * @example
+ * getImageUrl('/img/picsel/abc.jpg')  // https://imgdev.picsel.co.kr/img/picsel/abc.jpg
+ * getImageUrl('img/picsel/abc.jpg')   // https://imgdev.picsel.co.kr/img/picsel/abc.jpg
+ * getImageUrl('')                      // ''
+ * getImageUrl(undefined)               // ''
+ */
+export const getImageUrl = (path?: string | null): string => {
+  if (!path) {
+    return '';
+  }
+
+  const baseUrl = (Config.IMAGE_URL ?? '').replace(/\/+$/, '');
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  return `${baseUrl}${normalizedPath}`;
+};


### PR DESCRIPTION
## 이슈 번호

> close #102, close #108, close #117 

## 작업 내용 및 테스트 방법1
### 1. bottom-sheet type issue
```js
타입 에러 없이 통과합니다 👍🏻 
`@ts-ignore` 3개 제거 → `dismiss()` 헬퍼 함수로 통합:

```typescript
const dismiss = () => {
  if (ref && 'current' in ref) {
    ref.current?.dismiss();
  }
};
```

- `'current' in ref` — `ref`가 `RefObject`인지 확인하는 타입 가드 (콜백 ref가 아닌 경우)
- `ref.current?.dismiss()` — optional chaining으로 `null` 안전 접근
- `handleBackdropPress`, `handleComplete`, `handleSelectedCover` 3곳에서 공통 사용

### 2. 모든 API 요청에서 UserAgent 공통처리

-  **`shared/store/appConfig/index.ts`** — `isLatest` 상태를 관리하는 zustand store 생성
-  **`shared/hooks/useUserConfig.ts`** — `/app/config` API에서 받아온 `version.latest`와 `DeviceInfo.getVersion()`을 비교하여 `isLatest` store에 저장
- **`screens/mypage/account/index.tsx`** — 하드코딩된 `isLatest` 대신 store에서 값을 가져와 전달
- **`AppVersionSection.tsx`** — `isLatest`가 `false`일 때 `"(업데이트 필요)"` 텍스트 표시

### 3. 유저 알림 권한 설정
- 동작 플로우
1. 홈화면 마운트 → `hasRequestedNotification`이 `false`인지 확인
2. `false`이면 → `requestNotifications(['alert', 'sound', 'badge'])` 호출 (OS 팝업)
3. 허용/거부 관계없이 → `hasRequestedNotification = true`로 persist (재요청 방지)
4. **허용 시** → `patchNotificationSettingApi`로 서버에 픽셀소식/이벤트소식 ON 전송
5. 마이페이지 > 알림 설정에서 토글 상태 자동 반영