### PR TITLE
🚨 Hotfix : 회원가입 완료 페이지에서 화면이 넘어가지 않는 버그

### DIFF
--- a/src/feature/auth/signup/model/useUserSignup.ts
+++ b/src/feature/auth/signup/model/useUserSignup.ts
@@ -56,9 +56,9 @@ export const useUserSignup = ({
         userAgreementConsentRequestDto: agreementData,
       });
 
-      saveTokens(response.accessToken);
+      saveTokens(response.data.accessToken);
       closeModal();
-      navigateToSelectBrand(response.refreshToken);
+      navigateToSelectBrand(response.data.refreshToken);
     } catch (err) {
       console.error('Signup failed:', err);
     }

--- a/src/feature/auth/signup/types/index.ts
+++ b/src/feature/auth/signup/types/index.ts
@@ -10,9 +10,11 @@ export interface ValidateResponse {
 }
 
 export interface SignupResponse {
-  socialType: string;
-  accessToken: string;
-  refreshToken: string;
+  data: {
+    socialType: string;
+    accessToken: string;
+    refreshToken: string;
+  };
 }
 
 export interface SignupRequest {

--- a/src/screens/signup/selectBrand/index.tsx
+++ b/src/screens/signup/selectBrand/index.tsx
@@ -79,7 +79,11 @@ const SelectBrandScreen = () => {
       <SelectButton
         actualSelectedCount={actualCount}
         disabled={isDisabled}
-        handleNavigation={() => navigation.navigate('SignupSuccess')}
+        handleNavigation={() =>
+          navigation.navigate('SignupSuccess', {
+            refreshToken: route.params?.refreshToken,
+          })
+        }
         handleSelectedCompleted={handleSelectedCompleted}
         scrollToTop={scrollToTop}
         showFloatingButton={showFloatingButton}


### PR DESCRIPTION
## 이슈 번호

> close #140 

## 작업 내용 및 테스트 방법

<p><strong>버그 원인</strong>: <code>signupApi</code>가 <code>response.data</code>를 반환하는데, 실제 API 응답은 <code>{ data: { socialType, accessToken, refreshToken } }</code> 구조입니다. <code>SignupResponse</code> 타입에 <code>data</code> 래퍼가 누락되어 있어서 <code>response.accessToken</code>/<code>response.refreshToken</code>이 <code>undefined</code>였고, 이 <code>undefined</code>가 <code>SelectBrand</code> → <code>SignupSuccess</code>로 그대로 전달되었습니다.</p></body></html>
