### PR TITLE
🚨 Hotfix: 재로그인시 로그인 화면에서 툴팁이 나타나지 않는 버그

### DIFF
--- a/src/feature/mypage/withdrawal/hooks/useWithdrawalSuccess.ts
+++ b/src/feature/mypage/withdrawal/hooks/useWithdrawalSuccess.ts
@@ -5,23 +5,23 @@ import { AppState } from 'react-native';
 import { useUserStore } from '@/shared/store';
 
 export const useWithdrawalSuccess = () => {
-  const { logout } = useUserStore();
-  const hasLoggedOut = useRef(false);
+  const { withdraw } = useUserStore();
+  const hasWithdrawn = useRef(false);
 
   useEffect(() => {
     return () => {
-      if (!hasLoggedOut.current) {
-        logout();
+      if (!hasWithdrawn.current) {
+        withdraw();
       }
     };
-  }, [logout]);
+  }, [withdraw]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (nextAppState === 'background' || nextAppState === 'inactive') {
-        if (!hasLoggedOut.current) {
-          logout();
-          hasLoggedOut.current = true;
+        if (!hasWithdrawn.current) {
+          withdraw();
+          hasWithdrawn.current = true;
         }
       }
     });
@@ -29,11 +29,11 @@ export const useWithdrawalSuccess = () => {
     return () => {
       subscription.remove();
     };
-  }, [logout]);
+  }, [withdraw]);
 
   const handleComplete = () => {
-    hasLoggedOut.current = true;
-    logout();
+    hasWithdrawn.current = true;
+    withdraw();
   };
 
   return {

--- a/src/shared/store/user/index.ts
+++ b/src/shared/store/user/index.ts
@@ -20,6 +20,7 @@ interface UserState {
   setEmail: (email: string | null) => void;
 
   logout: () => void;
+  withdraw: () => void;
 }
 
 export const useUserStore = create<UserState>()(
@@ -46,6 +47,15 @@ export const useUserStore = create<UserState>()(
       setEmail: (email: UserState['email']) => set({ email }),
 
       logout: () =>
+        set({
+          socialAccessToken: null,
+          accessToken: null,
+          refreshToken: null,
+          userNickname: null,
+          email: null,
+        }),
+
+      withdraw: () =>
         set({
           socialAccessToken: null,
           accessToken: null,


### PR DESCRIPTION
## 이슈 번호

> close #129 

## 작업 내용 및 테스트 방법

<p><strong>원인</strong>: <code>logout()</code> 시 <code>userSocialType</code>을 <code>null</code>로 초기화하여, 로그아웃 후 로그인 화면 진입 시 어떤 버튼에도 <code>userSocialType === type</code> 조건이 만족되지 않아 <code>LoginTooltip</code>이 렌더링되지 않았습니다.</p>
<p><strong>수정 내용</strong>:</p>

파일 | 변경
-- | --
src/shared/store/user/index.ts | logout()에서 userSocialType 초기화 제거 → 로그아웃 후에도 마지막 로그인 플랫폼 유지
src/shared/store/user/index.ts | withdraw() 함수 추가 → 회원탈퇴 시에는 userSocialType 포함 전체 초기화
useWithdrawalSuccess.ts | logout() → withdraw() 로 변경


<ul>
<li><strong>로그아웃</strong>: <code>userSocialType</code> 유지 → 재로그인 시 툴팁 표시 ✅</li>
<li><strong>회원탈퇴</strong>: <code>userSocialType</code> 포함 전체 초기화 → 새 계정으로 시작 ✅</li>
</ul></body></html>