### PR TITLE
✨ Feat: 데이터 fetching

### DIFF
--- a/src/feature/map/hooks/useFavoriteToggle.ts
+++ b/src/feature/map/hooks/useFavoriteToggle.ts
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import { useToggleFavoriteBrand } from '@/feature/brand/mutations/useToggleFavoriteBrand';
 import { useFavoriteStore } from '@/shared/store';
 import { useToastStore } from '@/shared/store/ui/toast';
@@ -10,20 +8,17 @@ interface Props {
 }
 
 export const useFavoriteToggle = ({ brandId, isFavorite }: Props) => {
-  const { optimisticFavorites, toggleOptimisticFavorite, syncFavorite } =
-    useFavoriteStore();
+  const {
+    optimisticFavorites,
+    toggleOptimisticFavorite,
+    setOptimisticFavorite,
+  } = useFavoriteStore();
   const { mutate: toggleFavorite, isPending } = useToggleFavoriteBrand();
   const { showToast } = useToastStore();
 
   const optimisticFavorite = brandId
     ? (optimisticFavorites[brandId] ?? isFavorite)
     : isFavorite;
-
-  useEffect(() => {
-    if (brandId && optimisticFavorites[brandId] === undefined) {
-      syncFavorite(brandId, isFavorite);
-    }
-  }, [brandId, isFavorite, syncFavorite, optimisticFavorites]);
 
   const handleToggleFavorite = (margin: number) => {
     if (!brandId) {
@@ -40,21 +35,18 @@ export const useFavoriteToggle = ({ brandId, isFavorite }: Props) => {
       margin,
     );
 
-    if (!isPending) {
-      toggleFavorite(
-        {
-          brandId,
-          action,
+    toggleFavorite(
+      {
+        brandId,
+        action,
+      },
+      {
+        onError: () => {
+          setOptimisticFavorite(brandId, isFavorite);
+          showToast('찜 처리 중 오류가 발생했어요', margin);
         },
-        {
-          onError: () => {
-            toggleOptimisticFavorite(brandId);
-            syncFavorite(brandId, isFavorite);
-            showToast('찜 처리 중 오류가 발생했어요', margin);
-          },
-        },
-      );
-    }
+      },
+    );
   };
 
   return {

--- a/src/feature/map/hooks/useHomeScreen.ts
+++ b/src/feature/map/hooks/useHomeScreen.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { NaverMapViewRef } from '@mj-studio/react-native-naver-map';
 import { useNavigation } from '@react-navigation/native';
@@ -16,6 +16,7 @@ import { useStoreFavorite } from './useStoreFavorite';
 
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { useModal } from '@/shared/hooks/useModal';
+import { useFavoriteStore } from '@/shared/store';
 
 export const useHomeScreen = () => {
   const mapRef = useRef<NaverMapViewRef>(null);
@@ -69,6 +70,19 @@ export const useHomeScreen = () => {
   });
 
   const isFavorite = useStoreFavorite(stores?.data?.brands, selectedStore);
+
+  const { syncFavorites } = useFavoriteStore();
+
+  useEffect(() => {
+    const brands = stores?.data?.brands;
+    if (brands && brands.length > 0) {
+      const favoritesMap = brands.reduce<Record<string, boolean>>(
+        (acc, b) => ({ ...acc, [b.brandId]: b.isFavorite }),
+        {},
+      );
+      syncFavorites(favoritesMap);
+    }
+  }, [stores?.data?.brands, syncFavorites]);
 
   return {
     // Refs

--- a/src/feature/map/ui/organisms/MapOverlay.tsx
+++ b/src/feature/map/ui/organisms/MapOverlay.tsx
@@ -24,20 +24,10 @@ interface Props {
 
 const MapOverlay = memo(
   ({ brand = [], store = [], selectedMarkerId, handleMarkerPress }: Props) => {
-    const { optimisticFavorites, syncFavorite } = useFavoriteStore();
+    const { optimisticFavorites } = useFavoriteStore();
     const { mapMode, searchedStore, selectedStoreId, keepSearchedMarker } =
       useMapLocationStore();
     const [hasBeenSelected, setHasBeenSelected] = useState(false);
-
-    useEffect(() => {
-      if (brand.length > 0) {
-        brand.forEach(b => {
-          if (optimisticFavorites[b.brandId] === undefined) {
-            syncFavorite(b.brandId, b.isFavorite);
-          }
-        });
-      }
-    }, [brand, optimisticFavorites, syncFavorite]);
 
     useEffect(() => {
       const isSearchMode = mapMode === 'search' && selectedStoreId;

--- a/src/feature/mypage/main/components/ui/atoms/NicknameSectionSkeleton.tsx
+++ b/src/feature/mypage/main/components/ui/atoms/NicknameSectionSkeleton.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+
+import { Animated, View } from 'react-native';
+
+const NicknameSectionSkeleton = () => {
+  const shimmerAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmerAnim, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(shimmerAnim, {
+          toValue: 0,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [shimmerAnim]);
+
+  const opacity = shimmerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.3, 0.7],
+  });
+
+  return (
+    <View
+      className="flex w-full flex-row items-center px-5 py-2"
+      style={{ gap: 8 }}>
+      <Animated.View
+        className="h-6 w-28 rounded bg-gray-200"
+        style={{ opacity }}
+      />
+      <Animated.View
+        className="h-6 w-6 rounded bg-gray-200"
+        style={{ opacity }}
+      />
+    </View>
+  );
+};
+
+export default NicknameSectionSkeleton;

--- a/src/feature/mypage/main/hooks/usePrefetchMyPage.ts
+++ b/src/feature/mypage/main/hooks/usePrefetchMyPage.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+import { userQueryOptions } from '../queries/useGetUser';
+
+import { queryClient } from '@/providers/AppProvider';
+
+export const usePrefetchMyPage = () => {
+  useEffect(() => {
+    queryClient.prefetchQuery(userQueryOptions);
+  }, []);
+};

--- a/src/feature/mypage/main/queries/useGetUser.ts
+++ b/src/feature/mypage/main/queries/useGetUser.ts
@@ -2,12 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getUserApi, UserData } from '../api/getUserApi';
 
+export const userQueryOptions = {
+  queryKey: ['user'] as const,
+  queryFn: getUserApi,
+  staleTime: 1000 * 60 * 5,
+  gcTime: 1000 * 60 * 10,
+  retry: 2,
+};
+
 export const useGetUser = () => {
-  return useQuery<UserData>({
-    queryKey: ['user'],
-    queryFn: getUserApi,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 10,
-    retry: 2,
-  });
+  return useQuery<UserData>(userQueryOptions);
 };

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -14,6 +14,7 @@ import BrandDetailBottomSheet from '@/feature/map/ui/organisms/BrandDetailBottom
 import EmptyBottomSheet from '@/feature/map/ui/organisms/EmptyBottomSheet';
 import MapActionButton from '@/feature/map/ui/organisms/MapActionButton';
 import MapOverlay from '@/feature/map/ui/organisms/MapOverlay';
+import { usePrefetchMyPage } from '@/feature/mypage/main/hooks/usePrefetchMyPage';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { useRequestNotificationPermission } from '@/shared/hooks/useRequestNotificationPermission';
 import { useMapLocationStore } from '@/shared/store';
@@ -21,6 +22,7 @@ import Input from '@/shared/ui/atoms/Input';
 
 const HomeScreen = () => {
   useRequestNotificationPermission();
+  usePrefetchMyPage();
   const { showBrandTooltip, fadeAnim } = useBrandTooltipOnce();
 
   const {

--- a/src/screens/mypage/index.tsx
+++ b/src/screens/mypage/index.tsx
@@ -5,6 +5,7 @@ import { View } from 'react-native';
 
 import MypageTopBar from '@/feature/mypage/main/components/ui/atoms/MypageTopBar';
 import NicknameSection from '@/feature/mypage/main/components/ui/atoms/NicknameSection';
+import NicknameSectionSkeleton from '@/feature/mypage/main/components/ui/atoms/NicknameSectionSkeleton';
 import MypageMenuItem from '@/feature/mypage/main/components/ui/molecules/MypageMenuItem';
 import { useMypageMenu } from '@/feature/mypage/main/hooks/useMypageMenu';
 import { useGetUser } from '@/feature/mypage/main/queries/useGetUser';
@@ -14,7 +15,7 @@ import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import StarIcons from '@/shared/icons/StarIcons';
 
 const MypageScreen = () => {
-  const { data: user } = useGetUser();
+  const { data: user, isLoading } = useGetUser();
   const { menuItems } = useMypageMenu();
   const navigation = useNavigation<RootStackNavigationProp>();
 
@@ -31,14 +32,18 @@ const MypageScreen = () => {
         }
       />
 
-      <NicknameSection
-        nickname={user?.userNickname ?? null}
-        onPressEdit={() =>
-          navigation.navigate('MypageRoute', {
-            screen: 'EditNicknameScreen',
-          })
-        }
-      />
+      {isLoading ? (
+        <NicknameSectionSkeleton />
+      ) : (
+        <NicknameSection
+          nickname={user?.userNickname ?? ''}
+          onPressEdit={() =>
+            navigation.navigate('MypageRoute', {
+              screen: 'EditNicknameScreen',
+            })
+          }
+        />
+      )}
 
       <View className="mb-4 mt-4 px-4" style={{ gap: 12 }}>
         <MypageMenuItem

--- a/src/shared/lib/clearUserData.ts
+++ b/src/shared/lib/clearUserData.ts
@@ -1,7 +1,8 @@
 import { queryClient } from '@/providers/AppProvider';
-import { useSelectedBrandsStore } from '@/shared/store';
+import { useFavoriteStore, useSelectedBrandsStore } from '@/shared/store';
 
 export const clearUserData = () => {
   queryClient.clear();
   useSelectedBrandsStore.getState().resetSelectedBrands();
+  useFavoriteStore.getState().resetFavorites();
 };

--- a/src/shared/store/brand/favoriteBrand/index.ts
+++ b/src/shared/store/brand/favoriteBrand/index.ts
@@ -4,7 +4,8 @@ interface FavoriteStore {
   optimisticFavorites: Record<string, boolean>;
   setOptimisticFavorite: (brandId: string, isFavorite: boolean) => void;
   toggleOptimisticFavorite: (brandId: string) => void;
-  syncFavorite: (brandId: string, isFavorite: boolean) => void;
+  syncFavorites: (favorites: Record<string, boolean>) => void;
+  resetFavorites: () => void;
 }
 
 export const useFavoriteStore = create<FavoriteStore>(set => ({
@@ -26,11 +27,13 @@ export const useFavoriteStore = create<FavoriteStore>(set => ({
       },
     })),
 
-  syncFavorite: (brandId, isFavorite) =>
+  syncFavorites: favorites =>
     set(state => ({
       optimisticFavorites: {
+        ...favorites,
         ...state.optimisticFavorites,
-        [brandId]: isFavorite,
       },
     })),
+
+  resetFavorites: () => set({ optimisticFavorites: {} }),
 }));


### PR DESCRIPTION
## 이슈 번호

> close #133, close #138 

## 작업 내용 및 테스트 방법
### 1. 찜 브랜드 동기화 리팩토링

**문제**
- `optimisticFavorites`가 마이페이지 진입 시 빈 상태로 찜 목록 미표시
- 로그아웃 후 다른 계정 로그인 시 이전 계정 찜 데이터 잔존
- `useFavoriteToggle`의 `isPending` 가드로 연속 토글 시 API 호출 누락

**변경**
- `syncFavorites`를 merge 방식으로 변경 (서버 값 base + 기존 optimistic 보존)
- `useHomeScreen`에서 stores API 응답 시 `syncFavorites` 일괄 호출
- `useFavoriteToggle`에서 `isPending` 가드 제거, 개별 `syncFavorite` 제거
- `MapOverlay`에서 개별 동기화 useEffect 제거
- `clearUserData`에 `resetFavorites()` 추가 (계정 분리)

### 2. 마이페이지 Prefetch + Skeleton

**문제**
- 마이페이지 진입 시 닉네임 fetching 0.3~1초간 빈 화면 노출

**변경**
- `useGetUser`에서 `userQueryOptions` 상수 추출
- `usePrefetchMyPage` 훅 생성 → 홈 화면 mount 시 `['user']` 캐시 선점
- `NicknameSectionSkeleton` 생성 (shimmer 애니메이션, 기존 프로젝트 패턴 동일)
- `MypageScreen`에서 `isLoading` 기반 스켈레톤/닉네임 조건 렌더링