### PR TITLE
🚨 Hotfix: 마이페이지 닉네임 수정 버그

### DIFF
--- a/src/feature/mypage/account/hooks/useEditNickname.ts
+++ b/src/feature/mypage/account/hooks/useEditNickname.ts
@@ -1,0 +1,57 @@
+import { useNavigation } from '@react-navigation/native';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useGetUser } from '@/feature/mypage/main/queries/useGetUser';
+import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import {
+  useNicknameValidation,
+  useKeyboardHeight,
+  updateNicknameApi,
+} from '@/shared/nickname';
+import { useToastStore } from '@/shared/store/ui/toast';
+
+export const useEditNickname = () => {
+  const navigation = useNavigation<MypageNavigationProp>();
+  const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
+  const { data: user } = useGetUser();
+  const nicknameValidation = useNicknameValidation();
+  const { keyboardHeight } = useKeyboardHeight();
+
+  const currentNickname = user?.userNickname ?? null;
+
+  const isSameAsCurrentNickname =
+    nicknameValidation.userNickname === currentNickname;
+
+  const errorMessage = isSameAsCurrentNickname
+    ? '현재 닉네임과 동일한 닉네임이에요'
+    : nicknameValidation.errorMessage;
+
+  const isSubmittable =
+    nicknameValidation.isAvailable && !isSameAsCurrentNickname;
+
+  const handleSubmit = async () => {
+    if (!isSubmittable) {
+      return;
+    }
+
+    try {
+      await updateNicknameApi(nicknameValidation.userNickname);
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+
+      showToast('닉네임 변경을 완료했어요');
+      navigation.getParent()?.goBack();
+    } catch (error) {
+      showToast('닉네임 변경에 실패했어요');
+      navigation.getParent()?.goBack();
+    }
+  };
+
+  return {
+    nicknameValidation,
+    keyboardHeight,
+    errorMessage,
+    isSubmittable,
+    handleSubmit,
+  };
+};

--- a/src/screens/mypage/editNickname/index.tsx
+++ b/src/screens/mypage/editNickname/index.tsx
@@ -1,59 +1,25 @@
 import React from 'react';
 
-import { useNavigation } from '@react-navigation/native';
 import { KeyboardAvoidingView, Platform, View, Text } from 'react-native';
 
+import { useEditNickname } from '@/feature/mypage/account/hooks/useEditNickname';
 import MypageHeader from '@/feature/mypage/shared/components/ui/molecules/MypageHeader';
-import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { HighlightedText } from '@/shared/components/HighlightedText';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import {
   NicknameInput,
   NicknameFeedback,
   NicknameEditButton,
-  useNicknameValidation,
-  useKeyboardHeight,
-  updateNicknameApi,
 } from '@/shared/nickname';
-import { useUserStore } from '@/shared/store';
-import { useToastStore } from '@/shared/store/ui/toast';
 
 const EditNicknameScreen = () => {
-  const navigation = useNavigation<MypageNavigationProp>();
-  const { showToast } = useToastStore();
   const {
-    userNickname: currentNickname,
-    setUserNickname,
-    setEmail,
-  } = useUserStore();
-  const nicknameValidation = useNicknameValidation();
-  const { keyboardHeight } = useKeyboardHeight();
-
-  const isSameAsCurrentNickname =
-    nicknameValidation.userNickname === currentNickname;
-
-  const errorMessage = isSameAsCurrentNickname
-    ? '현재 닉네임과 동일한 닉네임이에요'
-    : nicknameValidation.errorMessage;
-
-  const handleSubmit = async () => {
-    if (!nicknameValidation.isAvailable || isSameAsCurrentNickname) {
-      return;
-    }
-
-    try {
-      const response = await updateNicknameApi(nicknameValidation.userNickname);
-
-      setUserNickname(response.data.userNickname);
-      setEmail(response.data.email);
-
-      showToast('닉네임 변경을 완료했어요');
-      navigation.getParent()?.goBack();
-    } catch (error) {
-      showToast('닉네임 변경에 실패했어요');
-      navigation.getParent()?.goBack();
-    }
-  };
+    nicknameValidation,
+    keyboardHeight,
+    errorMessage,
+    isSubmittable,
+    handleSubmit,
+  } = useEditNickname();
 
   return (
     <ScreenLayout>
@@ -84,18 +50,14 @@ const EditNicknameScreen = () => {
           userNickname={nicknameValidation.userNickname}>
           <NicknameFeedback
             errorMessage={errorMessage}
-            isAvailable={
-              nicknameValidation.isAvailable && !isSameAsCurrentNickname
-            }
+            isAvailable={isSubmittable}
             length={nicknameValidation.userNickname.length}
           />
         </NicknameInput>
 
         <NicknameEditButton
           focus={nicknameValidation.focus}
-          isAvailable={
-            nicknameValidation.isAvailable && !isSameAsCurrentNickname
-          }
+          isAvailable={isSubmittable}
           keyboardHeight={keyboardHeight}
           onSubmit={handleSubmit}
         />


### PR DESCRIPTION
## 이슈 번호

> close #125 

## 작업 내용 및 테스트 방법

### 1. 닉네임이 수정되지 않는 버그
`handleSubmit`에서 닉네임 변경 성공 후 `queryClient.invalidateQueries({ queryKey: ['user'] })`를 추가했습니다. 
캐시를 refetch하여 변경된 닉네임이 즉시 반영하는 것으로 수정하였습니다 👍🏻 

### 2. 마이페이지 - 닉네임 수정 화면 리팩토링
<h3>책임 분리</h3>

레이어 | 파일 | 책임
-- | -- | --
훅 | useEditNickname.ts | 비즈니스 로직 (검증, API 호출, store/쿼리 업데이트, 네비게이션, 토스트)
화면 | EditNicknameScreen | 순수 UI 렌더링만

**제거한 것:**
- `useUserStore` 의존 — `setUserNickname`, `setEmail` 수동 동기화 제거
- `response.data` 사용 — API 응답값을 직접 store에 넣던 코드 제거

**변경:**
- 현재 닉네임 소스: `useUserStore` → `useGetUser()` (React Query)
- `handleSubmit`: API 호출 → `invalidateQueries`만 → 서버 상태가 단일 진실 공급원(SSOT)

**책임이 명확해진 흐름:**
- `updateNicknameApi` → 서버에 변경 요청
- `invalidateQueries` → 서버 상태 갱신 트리거
- 화면 반영은 React Query의 refetch가 자동 처리

-> zustand의 `userNickname`은 더 이상 닉네임 표시/비교에 사용되지 않고, 인증 관련 용도로만 남게 됩니다 💯 