### PR TITLE
♻️ Refactor: 회원가입 플로우

### DIFF
--- a/src/feature/auth/login/model/loginService.ts
+++ b/src/feature/auth/login/model/loginService.ts
@@ -2,10 +2,10 @@ import { loginApi } from '../api/loginApi';
 import { loginStrategies } from '../lib/socialStrategies';
 import { LoginRequest, LoginResponse, SocialTypes } from '../types';
 
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { useUserStore } from '@/shared/store';
 
-export const useLoginService = (navigation: RootStackNavigationProp) => {
+export const useLoginService = (navigation: SignupNavigationProp) => {
   const {
     setSocialAccessToken,
     setAccessToken,
@@ -36,7 +36,7 @@ export const useLoginService = (navigation: RootStackNavigationProp) => {
           setUserSocialType(response.data.socialType);
         }, 500);
 
-        navigation.navigate('SignupRoute');
+        navigation.navigate('NicknameInput');
       }
     } catch (err) {
       console.error('로그인 실패:', err);

--- a/src/feature/auth/signup/constants/selectBrand.ts
+++ b/src/feature/auth/signup/constants/selectBrand.ts
@@ -1,0 +1,7 @@
+export const SELECT_BRAND_TEXT = {
+  HEADER: '회원가입',
+  TITLE: '좋아하는 포토부스\n[브랜드]를 선택해주세요',
+  SUB: '좋아하는 브랜드를 저장하면 가까운 매장을\n검색 없이 바로 확인할 수 있어요!',
+  MARKETING_TOAST:
+    '마케팅 정보 수신에 동의했어요\n설정에서 수신여부를 변경할 수 있어요',
+} as const;

--- a/src/feature/auth/signup/model/useUserSignup.ts
+++ b/src/feature/auth/signup/model/useUserSignup.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { signupApi } from '../api/signupApi';
 
 import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { useUserStore } from '@/shared/store';
 
 interface Props {
   socialAccessToken: string;
@@ -21,6 +22,8 @@ export const useUserSignup = ({
   closeModal,
   navigation,
 }: Props) => {
+  const { setAccessToken, setSocialAccessToken } = useUserStore();
+
   const agreementData = useMemo(
     () => ({
       ageConsent: checkedStates[0],
@@ -32,30 +35,34 @@ export const useUserSignup = ({
     [checkedStates],
   );
 
-  const handleSignup = useCallback(async () => {
+  const saveTokens = (accessToken: string) => {
+    setAccessToken(accessToken);
+    setSocialAccessToken(null);
+  };
+
+  const navigateToSelectBrand = (refreshToken: string) => {
+    navigation.navigate('SelectBrand', {
+      marketingConsent: agreementData.marketingConsent,
+      refreshToken,
+    });
+  };
+
+  const handleSignup = async () => {
     try {
-      await signupApi({
+      const response = await signupApi({
         socialAccessToken,
         socialType: userSocialType,
         userNickname,
         userAgreementConsentRequestDto: agreementData,
       });
 
+      saveTokens(response.accessToken);
       closeModal();
-      navigation.navigate('SelectBrand', {
-        marketingConsent: agreementData.marketingConsent,
-      });
+      navigateToSelectBrand(response.refreshToken);
     } catch (err) {
       console.error('Signup failed:', err);
     }
-  }, [
-    socialAccessToken,
-    userSocialType,
-    userNickname,
-    agreementData,
-    closeModal,
-    navigation,
-  ]);
+  };
 
   return { handleSignup };
 };

--- a/src/feature/auth/signup/model/useUserSignup.ts
+++ b/src/feature/auth/signup/model/useUserSignup.ts
@@ -42,7 +42,9 @@ export const useUserSignup = ({
       });
 
       closeModal();
-      navigation.navigate('SelectBrand');
+      navigation.navigate('SelectBrand', {
+        marketingConsent: agreementData.marketingConsent,
+      });
     } catch (err) {
       console.error('Signup failed:', err);
     }

--- a/src/feature/brand/model/hooks/useSelectedBrands.ts
+++ b/src/feature/brand/model/hooks/useSelectedBrands.ts
@@ -1,10 +1,12 @@
-import { NavigationProp } from '@react-navigation/native';
-
 import { favoriteBrandApi } from '../../api/favoriteBrandApi';
 
+import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { useSelectedBrandsStore } from '@/shared/store';
 
-export const useSelectedBrands = (navigation: NavigationProp<any>) => {
+export const useSelectedBrands = (
+  navigation: SignupNavigationProp,
+  refreshToken?: string,
+) => {
   const { selectedList } = useSelectedBrandsStore();
 
   const actualCount = selectedList.some(b => b.brandId === 'NONE')
@@ -22,7 +24,7 @@ export const useSelectedBrands = (navigation: NavigationProp<any>) => {
       console.log(err);
     }
 
-    navigation.navigate('SignupSuccess');
+    navigation.navigate('SignupSuccess', { refreshToken });
   };
 
   return {

--- a/src/feature/brand/model/hooks/useSelectedBrands.ts
+++ b/src/feature/brand/model/hooks/useSelectedBrands.ts
@@ -10,7 +10,7 @@ export const useSelectedBrands = (navigation: NavigationProp<any>) => {
   const actualCount = selectedList.some(b => b.brandId === 'NONE')
     ? 0
     : selectedList.length;
-  const isDisabled = selectedList.length > 0;
+  const isDisabled = selectedList.length < 1;
 
   const handleSelectedCompleted = async () => {
     const brandIds = selectedList.map(value => value.brandId);

--- a/src/feature/brand/ui/organisms/BrandGridList.tsx
+++ b/src/feature/brand/ui/organisms/BrandGridList.tsx
@@ -85,7 +85,7 @@ const BrandGridList = ({
           {/* 3개 이하일 경우 공백 채우기 */}
           {row.length < 3 &&
             Array.from({ length: 3 - row.length }).map((_, i) => (
-              <View key={`empty-${i}`} className="flex-1" />
+              <View key={`empty-${i}`} className="flex-1 px-4" />
             ))}
         </View>
       ))}

--- a/src/feature/brand/ui/organisms/SelectButton.tsx
+++ b/src/feature/brand/ui/organisms/SelectButton.tsx
@@ -26,7 +26,7 @@ const SelectButton = ({
   onPress,
 }: Props) => {
   return (
-    <View className="w-full items-center">
+    <View className="absolute bottom-10 w-full items-center">
       <Button
         color={disabled ? 'disabled' : 'active'}
         textColor="white"

--- a/src/feature/mypage/account/hooks/useAccountMenu.tsx
+++ b/src/feature/mypage/account/hooks/useAccountMenu.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { MypageNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
+import { clearUserData } from '@/shared/lib/clearUserData';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { useUserStore } from '@/shared/store';
 
@@ -13,8 +14,9 @@ export const useAccountMenu = () => {
   const { logout } = useUserStore();
 
   const executeLogout = useCallback(() => {
+    clearUserData();
     logout();
-  }, [logout, navigation]);
+  }, [logout]);
 
   const handleLogout = () => {
     showConfirmModal('', executeLogout, {

--- a/src/feature/mypage/withdrawal/hooks/useWithdrawalSuccess.ts
+++ b/src/feature/mypage/withdrawal/hooks/useWithdrawalSuccess.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { AppState } from 'react-native';
 
+import { clearUserData } from '@/shared/lib/clearUserData';
 import { useUserStore } from '@/shared/store';
 
 export const useWithdrawalSuccess = () => {
@@ -33,6 +34,7 @@ export const useWithdrawalSuccess = () => {
 
   const handleComplete = () => {
     hasWithdrawn.current = true;
+    clearUserData();
     withdraw();
   };
 

--- a/src/navigation/route/signup/index.tsx
+++ b/src/navigation/route/signup/index.tsx
@@ -14,7 +14,7 @@ export type SignupNavigationProps = {
   Onboarding: undefined;
   Login: undefined;
   NicknameInput: undefined;
-  SelectBrand: undefined;
+  SelectBrand: { marketingConsent?: boolean } | undefined;
   BrandSearch: { variant: 'signup' | 'mypage' };
   SignupSuccess: undefined;
   Home: undefined;

--- a/src/navigation/route/signup/index.tsx
+++ b/src/navigation/route/signup/index.tsx
@@ -14,9 +14,9 @@ export type SignupNavigationProps = {
   Onboarding: undefined;
   Login: undefined;
   NicknameInput: undefined;
-  SelectBrand: { marketingConsent?: boolean } | undefined;
+  SelectBrand: { marketingConsent: boolean; refreshToken: string } | undefined;
   BrandSearch: { variant: 'signup' | 'mypage' };
-  SignupSuccess: undefined;
+  SignupSuccess: { refreshToken: string };
   Home: undefined;
 };
 

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -26,7 +26,7 @@ interface TextInputWithDefaultProps extends TextInput {
   defaultProps?: { allowFontScaling?: boolean };
 }
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 2,

--- a/src/screens/brandSearch/index.tsx
+++ b/src/screens/brandSearch/index.tsx
@@ -115,7 +115,7 @@ const BrandSearchScreen = () => {
     variant === 'signup' ? selectBrand : handleSelectBrandMypage;
 
   return (
-    <ScreenLayout>
+    <ScreenLayout edges={['top', 'left', 'right']}>
       {variant === 'signup' ? (
         <SignupHeader text="브랜드 검색" back onPressIn={handleGoBack} />
       ) : (
@@ -137,9 +137,9 @@ const BrandSearchScreen = () => {
           ref={scrollViewRef}
           onScroll={handleScroll}
           scrollEventThrottle={16}
-          showsVerticalScrollIndicator
+          showsVerticalScrollIndicator={false}
           indicatorStyle="black"
-          contentContainerStyle={{ paddingBottom: 50 }}
+          contentContainerStyle={{ paddingBottom: 100 }}
           keyboardShouldPersistTaps="handled">
           <BrandGridList
             brandList={searchedList}
@@ -170,7 +170,7 @@ const BrandSearchScreen = () => {
       )}
 
       {variant === 'mypage' && mypageSelectedBrands.length > 0 && (
-        <View className="px-4 pb-2 pt-2">
+        <View className="absolute bottom-10 w-full px-4">
           <Button
             className="w-full"
             text={`선택완료(${mypageSelectedBrands.length})`}

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -6,12 +6,12 @@ import { View } from 'react-native';
 import { useLoginService } from '@/feature/auth/login/model/loginService';
 import { SocialTypes } from '@/feature/auth/login/types';
 import LoginIntro from '@/feature/auth/login/ui/organisms/LoginIntro';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import SocialLoginButton from '@/shared/ui/molecules/SocialLoginButton';
 
 const LoginScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
+  const navigation = useNavigation<SignupNavigationProp>();
   const { handleSocialLogin } = useLoginService(navigation);
 
   return (

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -45,7 +45,7 @@ const SelectBrandScreen = () => {
   }, []);
 
   return (
-    <ScreenLayout className="relative">
+    <ScreenLayout className="relative" edges={['top', 'left', 'right']}>
       <SignupHeader
         text={SELECT_BRAND_TEXT.HEADER}
         search
@@ -68,7 +68,7 @@ const SelectBrandScreen = () => {
         className="pt-[4px]"
         showsVerticalScrollIndicator
         indicatorStyle="black"
-        contentContainerStyle={{ paddingBottom: 20 }}>
+        contentContainerStyle={{ paddingBottom: 100 }}>
         <BrandGridList
           brandList={brandList}
           selectedList={selectedList}

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -65,10 +65,10 @@ const SelectBrandScreen = () => {
         ref={scrollViewRef}
         onScroll={handleScroll}
         scrollEventThrottle={16}
-        className="pt-[14px]"
+        className="pt-[4px]"
         showsVerticalScrollIndicator
         indicatorStyle="black"
-        contentContainerStyle={{ paddingBottom: 50 }}>
+        contentContainerStyle={{ paddingBottom: 20 }}>
         <BrandGridList
           brandList={brandList}
           selectedList={selectedList}

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { ScrollView } from 'react-native';
 
 import SignupHeader from '@/feature/auth/signup/ui/organisms/SignupHeader';
@@ -11,12 +11,16 @@ import { useGetBrandsList } from '@/feature/brand/queries/useGetBrandList';
 import BrandGridList from '@/feature/brand/ui/organisms/BrandGridList';
 import SelectButton from '@/feature/brand/ui/organisms/SelectButton';
 import SelectedBrand from '@/feature/brand/ui/organisms/SelectedBrand';
+import { SignupNavigationProps } from '@/navigation/route/signup';
 import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { useBrandListStore, useSelectedBrandsStore } from '@/shared/store';
+import { useToastStore } from '@/shared/store/ui/toast';
 
 const SelectBrandScreen = () => {
   const navigation = useNavigation<SignupNavigationProp>();
+  const route = useRoute<RouteProp<SignupNavigationProps, 'SelectBrand'>>();
+  const { showToast } = useToastStore();
 
   const { data: brands } = useGetBrandsList();
   const { setBrandList, brandList } = useBrandListStore();
@@ -32,6 +36,15 @@ const SelectBrandScreen = () => {
       setBrandList(brands);
     }
   }, [brands]);
+
+  useEffect(() => {
+    if (route.params?.marketingConsent) {
+      showToast(
+        '마케팅 정보 수신에 동의했어요\n설정에서 수신여부를 변경할 수 있어요',
+        { height: 60 },
+      );
+    }
+  }, []);
 
   return (
     <ScreenLayout className="relative">

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -30,7 +30,7 @@ const SelectBrandScreen = () => {
   const { handleScroll, showFloatingButton, scrollToTop, scrollViewRef } =
     useHandleScroll();
   const { handleSelectedCompleted, actualCount, isDisabled } =
-    useSelectedBrands(navigation);
+    useSelectedBrands(navigation, route.params?.refreshToken);
 
   useEffect(() => {
     if (brands) {

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { ScrollView } from 'react-native';
 
+import { SELECT_BRAND_TEXT } from '@/feature/auth/signup/constants/selectBrand';
 import SignupHeader from '@/feature/auth/signup/ui/organisms/SignupHeader';
 import SignupIntro from '@/feature/auth/signup/ui/organisms/SignupIntro';
 import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
@@ -39,17 +40,14 @@ const SelectBrandScreen = () => {
 
   useEffect(() => {
     if (route.params?.marketingConsent) {
-      showToast(
-        '마케팅 정보 수신에 동의했어요\n설정에서 수신여부를 변경할 수 있어요',
-        { height: 60 },
-      );
+      showToast(SELECT_BRAND_TEXT.MARKETING_TOAST, { height: 60 });
     }
   }, []);
 
   return (
     <ScreenLayout className="relative">
       <SignupHeader
-        text="회원가입"
+        text={SELECT_BRAND_TEXT.HEADER}
         search
         onPressIn={() =>
           navigation.navigate('BrandSearch', { variant: 'signup' })
@@ -57,10 +55,8 @@ const SelectBrandScreen = () => {
       />
 
       <SignupIntro
-        title={'좋아하는 포토부스\n[브랜드]를 선택해주세요'}
-        sub={
-          '좋아하는 브랜드를 저장하면 가까운 매장을\n검색 없이 바로 확인할 수 있어요!'
-        }
+        title={SELECT_BRAND_TEXT.TITLE}
+        sub={SELECT_BRAND_TEXT.SUB}
       />
 
       <SelectedBrand onPressIn={removeBrand} selectedList={selectedList} />

--- a/src/screens/signup/signupSuccess/index.tsx
+++ b/src/screens/signup/signupSuccess/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 
-import { useNavigation } from '@react-navigation/native';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { View } from 'react-native';
 
 import SuccessHeader from '@/feature/success/ui/organisms/SuccessHeader';
-import { SignupNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { SignupNavigationProps } from '@/navigation/route/signup';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
+import { useUserStore } from '@/shared/store';
 import Button from '@/shared/ui/atoms/Button';
 
 const SignupSuccessScreen = () => {
-  const navigation = useNavigation<SignupNavigationProp>();
+  const route = useRoute<RouteProp<SignupNavigationProps, 'SignupSuccess'>>();
+  const { setRefreshToken } = useUserStore();
 
   return (
     <ScreenLayout className="bg-primary-black">
@@ -20,7 +22,7 @@ const SignupSuccessScreen = () => {
           text="시작하기"
           color="white"
           textColor="pink"
-          onPressIn={() => navigation.navigate('Home')}
+          onPressIn={() => setRefreshToken(route.params.refreshToken)}
         />
       </View>
     </ScreenLayout>

--- a/src/shared/components/layouts/ScreenLayout.tsx
+++ b/src/shared/components/layouts/ScreenLayout.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 
 import { ViewProps } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Edge, SafeAreaView } from 'react-native-safe-area-context';
 
 interface Props extends ViewProps {
   children: React.ReactNode;
+  edges?: Edge[];
 }
 
-const ScreenLayout = ({ children, ...rest }: Props) => {
+const ScreenLayout = ({ children, edges, ...rest }: Props) => {
   return (
-    <SafeAreaView className="h-full w-full flex-1 bg-white" {...rest}>
+    <SafeAreaView
+      className="h-full w-full flex-1 bg-white"
+      edges={edges}
+      {...rest}>
       {children}
     </SafeAreaView>
   );

--- a/src/shared/lib/clearUserData.ts
+++ b/src/shared/lib/clearUserData.ts
@@ -1,0 +1,7 @@
+import { queryClient } from '@/providers/AppProvider';
+import { useSelectedBrandsStore } from '@/shared/store';
+
+export const clearUserData = () => {
+  queryClient.clear();
+  useSelectedBrandsStore.getState().resetSelectedBrands();
+};

--- a/src/shared/store/brand/selectBrands/index.ts
+++ b/src/shared/store/brand/selectBrands/index.ts
@@ -11,6 +11,7 @@ interface BrandStore {
   selectedList: SelectedBrand[];
   selectBrand: (brandId: string, name: string) => void;
   removeBrand: (brandId: string) => void;
+  resetSelectedBrands: () => void;
 }
 
 export const useSelectedBrandsStore = create<BrandStore>()(
@@ -50,6 +51,8 @@ export const useSelectedBrandsStore = create<BrandStore>()(
             list => list.brandId !== brandId,
           ),
         })),
+
+      resetSelectedBrands: () => set({ selectedList: [] }),
     }),
     {
       name: 'selected-brands-storage', // AsyncStorage key

--- a/src/shared/store/ui/Toast/index.ts
+++ b/src/shared/store/ui/Toast/index.ts
@@ -1,10 +1,19 @@
 import { create } from 'zustand';
 
+interface ToastOptions {
+  marginBottom?: number;
+  height?: number;
+}
+
 interface ToastStore {
   message: string;
   visible: boolean;
   marginBottom: number;
-  showToast: (message: string, marginBottom?: number) => void;
+  height: number;
+  showToast: (
+    message: string,
+    optionsOrMarginBottom?: ToastOptions | number,
+  ) => void;
   hideToast: () => void;
 }
 
@@ -12,11 +21,21 @@ export const useToastStore = create<ToastStore>(set => ({
   message: '',
   visible: false,
   marginBottom: 12,
+  height: 40,
 
-  showToast: (message, marginBottom = 12) =>
-    set(() => {
-      return { message, marginBottom, visible: true };
-    }),
+  showToast: (message, optionsOrMarginBottom) => {
+    const options =
+      typeof optionsOrMarginBottom === 'number'
+        ? { marginBottom: optionsOrMarginBottom }
+        : optionsOrMarginBottom;
+
+    set({
+      message,
+      marginBottom: options?.marginBottom ?? 12,
+      height: options?.height ?? 40,
+      visible: true,
+    });
+  },
 
   hideToast: () => set({ visible: false }),
 }));

--- a/src/shared/store/user/index.ts
+++ b/src/shared/store/user/index.ts
@@ -68,6 +68,14 @@ export const useUserStore = create<UserState>()(
     {
       name: 'auth-storage',
       storage: createJSONStorage(() => AsyncStorage),
+      partialize: state => ({
+        socialAccessToken: state.socialAccessToken,
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
+        userSocialType: state.userSocialType,
+        userNickname: state.userNickname,
+        email: state.email,
+      }),
     },
   ),
 );

--- a/src/shared/ui/atoms/Toast/index.tsx
+++ b/src/shared/ui/atoms/Toast/index.tsx
@@ -21,7 +21,7 @@ import {
 import { useToastStore } from '@/shared/store/ui/toast';
 
 const Toast = () => {
-  const { message, visible, hideToast, marginBottom } = useToastStore();
+  const { message, visible, hideToast, marginBottom, height } = useToastStore();
   const insets = useSafeAreaInsets();
 
   const [shouldRender, setShouldRender] = useState(false);
@@ -156,7 +156,8 @@ const Toast = () => {
         locations={GRADIENT_LOCATIONS}
         start={{ x: 0.5, y: 0 }}
         end={{ x: 0.5, y: 1 }}
-        className="h-[40px] w-[288px] items-center justify-center rounded-xl">
+        className="w-[288px] items-center justify-center rounded-xl"
+        style={{ height }}>
         <Text className="text-center text-white body-rg-02">
           {displayMessage}
         </Text>


### PR DESCRIPTION
## 이슈 번호

> close #131, close #132 

## 작업 내용 및 테스트 방법

- 회원가입 플로우 네비게이션 구조 개선 (`pendingRefreshToken` 제거 → params 기반 `refreshToken` 전달)
- 로그아웃/회원탈퇴 시 유저 데이터 초기화를 `clearUserData()` 유틸 함수로 통합
- LoginTooltip 렌더링 버그 수정 (로그아웃 시 `userSocialType` 유지)
- 마케팅 수신 동의 토스트 구현 (SelectBrand 화면에서 params 기반 노출)
- 브랜드 선택/검색 화면 UI 개선

## Changes

### 🐛 Bug Fix
- **LoginTooltip 미노출**: `logout()` 시 `userSocialType` 초기화 제거, `withdraw()` 분리
- **Signup Route 네비게이션 에러**: `RootStackNavigationProp` → `SignupNavigationProp` + `navigate('NicknameInput')` 수정
- **로그아웃 후 이전 닉네임/브랜드 유지**: `queryClient.clear()` + `resetSelectedBrands()` 추가

### ♻️ Refactor
- **회원가입 토큰 플로우**: `pendingRefreshToken`/`activateRefreshToken` 제거 → `refreshToken`을 navigation params로 전달, SignupSuccess에서 `setRefreshToken` 호출 시 `App.tsx` 자동 전환
- **`handleSignup` 단일책임원칙 적용**: `saveTokens`, `navigateToSelectBrand` 함수 분리
- **`clearUserData()` 유틸 함수**: `queryClient.clear()` + `resetSelectedBrands()`를 하나로 통합
- **SelectBrand 텍스트 상수화**: `SELECT_BRAND_TEXT` 상수 파일 분리
- **Toast store `height` 옵션 추가**: 기존 `showToast(msg, marginBottom)` 하위 호환 유지

### ✨ Feature
- **마케팅 수신 동의 토스트**: TermsBottomSheet → SelectBrand params 전달 → 토스트 노출 (60px)
- **ScreenLayout `edges` prop 추가**: 하단 SafeArea 선택적 제외 가능

### 💄 Design
- **SelectButton absolute 하단 고정**: 스크롤 시 브랜드가 버튼 뒤로 보이도록
- **BrandGridList 그리드 정렬**: 3개 미만일 때 빈 칸 `px-4` 추가
- **브랜드 선택/검색 화면**: 하단 SafeArea 제외 (`edges={['top', 'left', 'right']}`)

## To reviewers
해당 PR merge 되면 빠르게 test flight 재배포 진행해볼게요!
수린님께서도 회원가입 다시 진행하시면서 테스트 한번씩 부탁드리겠습니다 👍🏻 