### PR TITLE
💄 Style: 픽셀 화면 floating 버튼 및 function 버튼 마진값 고정

### DIFF
--- a/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { View } from 'react-native';
-
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import { useMonthFolder } from '@/feature/picsel/myPicsel/hooks/useMonthFolder';
 import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons';
@@ -80,20 +78,16 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
         onMove={handleMove}
       />
 
-      {!isSelecting && (
-        <View className="absolute bottom-0 right-4">
-          <FloatingActionButtons
-            isSelecting={isSelecting}
-            showUpButton={showUpButton}
-            showFunctionButtons={showFunctionButtons}
-            onToggleFunctionButtons={toggleFunctionButtons}
-            onScrollToTop={scrollToTop}
-            onAlbumPress={handleAlbumPress}
-            onQrPress={handleQrPress}
-            onCloseFunctionButtons={closeFunctionButtons}
-          />
-        </View>
-      )}
+      <FloatingActionButtons
+        isSelecting={isSelecting}
+        showUpButton={showUpButton}
+        showFunctionButtons={showFunctionButtons}
+        onToggleFunctionButtons={toggleFunctionButtons}
+        onScrollToTop={scrollToTop}
+        onAlbumPress={handleAlbumPress}
+        onQrPress={handleQrPress}
+        onCloseFunctionButtons={closeFunctionButtons}
+      />
     </ScreenLayout>
   );
 };

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { View } from 'react-native';
 
 import EmptyStateLayout from '../../../../shared/components/layouts/EmptyStateLayout';
-import AddButton from '../../../../shared/components/ui/atoms/Button/AddButton';
-import FunctionButton from '../../../../shared/components/ui/atoms/Button/FunctionButton';
 import EmptyMessage from '../../../../shared/components/ui/molecules/EmptyMessage';
 import UploadTooltip from '../../../../shared/components/ui/molecules/UploadTooltip';
 import SelectionBottomSheet from '../../../../shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
@@ -14,7 +12,7 @@ import DateFilterButton from '../atoms/DateFilterButton';
 import MonthFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView';
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import YearFilterView from '@/feature/picsel/myPicsel/components/ui/organisms/YearFilterView';
-import UpButton from '@/feature/picsel/shared/components/ui/atoms/Button/UpButton';
+import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons';
 import PixelToolbar from '@/feature/picsel/shared/components/ui/organisms/toolBar';
 import { showBrandFilterSheet } from '@/shared/lib/brandFilterSheet';
 
