### PR TITLE
✨ Feat: 픽셀 업로드 내용 기록 Step 및 완료 화면 구현

### DIFF
--- a/src/feature/picsel/myPicsel/api/getPicselDetailApi.ts
+++ b/src/feature/picsel/myPicsel/api/getPicselDetailApi.ts
@@ -1,0 +1,12 @@
+import { getPicselDetailResponse, PicselDetailResponse } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const getPicselDetailApi = async (
+  picselId: string,
+): Promise<PicselDetailResponse> => {
+  const response = await axiosInstance.get<getPicselDetailResponse>(
+    `/picsels/${picselId}`,
+  );
+  return response.data.data;
+};

--- a/src/feature/picsel/myPicsel/components/ui/molecules/PicselDetailHeader.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/molecules/PicselDetailHeader.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Pressable, View } from 'react-native';
+
+import Kebab from '@/assets/icons/kebab/icon-kebab.svg';
+import ArrowIcons from '@/shared/icons/ArrowIcons';
+
+interface Props {
+  onBack?: () => void;
+}
+const PicselDetailHeader = ({ onBack }: Props) => {
+  return (
+    <View className="flex w-full flex-row items-center justify-between px-4">
+      <Pressable onPress={onBack}>
+        <ArrowIcons shape="back" width={24} height={24} />
+      </Pressable>
+
+      <Pressable onPress={() => console.log('더보기 클릭')}>
+        <Kebab />
+      </Pressable>
+    </View>
+  );
+};
+
+export default PicselDetailHeader;

--- a/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
+++ b/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
@@ -8,7 +8,6 @@ export const useGetPicselDetail = (picselId: string) => {
     queryKey: ['picselDetail', picselId],
     queryFn: () => getPicselDetailApi(picselId),
     enabled: !!picselId,
-
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 10,
     retry: 2,

--- a/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
+++ b/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getPicselDetailApi } from '../api/getPicselDetailApi';
+import { PicselDetailResponse } from '../types';
+
+export const useGetPicselDetail = (picselId: string) => {
+  return useQuery<PicselDetailResponse>({
+    queryKey: ['picselDetail', picselId],
+
+    queryFn: () => getPicselDetailApi(picselId),
+
+    enabled: !!picselId,
+
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    retry: 2,
+  });
+};

