### PR TITLE
⛑️ QA: TestFlight 0.1(9)v 수정사항 대응

### DIFF
--- a/src/feature/picsel/picselUpload/hooks/useConfirmExit.ts
+++ b/src/feature/picsel/picselUpload/hooks/useConfirmExit.ts
@@ -1,24 +1,19 @@
-import { useNavigation } from '@react-navigation/native';
-
 import { usePicselUploadStore } from './usePicselUploadStore';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { usePhotoStore } from '@/shared/store/picselUpload';
 
 export const useConfirmExit = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
   const { reset: resetPhotoStore } = usePhotoStore();
   const { resetUploadData } = usePicselUploadStore();
 
-  const handleConfirmExit = () => {
-    resetPhotoStore();
-    resetUploadData();
+  const confirmExitUpload = (onExit: () => void) => {
+    const handleConfirmExit = () => {
+      resetPhotoStore();
+      resetUploadData();
+      onExit();
+    };
 
-    navigation.replace('QrScan');
-  };
-
-  const confirmExitUpload = () => {
     showConfirmModal(
       '지금까지 입력한 정보가\n모두 지워져요',
       handleConfirmExit,
@@ -30,7 +25,5 @@ export const useConfirmExit = () => {
     );
   };
 
-  return {
-    confirmExitUpload,
-  };
+  return { confirmExitUpload };
 };

--- a/src/feature/picsel/picselUpload/hooks/useConfirmExit.ts
+++ b/src/feature/picsel/picselUpload/hooks/useConfirmExit.ts
@@ -7,16 +7,18 @@ export const useConfirmExit = () => {
   const { reset: resetPhotoStore } = usePhotoStore();
   const { resetUploadData } = usePicselUploadStore();
 
-  const confirmExitUpload = (onExit: () => void) => {
-    const handleConfirmExit = () => {
-      resetPhotoStore();
-      resetUploadData();
-      onExit();
-    };
+  const resetAllUploadData = () => {
+    resetPhotoStore();
+    resetUploadData();
+  };
 
+  const confirmExitUpload = (onExit: () => void) => {
     showConfirmModal(
       '지금까지 입력한 정보가\n모두 지워져요',
-      handleConfirmExit,
+      () => {
+        resetAllUploadData();
+        onExit();
+      },
       {
         title: '업로드를 종료할까요?',
         confirmText: '종료',

--- a/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
+++ b/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
@@ -22,8 +22,10 @@ export const useInfiniteScrollPhotos = () => {
 
     loadingRef.current = true;
     try {
+      const fetchCount = endCursor ? 100 : 15;
+
       const { edges, page_info } = await CameraRoll.getPhotos({
-        first: 40,
+        first: fetchCount,
         after: endCursor,
         assetType: 'Photos',
       });

--- a/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
@@ -26,9 +26,19 @@ const PicselUploadLayout = ({ children, onBack }: Props) => {
     }
   };
 
+  const handleClose = () => {
+    confirmExitUpload(() => {
+      if (navigation.canGoBack()) {
+        navigation.goBack();
+      } else {
+        navigation.navigate('Home');
+      }
+    });
+  };
+
   return (
     <ScreenLayout>
-      <PicselUploadHeader onBack={handleBack} onClose={confirmExitUpload} />
+      <PicselUploadHeader onBack={handleBack} onClose={handleClose} />
       {children}
     </ScreenLayout>
   );

--- a/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
@@ -18,6 +18,14 @@ const PicselUploadLayout = ({ children, onBack }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const { confirmExitUpload } = useConfirmExit();
 
+  const navigateToExit = () => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate('Home');
+    }
+  };
+
   const handleBack = () => {
     if (onBack) {
       onBack();
@@ -27,13 +35,7 @@ const PicselUploadLayout = ({ children, onBack }: Props) => {
   };
 
   const handleClose = () => {
-    confirmExitUpload(() => {
-      if (navigation.canGoBack()) {
-        navigation.goBack();
-      } else {
-        navigation.navigate('Home');
-      }
-    });
+    confirmExitUpload(navigateToExit);
   };
 
   return (

--- a/src/feature/picsel/picselUpload/ui/organisms/PhotoGrid.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PhotoGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import {
   Dimensions,
@@ -36,10 +36,13 @@ export const PhotoGrid = ({
   onOpenCamera,
   onLoadMore,
 }: Props) => {
-  const data: GridItem[] = [
-    { type: 'camera' },
-    ...photos.map(photo => ({ type: 'photo' as const, photo })),
-  ];
+  const data: GridItem[] = useMemo(
+    () => [
+      { type: 'camera' },
+      ...photos.map(photo => ({ type: 'photo' as const, photo })),
+    ],
+    [photos],
+  );
 
   const renderItem = ({ item }: { item: GridItem }) => {
     if (item.type === 'camera') {
@@ -97,11 +100,11 @@ export const PhotoGrid = ({
     <FlatList
       data={data}
       numColumns={3}
-      keyExtractor={(_, idx) => idx.toString()}
+      keyExtractor={item => (item.type === 'camera' ? 'camera' : item.photo.id)}
       renderItem={renderItem}
       showsVerticalScrollIndicator={false}
       onEndReached={onLoadMore}
-      onEndReachedThreshold={0.6}
+      onEndReachedThreshold={2.0}
       bounces={false}
       contentContainerStyle={{ paddingBottom: 100 }}
     />

--- a/src/feature/qr/ui/layout/QrScanHeader.tsx
+++ b/src/feature/qr/ui/layout/QrScanHeader.tsx
@@ -14,12 +14,7 @@ const QrScanHeader = () => {
       <Text className="px-4 py-2 text-white title-01">QR 스캔</Text>
       <Pressable
         className="absolute right-4"
-        onPress={() => {
-          navigation.reset({
-            index: 0,
-            routes: [{ name: 'Home' }],
-          });
-        }}>
+        onPress={() => navigation.popToTop()}>
         <CloseIcons shape="white" width={24} height={24} />
       </Pressable>
     </View>

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -51,15 +51,18 @@ const SelectPhotoScreen = () => {
   const { handleSubmit } = usePicselBook();
 
   const handleSelectedCompleted = () => {
-    if (variant === 'main') {
-      setMainPhoto(selectedUris[0]);
-      navigation.replace('PicselUpload');
-    } else if (variant === 'extra') {
-      addExtraPhotos(selectedUris);
-      navigation.replace('PicselUpload');
-    } else if (variant === 'cover') {
-      picselBookRef.current?.present();
+    switch (variant) {
+      case 'cover':
+        picselBookRef.current?.present();
+        return;
+      case 'main':
+        setMainPhoto(selectedUris[0]);
+        break;
+      case 'extra':
+        addExtraPhotos(selectedUris);
+        break;
     }
+    navigation.replace('PicselUpload');
   };
 
   return (

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -53,10 +53,10 @@ const SelectPhotoScreen = () => {
   const handleSelectedCompleted = () => {
     if (variant === 'main') {
       setMainPhoto(selectedUris[0]);
-      navigation.navigate('PicselUpload');
+      navigation.replace('PicselUpload');
     } else if (variant === 'extra') {
       addExtraPhotos(selectedUris);
-      navigation.navigate('PicselUpload');
+      navigation.replace('PicselUpload');
     } else if (variant === 'cover') {
       picselBookRef.current?.present();
     }


### PR DESCRIPTION
## 이슈 번호

> close #109

## 작업 내용 및 테스트 방법

> 사진 선택 화면 진입 시 이미지 로딩 속도 개선
> 업로드 화면 종료 시 상황별 진입 화면으로 back
> QR 스캔 종료 시, 위에서 아래로 내려가는 인터렉션으로 개선

## To reviewers
사진 선택 화면 진입 시 이미지가 너무 늦게 로딩되는 것 같다는 QA 이슈가 있었습니다!
캐싱된 데이터를 보여줘 로딩 체감을 말끔히 제거해보려 했으나,, 원본 이미지의 해상도를 줄인 썸네일을 미리 가지고 있어야 한다는 점이 당장 개선을 하기 어렵다고 판단하여 최대한 체감을 덜 느낄 수 있도록 개선 진행해보았습니다.. 🥲

업로드 화면 종료 시 상황별 진입 화면으로 back의 경우
- 픽셀북에서 플로팅 버튼을 눌러 업로드하는 경우 → 픽셀북 화면으로 back
- QR 스캔을 통해 업로드하는 경우 → QR 스캔 화면으로 back