@@ -61,20 +59,17 @@ const MyPicselTemplate = () => {
     return (
       <EmptyStateLayout
         floatingButton={
-          <>
-            <View className="absolute bottom-8 right-0.5">
-              <UploadTooltip />
-              {showFunctionButtons ? (
-                <FunctionButton
-                  onAlbumPress={handleAlbumPress}
-                  onQrPress={handleQrPress}
-                  onClose={closeFunctionButtons}
-                />
-              ) : (
-                <AddButton onPress={toggleFunctionButtons} />
-              )}
-            </View>
-          </>
+          <FloatingActionButtons
+            isSelecting={false}
+            showUpButton={false}
+            showFunctionButtons={showFunctionButtons}
+            onScrollToTop={scrollToTop}
+            onToggleFunctionButtons={toggleFunctionButtons}
+            onAlbumPress={handleAlbumPress}
+            onQrPress={handleQrPress}
+            onCloseFunctionButtons={closeFunctionButtons}
+            tooltip={<UploadTooltip />}
+          />
         }>
         <EmptyMessage message="당신의 네컷사진을 올려보세요!" />
       </EmptyStateLayout>
@@ -140,25 +135,16 @@ const MyPicselTemplate = () => {
             />
           </View>
 
-          <View className="absolute bottom-4 right-4">
-            {showUpButton && (
-              <View
-                style={{
-                  marginBottom: showFunctionButtons ? 200 : 56,
-                }}>
-                <UpButton onPress={scrollToTop} />
-              </View>
-            )}
-            {showFunctionButtons ? (
-              <FunctionButton
-                onAlbumPress={handleAlbumPress}
-                onQrPress={handleQrPress}
-                onClose={closeFunctionButtons}
-              />
-            ) : (
-              <AddButton onPress={toggleFunctionButtons} />
-            )}
-          </View>
+          <FloatingActionButtons
+            isSelecting={isSelecting}
+            showUpButton={showUpButton}
+            showFunctionButtons={showFunctionButtons}
+            onScrollToTop={scrollToTop}
+            onToggleFunctionButtons={toggleFunctionButtons}
+            onAlbumPress={handleAlbumPress}
+            onQrPress={handleQrPress}
+            onCloseFunctionButtons={closeFunctionButtons}
+          />
         </>
       )}
     </View>

--- a/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { View } from 'react-native';
-
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import { useYearFolder } from '@/feature/picsel/myPicsel/hooks/useYearFolder';
 import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons';
@@ -79,20 +77,16 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
         onMove={handleMove}
       />
 
-      {!isSelecting && (
-        <View className="bottom absolute right-4">
-          <FloatingActionButtons
-            isSelecting={isSelecting}
-            showUpButton={showUpButton}
-            showFunctionButtons={showFunctionButtons}
-            onToggleFunctionButtons={toggleFunctionButtons}
-            onScrollToTop={scrollToTop}
-            onAlbumPress={handleAlbumPress}
-            onQrPress={handleQrPress}
-            onCloseFunctionButtons={closeFunctionButtons}
-          />
-        </View>
-      )}
+      <FloatingActionButtons
+        isSelecting={isSelecting}
+        showUpButton={showUpButton}
+        showFunctionButtons={showFunctionButtons}
+        onToggleFunctionButtons={toggleFunctionButtons}
+        onScrollToTop={scrollToTop}
+        onAlbumPress={handleAlbumPress}
+        onQrPress={handleQrPress}
+        onCloseFunctionButtons={closeFunctionButtons}
+      />
     </ScreenLayout>
   );
 };

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 
-import { View } from 'react-native';
-
 import { PicselBookEditType } from '../../../types';
 
 import PhotoListView from '@/feature/picsel/myPicsel/components/ui/organisms/PhotoListView';
 import PhotoTextListView from '@/feature/picsel/picselBook/components/ui/organisms/PhotoTextListView';
 import { usePicselBookFolder } from '@/feature/picsel/picselBook/hooks/usePicselBookFolder';
 import EmptyStateLayout from '@/feature/picsel/shared/components/layouts/EmptyStateLayout';
-import AddButton from '@/feature/picsel/shared/components/ui/atoms/Button/AddButton';
-import FunctionButton from '@/feature/picsel/shared/components/ui/atoms/Button/FunctionButton';
 import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons';
 import EmptyMessage from '@/feature/picsel/shared/components/ui/molecules/EmptyMessage';
 import FolderHeader from '@/feature/picsel/shared/components/ui/molecules/FolderHeader';