--- a/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
+++ b/src/feature/picsel/myPicsel/queries/useGetPicselDetail.ts
@@ -6,9 +6,7 @@ import { PicselDetailResponse } from '../types';
 export const useGetPicselDetail = (picselId: string) => {
   return useQuery<PicselDetailResponse>({
     queryKey: ['picselDetail', picselId],
-
     queryFn: () => getPicselDetailApi(picselId),
-
     enabled: !!picselId,
 
     staleTime: 1000 * 60 * 5,

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -1,3 +1,5 @@
+import { CommonResponseType } from '@/shared/api/types';
+
 export type DateFilterType = 'all' | 'year' | 'month';
 
 // 정렬 타입
@@ -54,4 +56,39 @@ export interface MyPicselResult {
 // 픽셀 삭제 요청
 export interface DeletePicselsRequest {
   picselIds: string[];
+}
+
+// 상세 페이지 내 픽셀북 정보
+export interface PicselDetailBook {
+  picselbookId: string;
+  bookName: string;
+  coverImagePath: string;
+}
+
+// 상세 페이지 내 스토어 정보
+export interface PicselDetailStore {
+  storeId: string;
+  storeName: string;
+}
+
+// 상세 페이지 내 개별 사진 아이템
+export interface PicselDetailPhoto {
+  imagePath: string;
+  displayOrder: number;
+}
+
+// 픽셀 게시글 상세 조회 API 응답
+export interface PicselDetailResponse {
+  picselId: string;
+  picselbook: PicselDetailBook;
+  representativeImagePath: string;
+  title: string;
+  content: string;
+  takenDate: string;
+  store: PicselDetailStore;
+  photos: PicselDetailPhoto[];
+}
+
+export interface getPicselDetailResponse extends CommonResponseType {
+  data: PicselDetailResponse;
 }

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView.tsx
@@ -56,7 +56,7 @@ const PhotoTextListView = forwardRef<FlatList, Props>(
           isSelecting={isSelecting}
           isSelected={isSelected}
           onToggleSelection={onToggleSelection}
-          onPress={onPhotoPress}
+          onPress={() => !isSelecting && onPhotoPress?.(item.picselId)}
           onImageLoad={handleImageLoad}
           onImageError={handleImageError}
         />

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
@@ -24,9 +24,15 @@ interface Props {
   bookId: string;
   bookName?: string;
   onBack: () => void;
+  onPhotoPress: (picselId: string) => void;
 }
 
-const PicselBookFolderTemplate = ({ bookId, bookName = '', onBack }: Props) => {
+const PicselBookFolderTemplate = ({
+  bookId,
+  bookName = '',
+  onBack,
+  onPhotoPress,
+}: Props) => {
   const {
     photoData,
     rawData,
@@ -142,6 +148,7 @@ const PicselBookFolderTemplate = ({ bookId, bookName = '', onBack }: Props) => {
               isLoading={isLoading}
               onScroll={handleScroll}
               onToggleSelection={toggleSelection}
+              onPhotoPress={onPhotoPress}
             />
           )}
           <FloatingActionButtons

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -114,6 +114,8 @@ export const usePicselBook = () => {
 
     createPicselBook(payload, {
       onSuccess: response => {
+        showToast(`"${bookName}"을 추가했어요`, 60);
+
         navigation.pop(1);
         picselBookRef.current?.dismiss();
 

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -120,7 +120,7 @@ export const usePicselBook = () => {
         const newBookId = response.data?.picselbookId;
 
         if (newBookId) {
-          setPicselbookId(newBookId);
+          setPicselbookId(newBookId, bookName);
           refetch();
         }
 
@@ -150,6 +150,8 @@ export const usePicselBook = () => {
     // 픽셀 업로드 내 픽셀북 선택 단계일 때
     if (isUploadStep) {
       setSelectedBookIds(prev => (prev.includes(bookId) ? [] : [bookId]));
+
+      setPicselbookId(bookId, bookName);
       return;
     }
 

--- a/src/feature/picsel/picselUpload/hooks/usePicselUploadStore.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePicselUploadStore.ts
@@ -10,6 +10,7 @@ interface PicselUploadStore {
   locationName: string;
 
   picselbookId: string;
+  bookName: string;
 
   title: string;
   content: string;
@@ -25,7 +26,7 @@ interface PicselUploadStore {
     storeId: string,
     locationName?: string,
   ) => void;
-  setPicselbookId: (id: string) => void;
+  setPicselbookId: (id: string, name: string) => void;
   setRecord: (title: string, content: string) => void;
 
   getImagePaths: () => string[];
@@ -39,6 +40,7 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
   storeId: '',
   locationName: '',
   picselbookId: '',
+  bookName: '',
   title: '',
   content: '',
 
@@ -61,7 +63,7 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
       locationName: locationName,
     }),
 
-  setPicselbookId: id => set({ picselbookId: id }),
+  setPicselbookId: (id, name) => set({ picselbookId: id, bookName: name }),
 
   setRecord: (title, content) => set({ title, content }),
 
@@ -78,6 +80,7 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
       storeId: '',
       locationName: '',
       picselbookId: '',
+      bookName: '',
       title: '',
       content: '',
     }),

--- a/src/feature/picsel/picselUpload/types/index.ts
+++ b/src/feature/picsel/picselUpload/types/index.ts
@@ -1,3 +1,5 @@
+import { CommonResponseType } from '@/shared/api/types';
+
 // 픽셀 추가 요청
 export interface PicselUploadRequest {
   picselbookId: string;
@@ -9,9 +11,13 @@ export interface PicselUploadRequest {
 }
 
 // 픽셀 추가 응답
-export interface PicselUploadResponse {
+export interface PicselUploadResult {
   picselId: string;
   picselbookId: string;
   representativeImagePath: string;
   createdAt: string;
+}
+
+export interface PicselUploadResponse extends CommonResponseType {
+  data: PicselUploadResult;
 }

--- a/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
@@ -36,7 +36,7 @@ const PicselBookSelectStep = ({ onNext }: Props) => {
 
     if (targetBook) {
       if (targetBook) {
-        setPicselbookId(targetBook.picselbookId);
+        setPicselbookId(targetBook.picselbookId, targetBook.bookName);
 
         onNext(targetBook.picselbookId, targetBook.bookName);
       }

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -80,10 +80,10 @@ const RecordWriteStep = () => {
       className="flex-1">
       <ScrollView
         contentContainerStyle={{ flexGrow: 1 }}
-        keyboardDismissMode="on-drag"
+        keyboardDismissMode="none"
         keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
         bounces={false}
-        onScrollBeginDrag={() => Keyboard.dismiss()}
         className="flex-1">
         <UploadStepHeader
           title={

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
+import { useNavigation } from '@react-navigation/native';
 import {
-  Keyboard,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -14,19 +14,19 @@ import { usePicselUploadStore } from '../../hooks/usePicselUploadStore';
 import { useAddPicselToPicselBook } from '../../mutations/useAddPicselToPicselBook';
 
 import UploadStepHeader from '@/feature/picsel/shared/components/ui/molecules/UploadStepHeader';
+import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { usePhotoStore } from '@/shared/store/picselUpload';
 import Button from '@/shared/ui/atoms/Button';
 
-interface Props {
-  onNext: () => void;
-}
-const RecordWriteStep = ({ onNext }: Props) => {
+const RecordWriteStep = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
   const {
     title: savedTitle,
     content: savedContent,
     takenDate,
     storeId,
     picselbookId,
+    bookName,
     setRecord,
     getImagePaths,
     resetUploadData,
@@ -50,14 +50,21 @@ const RecordWriteStep = ({ onNext }: Props) => {
     };
 
     uploadPicsel(requestPayload, {
-      onSuccess: () => {
+      onSuccess: data => {
+        navigation.reset({
+          index: 1,
+          routes: [
+            {
+              name: 'PicselBookFolder',
+              params: { bookId: picselbookId, bookName: bookName },
+            },
+            { name: 'PicselDetail', params: { picselId: data.data.picselId } },
+          ],
+        });
+
         setRecord(title, content);
         resetUploadData();
         resetPhotoStore();
-
-        // TODO : 다음 화면(완료 페이지 등)으로 이동
-        onNext();
-        console.log('업로드 성공! 완료 페이지로 이동 필요');
       },
       onError: error => {
         console.log('픽셀 업로드 중 에러 발생:', error.message);
@@ -100,7 +107,6 @@ const RecordWriteStep = ({ onNext }: Props) => {
               placeholderTextColor="#7E8392"
               className="mb-2 font-nanum-square-ac-regular text-primary-black headline-02"
               maxLength={20}
-              multiline
               returnKeyType="next"
               style={{ lineHeight: 20 }}
               selectionColor="#FF6C9A"
@@ -114,6 +120,7 @@ const RecordWriteStep = ({ onNext }: Props) => {
               }
               placeholderTextColor="#7E8392"
               multiline
+              scrollEnabled
               textAlignVertical="top"
               className="font-nanum-square-ac-regular text-gray-900"
               style={{ minHeight: 180, lineHeight: 22 }}
@@ -122,7 +129,7 @@ const RecordWriteStep = ({ onNext }: Props) => {
           </View>
         </View>
       </ScrollView>
-      <View className="absolute bottom-[-5px] w-full items-center">
+      <View className="w-full items-center">
         <Button
           text="완료"
           color={isFilled ? 'active' : 'disabled'}

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -98,7 +98,7 @@ const RecordWriteStep = ({ onNext }: Props) => {
               onChangeText={setTitle}
               placeholder="✏️ 제목 입력"
               placeholderTextColor="#7E8392"
-              className="mb-2 text-primary-black headline-02"
+              className="mb-2 font-nanum-square-ac-regular text-primary-black headline-02"
               maxLength={20}
               multiline
               returnKeyType="next"
@@ -115,7 +115,7 @@ const RecordWriteStep = ({ onNext }: Props) => {
               placeholderTextColor="#7E8392"
               multiline
               textAlignVertical="top"
-              className="text-gray-900 body-rg-03"
+              className="font-nanum-square-ac-regular text-gray-900"
               style={{ minHeight: 180, lineHeight: 22 }}
               selectionColor="#FF6C9A"
             />

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -11,6 +11,7 @@ import PicselTabScreen from '@/screens/picsel';
 import MonthFolderScreen from '@/screens/picsel/myPicsel/monthFolder';
 import YearFolderScreen from '@/screens/picsel/myPicsel/yearFolder';
 import PicselBookFolderScreen from '@/screens/picsel/picselBook/picselBookFolder';
+import PicselDetailScreen from '@/screens/picsel/picselDetail';
 import PicselUploadScreen from '@/screens/picsel/picselUpload';
 import RegisterPhotoScreen from '@/screens/picsel/picselUpload/registerPhoto';
 import SelectPhotoScreen from '@/screens/picsel/picselUpload/selectPhoto';
@@ -37,6 +38,7 @@ export type MainNavigationProps = {
   SelectExtraPhoto: { variant: 'extra' };
   RegisterPhoto: undefined;
   PicselUpload: undefined;
+  PicselDetail: { picselId: string };
 
   // Picsel Tab & Book
   PicselTab: undefined;
@@ -93,6 +95,8 @@ const MainRoute = () => {
       <Stack.Screen name="RegisterPhoto" component={RegisterPhotoScreen} />
 
       <Stack.Screen name="PicselUpload" component={PicselUploadScreen} />
+
+      <Stack.Screen name="PicselDetail" component={PicselDetailScreen} />
 
       {/* Picsel Tab & Book */}
       <Stack.Screen name="PicselTab" component={PicselTabScreen} />

--- a/src/screens/picsel/picselBook/picselBookFolder/index.tsx
+++ b/src/screens/picsel/picselBook/picselBookFolder/index.tsx
@@ -19,11 +19,16 @@ const PicselBookFolderScreen = () => {
     navigation.goBack();
   };
 
+  const handlePhotoPress = (picselId: string) => {
+    navigation.navigate('PicselDetail', { picselId });
+  };
+
   return (
     <PicselBookFolderTemplate
       bookId={bookId}
       bookName={bookName}
       onBack={handleBack}
+      onPhotoPress={handlePhotoPress}
     />
   );
 };

--- a/src/screens/picsel/picselDetail/index.tsx
+++ b/src/screens/picsel/picselDetail/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { ScrollView, Text, View } from 'react-native';
+
+import PicselDetailHeader from '@/feature/picsel/myPicsel/components/ui/molecules/PicselDetailHeader';
+import { useGetPicselDetail } from '@/feature/picsel/myPicsel/queries/useGetPicselDetail';
+import { usePhotoFormat } from '@/feature/picsel/shared/utils/usePhotoFormat';
+import { MainNavigationProps } from '@/navigation';
+import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
+import AspectRatioImage from '@/shared/components/ui/atoms/AspectRatioImage';
+import SparkleImages from '@/shared/images/Sparkle';
+import { getImageUrl } from '@/shared/utils/image';
+
+type Props = NativeStackScreenProps<MainNavigationProps, 'PicselDetail'>;
+
+const PicselDetailScreen = ({ route, navigation }: Props) => {
+  const { picselId } = route.params;
+  const { formatDate } = usePhotoFormat();
+
+  const { data: picsel, isError } = useGetPicselDetail(picselId);
+
+  if (isError || !picsel) {
+    return null;
+  }
+
+  return (
+    <ScreenLayout>
+      <PicselDetailHeader onBack={() => navigation.goBack()} />
+      <ScrollView>
+        <View className="items-center">
+          <Text className="px-4 text-gray-900 headline-01">
+            {formatDate(picsel.takenDate)}
+          </Text>
+          <Text className="px-4 py-1 text-gray-900 title-01">
+            {picsel.title}
+          </Text>
+
+          <View className="flex-row items-center gap-1">
+            <SparkleImages shape="icon-one" height={24} width={24} />
+            <Text className="text-gray-900 body-rg-03">
+              {picsel.store.storeName}
+            </Text>
+          </View>
+        </View>
+
+        <View className="flex-row flex-wrap justify-between px-4">
+          {picsel.photos.map((photo, index) => (
+            <AspectRatioImage
+              key={index}
+              uri={getImageUrl(photo.imagePath)}
+              className="mb-4"
+            />
+          ))}
+        </View>
+
+        <View className="px-6 pb-6 pt-2">
+          <Text className="text-gray-900 body-rg-02">{picsel.content}</Text>
+        </View>
+      </ScrollView>
+    </ScreenLayout>
+  );
+};
+
+export default PicselDetailScreen;

--- a/src/screens/picsel/picselUpload/index.tsx
+++ b/src/screens/picsel/picselUpload/index.tsx
@@ -16,7 +16,6 @@ const PicselUploadScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
 
   const { step, goNext, goBack, isFirstStep } = useUploadStep();
-
   const handleBack = () => {
     if (isFirstStep) {
       navigation.goBack();
@@ -34,7 +33,7 @@ const PicselUploadScreen = () => {
       case UPLOAD_STEP.PICSEL_BOOK_SELECT:
         return <PicselBookSelectStep onNext={goNext} />;
       case UPLOAD_STEP.RECORD_WRITE:
-        return <RecordWriteStep onNext={goNext} />;
+        return <RecordWriteStep />;
       default:
         return null;
     }

--- a/src/shared/components/ui/atoms/AspectRatioImage.tsx
+++ b/src/shared/components/ui/atoms/AspectRatioImage.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+import { Image, ImageProps } from 'react-native';
+
+interface Props extends ImageProps {
+  uri: string;
+}
+
+const AspectRatioImage = ({ uri, style, ...rest }: Props) => {
+  const [ratio, setRatio] = useState(1);
+
+  useEffect(() => {
+    if (!uri) {
+      return;
+    }
+
+    Image.getSize(uri, (width, height) => {
+      setRatio(width / height);
+    });
+  }, [uri]);
+
+  return (
+    <Image
+      {...rest}
+      source={{ uri }}
+      style={[{ width: '100%', aspectRatio: ratio }, style]}
+      resizeMode="cover"
+    />
+  );
+};
+
+export default AspectRatioImage;


### PR DESCRIPTION
## 이슈 번호

> close #103 

## 작업 내용 및 테스트 방법

> - 픽셀 업로드 완료 화면 구현
> - 픽셀 게시글 상세 조회 API 연동
> - 픽셀 게시글 상세 내에서 사용될 이미지 원본 비율에 맞는 Image Container UI 생성
> - 픽셀 게시글 상세 스크린에서 뒤로가기 시 종속된 픽셀북 스크린으로 이동되게 `navigate` 설정
> - `TextInput` 깨짐 이슈에 대응하기 위한 나눔스퀘어로 수정하여 적용

## To reviewers
🚨 픽셀북 추가 및 픽셀 업로드 API가 13일 이후로 수정되어 해당 내용을 fetch 하여 테스트 하실 때, 테스트가 원활하지 않을 수 있습니다ㅠㅠ 🥲
우선은 코드 스타일링 위주로 검토 해주시고 계시면 해당 내용 수정하여 최대한 빠르게 PR 올리도록 하겠습니다!! 

➕ issue에 수정사항으로 기재해놓은 **픽셀 글 기록 Step 내 제목 커서 색 적용**은 일시적인 버그로 판단되어 별도 추가 수정은 해놓지 않았고,
이후 발견되면 디버깅 해보겠습니다!