@@ -109,20 +105,17 @@ const PicselBookFolderTemplate = ({
       {photoData.length === 0 && !isLoading ? (
         <EmptyStateLayout
           floatingButton={
-            <>
-              <UploadTooltip bottom={120} />
-              <View className="absolute bottom-14 right-1">
-                {showFunctionButtons ? (
-                  <FunctionButton
-                    onAlbumPress={handleAlbumPress}
-                    onQrPress={handleQrPress}
-                    onClose={closeFunctionButtons}
-                  />
-                ) : (
-                  <AddButton onPress={toggleFunctionButtons} />
-                )}
-              </View>
-            </>
+            <FloatingActionButtons
+              isSelecting={false}
+              showUpButton={false}
+              showFunctionButtons={showFunctionButtons}
+              onScrollToTop={scrollToTop}
+              onToggleFunctionButtons={toggleFunctionButtons}
+              onAlbumPress={handleAlbumPress}
+              onQrPress={handleQrPress}
+              onCloseFunctionButtons={closeFunctionButtons}
+              tooltip={<UploadTooltip />}
+            />
           }>
           <EmptyMessage message="픽셀북이 비어있어요" />
         </EmptyStateLayout>

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
@@ -7,9 +7,7 @@ import AddBookButton from '../organisms/AddBookButton';
 import PicselBookList from '../organisms/PicselBookList';
 
 import EmptyStateLayout from '@/feature/picsel/shared/components/layouts/EmptyStateLayout';
-import AddButton from '@/feature/picsel/shared/components/ui/atoms/Button/AddButton';
-import FunctionButton from '@/feature/picsel/shared/components/ui/atoms/Button/FunctionButton';
-import UpButton from '@/feature/picsel/shared/components/ui/atoms/Button/UpButton';
+import FloatingActionButtons from '@/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons';
 import EmptyMessage from '@/feature/picsel/shared/components/ui/molecules/EmptyMessage';
 import PicselBookBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet';
 import SelectionBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/SelectionBottomSheet';
@@ -55,17 +53,16 @@ const PicselBookTemplate = () => {
     return (
       <EmptyStateLayout
         floatingButton={
-          <View className="absolute bottom-8 right-0">
-            {showFunctionButtons ? (
-              <FunctionButton
-                onAlbumPress={handleAlbumPress}
-                onQrPress={handleQrPress}
-                onClose={closeFunctionButtons}
-              />
-            ) : (
-              <AddButton onPress={toggleFunctionButtons} />
-            )}
-          </View>
+          <FloatingActionButtons
+            isSelecting={false}
+            showUpButton={false}
+            showFunctionButtons={showFunctionButtons}
+            onScrollToTop={scrollToTop}
+            onToggleFunctionButtons={toggleFunctionButtons}
+            onAlbumPress={handleAlbumPress}
+            onQrPress={handleQrPress}
+            onCloseFunctionButtons={closeFunctionButtons}
+          />
         }>
         <View className="flex-1">
           <View className="absolute left-[41px] top-16">
@@ -116,27 +113,16 @@ const PicselBookTemplate = () => {
         />
       )}
 
-      {!isSelecting && (
-        <View className="absolute bottom-4 right-4">
-          {showUpButton && (
-            <View
-              style={{
-                marginBottom: showFunctionButtons ? 200 : 56,
-              }}>
-              <UpButton onPress={scrollToTop} />
-            </View>
-          )}
-          {showFunctionButtons ? (
-            <FunctionButton
-              onAlbumPress={handleAlbumPress}
-              onQrPress={handleQrPress}
-              onClose={closeFunctionButtons}
-            />
-          ) : (
-            <AddButton onPress={toggleFunctionButtons} />
-          )}
-        </View>
-      )}
+      <FloatingActionButtons
+        isSelecting={isSelecting}
+        showUpButton={showUpButton}
+        showFunctionButtons={showFunctionButtons}
+        onScrollToTop={scrollToTop}
+        onToggleFunctionButtons={toggleFunctionButtons}
+        onAlbumPress={handleAlbumPress}
+        onQrPress={handleQrPress}
+        onCloseFunctionButtons={closeFunctionButtons}
+      />
     </View>
   );
 };

--- a/src/feature/picsel/shared/components/layouts/EmptyStateLayout.tsx
+++ b/src/feature/picsel/shared/components/layouts/EmptyStateLayout.tsx
@@ -1,7 +1,5 @@
 import React, { Fragment, ReactNode } from 'react';
 
-import { View } from 'react-native';
-
 interface Props {
   children: ReactNode;
   floatingButton: ReactNode;
@@ -11,9 +9,7 @@ const EmptyStateLayout = ({ children, floatingButton }: Props) => {
   return (
     <Fragment>
       {children}
-      <View className="absolute -bottom-4 right-4 space-y-5">
-        {floatingButton}
-      </View>
+      {floatingButton}
     </Fragment>
   );
 };

--- a/src/feature/picsel/shared/components/ui/atoms/Button/UpButton.tsx
+++ b/src/feature/picsel/shared/components/ui/atoms/Button/UpButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pressable, View } from 'react-native';
+import { Pressable } from 'react-native';
 
 import FloatingButton from '@/shared/icons/FloatingButton';
 
@@ -10,11 +10,9 @@ interface Props {
 
 const UpButton = ({ onPress }: Props) => {
   return (
-    <View className="absolute left-[5px]">
-      <Pressable onPress={onPress}>
-        <FloatingButton shape="floating" />
-      </Pressable>
-    </View>
+    <Pressable onPress={onPress}>
+      <FloatingButton shape="floating" />
+    </Pressable>
   );
 };
 

--- a/src/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { View } from 'react-native';
 
@@ -16,6 +16,7 @@ interface FloatingActionButtonsProps {
   onAlbumPress: () => void;
   onQrPress: () => void;
   onCloseFunctionButtons: () => void;
+  tooltip?: ReactNode;
 }
 
 const FloatingActionButtons = ({
@@ -27,15 +28,17 @@ const FloatingActionButtons = ({
   onAlbumPress,
   onQrPress,
   onCloseFunctionButtons,
+  tooltip,
 }: FloatingActionButtonsProps) => {
   if (isSelecting) {
     return null;
   }
 
   return (
-    <View className="absolute bottom-11 right-4">
+    <View className="absolute bottom-3 right-4 items-end">
+      {!showFunctionButtons && tooltip}
       {showUpButton && (
-        <View className="mb-14">
+        <View className="mb-4">
           <UpButton onPress={onScrollToTop} />
         </View>
       )}

--- a/src/feature/picsel/shared/components/ui/molecules/UploadTooltip.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/UploadTooltip.tsx
@@ -7,11 +7,7 @@ import BottomRight from '@/assets/icons/tooltip/tooltip-bottom-right.svg';
 import { useFloatingAnimation } from '@/shared/hooks/useFloatingAnimation';
 import { insetShadow } from '@/shared/styles/shadows';
 
-interface UploadTooltipProps {
-  bottom?: number;
-}
-
-const UploadTooltip = ({ bottom = 70 }: UploadTooltipProps) => {
+const UploadTooltip = () => {
   const translateY = useFloatingAnimation({
     toValue: 2,
     duration1: 900,
@@ -20,9 +16,8 @@ const UploadTooltip = ({ bottom = 70 }: UploadTooltipProps) => {
 
   return (
     <Animated.View
-      className="absolute right-0.5 items-center rounded-3xl bg-primary-pink px-3 py-2"
+      className="mb-4 items-center self-end rounded-3xl bg-primary-pink px-3 py-2"
       style={{
-        bottom,
         width: scale(155),
         boxShadow: `${insetShadow.default}, 0 2px 4px 0 rgba(0, 0, 0, 0.20), -2px -4px 12px 0 rgba(255, 255, 255, 0.10)`,
         transform: [{ translateY }],


### PR DESCRIPTION
## 이슈 번호

> close #123 

## 작업 내용 및 테스트 방법

<h3>통일된 레이아웃 스펙</h3>
<ul>
<li><strong>FunctionButton / AddButton</strong>: <code>bottom: 12px</code>, <code>right: 16px</code></li>
<li><strong>UpButton / tooltip</strong>: 위 버튼과 <code>16px</code> 간격 (<code>mb-4</code>)</li>
</ul>
<h3>수정 내용</h3>
<p><strong>핵심 변경 — 포지셔닝을 <code>FloatingActionButtons</code> 하나로 통일:</strong></p>
<ul>
<li><code>FloatingActionButtons.tsx</code> — <code>absolute bottom-3 right-4 items-end</code> + <code>tooltip</code> prop 추가</li>
<li><code>UpButton.tsx</code> — 자체 <code>absolute left-[5px]</code> 제거, 순수 버튼으로</li>
<li><code>UploadTooltip.tsx</code> — <code>absolute</code> + <code>bottom</code> prop 제거, <code>mb-4 self-end</code> 흐름 기반으로</li>
<li><code>EmptyStateLayout.tsx</code> — 자체 <code>absolute -bottom-4 right-4</code> 래핑 View 제거</li>
</ul>
<p><strong>Template 통일 (6곳):</strong></p>

Before | After
-- | --
MyPicselTemplate: 직접 UpButton/FunctionButton/AddButton 조합 | FloatingActionButtons 사용
PicselBookTemplate: 직접 조합 | FloatingActionButtons 사용
YearFolderTemplate: 래핑 View className="bottom absolute right-4" | 래핑 View 제거
MonthFolderTemplate: 래핑 View absolute bottom-0 right-4 | 래핑 View 제거
PicselBookFolderTemplate: empty에서 직접 조합 | FloatingActionButtons + tooltip prop
모든 empty state: 각기 다른 bottom-8 right-0.5 등 | FloatingActionButtons 내부에서 통일

</body></html>
