### PR TITLE
🚨 Hotfix: 픽셀북 생성 및 픽셀 업로드 API 연동 프로세스 변경

### DIFF
--- a/src/feature/picsel/myPicsel/components/ui/organisms/PhotoListView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/PhotoListView.tsx
@@ -30,6 +30,7 @@ interface Props {
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   data: Photo[];
   showYear?: boolean;
+  onPhotoPress?: (photoId: string) => void;
 }
 
 const PhotoListView = forwardRef<FlatList, Props>(
@@ -42,6 +43,7 @@ const PhotoListView = forwardRef<FlatList, Props>(
       onScroll,
       data,
       showYear = true,
+      onPhotoPress,
     },
     ref,
   ) => {
@@ -85,6 +87,7 @@ const PhotoListView = forwardRef<FlatList, Props>(
             onToggleSelection={onToggleSelection}
             onImageLoad={handleImageLoad}
             onImageError={handleImageError}
+            onPress={() => !isSelecting && onPhotoPress?.(photo.id)}
           />
         </View>
       );

--- a/src/feature/picsel/picselBook/api/createPicselBookDraftApi.ts
+++ b/src/feature/picsel/picselBook/api/createPicselBookDraftApi.ts
@@ -1,0 +1,13 @@
+import { CreatePicselBookDraftResponse } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const createPicselBookDraftApi =
+  async (): Promise<CreatePicselBookDraftResponse> => {
+    const response =
+      await axiosInstance.post<CreatePicselBookDraftResponse>(
+        '/picselbooks/draft',
+      );
+
+    return response.data;
+  };

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
@@ -131,6 +131,7 @@ const PicselBookFolderTemplate = ({
               isLoading={isLoading}
               onScroll={handleScroll}
               onToggleSelection={toggleSelection}
+              onPhotoPress={onPhotoPress}
             />
           ) : (
             <PhotoTextListView

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -6,6 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { usePicselUploadStore } from '../../picselUpload/hooks/usePicselUploadStore';
 import { CoverType } from '../../shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet';
 import { useCreatePicselBook } from '../mutations/useCreatePicselBook';
+import { useCreatePicselBookDraft } from '../mutations/useCreatePicselBookDraft';
 import { useDeletePicselBooks } from '../mutations/useDeletePicselBooks';
 import { useGetPicselBooks } from '../queries/useGetPicselBooks';
 import { PicselBookItem } from '../types';
@@ -60,6 +61,8 @@ export const usePicselBook = () => {
 
   const { bookCoverPhoto, reset: resetPhotoStore } = usePhotoStore();
 
+  const { mutateAsync: createDraft } = useCreatePicselBookDraft();
+
   const books: PicselBookItem[] = data ?? [];
   const totalBooks = books.length;
   const hasBooks = books.length > 0;
@@ -106,8 +109,16 @@ export const usePicselBook = () => {
   };
 
   // 픽셀북 생성
-  const handleSubmit = (bookName: string, coverType: CoverType) => {
+  const handleSubmit = async (bookName: string, coverType: CoverType) => {
+    picselBookRef.current?.dismiss();
+    if (bookCoverPhoto) {
+      navigation.pop(1);
+    }
+
+    const draftUuid = await createDraft();
+
     const payload = {
+      picselbookId: draftUuid,
       bookName,
       coverImagePath: coverType === 'photo' ? bookCoverPhoto : null,
     };
@@ -115,9 +126,6 @@ export const usePicselBook = () => {
     createPicselBook(payload, {
       onSuccess: response => {
         showToast(`"${bookName}"을 추가했어요`, 60);
-
-        navigation.pop(1);
-        picselBookRef.current?.dismiss();
 
         const newBookId = response.data?.picselbookId;
 

--- a/src/feature/picsel/picselBook/mutations/useCreatePicselBook.ts
+++ b/src/feature/picsel/picselBook/mutations/useCreatePicselBook.ts
@@ -10,12 +10,26 @@ export const useCreatePicselBook = () => {
 
   return useMutation({
     mutationFn: async ({
+      picselbookId,
       bookName,
       coverImagePath,
     }: CreatePicselBookRequest) => {
-      const s3ImageUrl = await uploadImageToS3(coverImagePath, 'PICSELBOOK');
+      if (!coverImagePath) {
+        return createPicselBookApi({
+          picselbookId,
+          bookName,
+          coverImagePath: null,
+        });
+      }
+
+      const s3ImageUrl = await uploadImageToS3(
+        coverImagePath,
+        picselbookId,
+        'PICSELBOOK',
+      );
 
       return createPicselBookApi({
+        picselbookId,
         bookName,
         coverImagePath: s3ImageUrl,
       });

--- a/src/feature/picsel/picselBook/mutations/useCreatePicselBookDraft.ts
+++ b/src/feature/picsel/picselBook/mutations/useCreatePicselBookDraft.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { createPicselBookDraftApi } from '../api/createPicselBookDraftApi';
+
+export const useCreatePicselBookDraft = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await createPicselBookDraftApi();
+      return response.data.draftUuid;
+    },
+    onError: error => {
+      console.log('픽셀북 드래프트 생성 실패:', error);
+    },
+  });
+};

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -67,6 +67,7 @@ export interface DeletePicselBooksRequest {
 
 // 픽셀북 생성 요청
 export interface CreatePicselBookRequest {
+  picselbookId: string;
   bookName: string;
   coverImagePath: string;
 }
@@ -74,4 +75,14 @@ export interface CreatePicselBookRequest {
 // 픽셀북 생성 응답
 export interface CreatePicselbookResponse extends CommonResponseType {
   data: PicselBookItem;
+}
+
+// 픽셀북 드래프트 생성 응답 Data
+export interface CreatePicselBookDraftData {
+  draftUuid: string;
+}
+
+// 픽셀북 드래프트 생성 응답
+export interface CreatePicselBookDraftResponse extends CommonResponseType {
+  data: CreatePicselBookDraftData;
 }

--- a/src/feature/picsel/picselUpload/api/createPicselDraftApi.ts
+++ b/src/feature/picsel/picselUpload/api/createPicselDraftApi.ts
@@ -1,0 +1,19 @@
+import { CreatePicselDraftResponse } from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const createPicselDraftApi = async (
+  picselbookId: string,
+): Promise<CreatePicselDraftResponse> => {
+  const response = await axiosInstance.post<CreatePicselDraftResponse>(
+    '/picsels/draft',
+    undefined,
+    {
+      params: {
+        picselbookId,
+      },
+    },
+  );
+
+  return response.data;
+};

--- a/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
+++ b/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
@@ -1,0 +1,80 @@
+import { useNavigation } from '@react-navigation/native';
+
+import { useAddPicselToPicselBook } from '../mutations/useAddPicselToPicselBook';
+import { useCreatePicselDraft } from '../mutations/useCreatePicselDraft';
+
+import { usePicselUploadStore } from './usePicselUploadStore';
+
+import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
+import { usePhotoStore } from '@/shared/store/picselUpload';
+
+type Params = {
+  title: string;
+  content: string;
+};
+
+export const useCompletePicselUpload = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+
+  const {
+    takenDate,
+    storeId,
+    picselbookId,
+    bookName,
+    setRecord,
+    getImagePaths,
+    resetUploadData,
+  } = usePicselUploadStore();
+
+  const { reset: resetPhotoStore } = usePhotoStore();
+
+  const { mutate: uploadPicsel, isPending } = useAddPicselToPicselBook();
+  const { mutateAsync: createDraft } = useCreatePicselDraft();
+
+  const complete = async ({ title, content }: Params) => {
+    const draftUuid = await createDraft(picselbookId);
+
+    const requestPayload = {
+      picselId: draftUuid,
+      picselbookId,
+      storeId,
+      takenDate,
+      title,
+      content,
+      imagePaths: getImagePaths(),
+    };
+
+    uploadPicsel(requestPayload, {
+      onSuccess: data => {
+        navigation.reset({
+          index: 1,
+          routes: [
+            {
+              name: 'PicselBookFolder',
+              params: { bookId: picselbookId, bookName },
+            },
+            {
+              name: 'PicselDetail',
+              params: {
+                picselId: data.data.picselId,
+                bookId: data.data.picselbookId,
+              },
+            },
+          ],
+        });
+
+        setRecord(title, content);
+        resetUploadData();
+        resetPhotoStore();
+      },
+      onError: error => {
+        console.log('픽셀 업로드 중 에러 발생:', error);
+      },
+    });
+  };
+
+  return {
+    complete,
+    isPending,
+  };
+};

--- a/src/feature/picsel/picselUpload/mutations/useAddPicselToPicselBook.ts
+++ b/src/feature/picsel/picselUpload/mutations/useAddPicselToPicselBook.ts
@@ -12,6 +12,7 @@ export const useAddPicselToPicselBook = () => {
     mutationFn: async (request: PicselUploadRequest) => {
       const s3ImageUrls = await uploadMultipleImagesToS3(
         request.imagePaths,
+        request.picselId,
         'PICSEL',
       );
 

--- a/src/feature/picsel/picselUpload/mutations/useCreatePicselDraft.ts
+++ b/src/feature/picsel/picselUpload/mutations/useCreatePicselDraft.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { createPicselDraftApi } from '../api/createPicselDraftApi';
+
+export const useCreatePicselDraft = () => {
+  return useMutation({
+    mutationFn: async (picselbookId: string) => {
+      const response = await createPicselDraftApi(picselbookId);
+      return response.data.draftUuid;
+    },
+    onError: error => {
+      console.log('픽셀 드래프트 생성 실패:', error);
+    },
+  });
+};

--- a/src/feature/picsel/picselUpload/types/index.ts
+++ b/src/feature/picsel/picselUpload/types/index.ts
@@ -2,6 +2,7 @@ import { CommonResponseType } from '@/shared/api/types';
 
 // 픽셀 추가 요청
 export interface PicselUploadRequest {
+  picselId: string;
   picselbookId: string;
   storeId: string;
   takenDate: string;
@@ -20,4 +21,14 @@ export interface PicselUploadResult {
 
 export interface PicselUploadResponse extends CommonResponseType {
   data: PicselUploadResult;
+}
+
+// 픽셀 드래프트 생성 응답 Data
+export interface CreatePicselDraftData {
+  draftUuid: string;
+}
+
+// 픽셀 드래프트 생성 응답
+export interface CreatePicselDraftResponse extends CommonResponseType {
+  data: CreatePicselDraftData;
 }

--- a/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
@@ -62,7 +62,7 @@ const PicselBookSelectStep = ({ onNext }: Props) => {
       <View className="flex-1 pt-6">
         <Text className="px-5 text-gray-900 headline-02">픽셀북 선택</Text>
 
-        <View className="py-6">
+        <View className="flex-1 py-6">
           <PicselBookList
             books={books}
             isSelecting={true}

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { useNavigation } from '@react-navigation/native';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -10,81 +9,23 @@ import {
   View,
 } from 'react-native';
 
+import { useCompletePicselUpload } from '../../hooks/useCompletePicselUpload';
 import { usePicselUploadStore } from '../../hooks/usePicselUploadStore';
-import { useAddPicselToPicselBook } from '../../mutations/useAddPicselToPicselBook';
-import { useCreatePicselDraft } from '../../mutations/useCreatePicselDraft';
 
 import UploadStepHeader from '@/feature/picsel/shared/components/ui/molecules/UploadStepHeader';
-import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
-import { usePhotoStore } from '@/shared/store/picselUpload';
 import Button from '@/shared/ui/atoms/Button';
 
 const RecordWriteStep = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
-  const {
-    title: savedTitle,
-    content: savedContent,
-    takenDate,
-    storeId,
-    picselbookId,
-    bookName,
-    setRecord,
-    getImagePaths,
-    resetUploadData,
-  } = usePicselUploadStore();
-  const { reset: resetPhotoStore } = usePhotoStore();
+  const { title: savedTitle, content: savedContent } = usePicselUploadStore();
 
   const [title, setTitle] = useState(savedTitle || '');
   const [content, setContent] = useState(savedContent || '');
 
-  // 픽셀 업로드 mutation
-  const { mutate: uploadPicsel, isPending } = useAddPicselToPicselBook();
-
-  const { mutateAsync: createDraft } = useCreatePicselDraft();
-
-  const handleComplete = async () => {
-    const draftUuid = await createDraft(picselbookId);
-
-    const requestPayload = {
-      picselId: draftUuid,
-      picselbookId,
-      storeId,
-      takenDate,
-      title,
-      content,
-      imagePaths: getImagePaths(),
-    };
-
-    uploadPicsel(requestPayload, {
-      onSuccess: data => {
-        navigation.reset({
-          index: 1,
-          routes: [
-            {
-              name: 'PicselBookFolder',
-              params: { bookId: picselbookId, bookName: bookName },
-            },
-            {
-              name: 'PicselDetail',
-              params: {
-                picselId: data.data.picselId,
-                bookId: data.data.picselbookId,
-              },
-            },
-          ],
-        });
-
-        setRecord(title, content);
-        resetUploadData();
-        resetPhotoStore();
-      },
-      onError: error => {
-        console.log('픽셀 업로드 중 에러 발생:', error.message);
-      },
-    });
-  };
+  const { complete, isPending } = useCompletePicselUpload();
 
   const isFilled = title.trim().length > 0 && content.trim().length > 0;
+
+  const handleComplete = () => complete({ title, content });
 
   return (
     <KeyboardAvoidingView
@@ -110,7 +51,6 @@ const RecordWriteStep = () => {
         <View className="px-5 pt-6">
           <Text className="mb-3 text-gray-900 headline-02">내용</Text>
 
-          {/* 입력 컨테이너 */}
           <View className="min-h-[300px] rounded-xl border border-gray-300 p-4">
             <TextInput
               value={title}

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -12,6 +12,7 @@ import {
 
 import { usePicselUploadStore } from '../../hooks/usePicselUploadStore';
 import { useAddPicselToPicselBook } from '../../mutations/useAddPicselToPicselBook';
+import { useCreatePicselDraft } from '../../mutations/useCreatePicselDraft';
 
 import UploadStepHeader from '@/feature/picsel/shared/components/ui/molecules/UploadStepHeader';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
@@ -39,8 +40,13 @@ const RecordWriteStep = () => {
   // 픽셀 업로드 mutation
   const { mutate: uploadPicsel, isPending } = useAddPicselToPicselBook();
 
-  const handleComplete = () => {
+  const { mutateAsync: createDraft } = useCreatePicselDraft();
+
+  const handleComplete = async () => {
+    const draftUuid = await createDraft(picselbookId);
+
     const requestPayload = {
+      picselId: draftUuid,
       picselbookId,
       storeId,
       takenDate,
@@ -58,7 +64,13 @@ const RecordWriteStep = () => {
               name: 'PicselBookFolder',
               params: { bookId: picselbookId, bookName: bookName },
             },
-            { name: 'PicselDetail', params: { picselId: data.data.picselId } },
+            {
+              name: 'PicselDetail',
+              params: {
+                picselId: data.data.picselId,
+                bookId: data.data.picselbookId,
+              },
+            },
           ],
         });
 

--- a/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
@@ -21,6 +21,7 @@ interface Props {
   isSelected: boolean;
   showYear?: boolean;
   onToggleSelection: (photoId: string) => void;
+  onPress?: (photoId: string) => void;
   onImageLoad?: (uri: string) => void;
   onImageError?: (uri: string) => void;
 }
@@ -33,9 +34,18 @@ const SelectablePhotoCard = ({
   isSelected,
   showYear = true,
   onToggleSelection,
+  onPress,
   onImageLoad,
   onImageError,
 }: Props) => {
+  const handlePress = () => {
+    if (isSelecting) {
+      onToggleSelection(photo.id);
+    } else {
+      onPress?.(photo.id);
+    }
+  };
+
   return (
     <View style={{ width: imageWidth }}>
       {/* 날짜 */}
@@ -43,7 +53,7 @@ const SelectablePhotoCard = ({
         {formatDate(photo.date, { showYear })}
       </Text>
 
-      <Pressable onPress={() => isSelecting && onToggleSelection(photo.id)}>
+      <Pressable onPress={handlePress}>
         {isSelecting && <SelectionCheckbox isSelected={isSelected} />}
 
         <View

--- a/src/feature/picsel/shared/utils/usePhotoFormat.ts
+++ b/src/feature/picsel/shared/utils/usePhotoFormat.ts
@@ -11,7 +11,10 @@ export const usePhotoFormat = () => {
       /**
        * 날짜를 YYYY.MM.DD 형식으로 포맷팅
        */
-      formatDate: (date: string) => {
+      formatDate: (date?: string | null) => {
+        if (!date) {
+          return '';
+        }
         return date.replace(/-/g, DATE_FORMAT_SEPARATOR);
       },
 

--- a/src/screens/picsel/picselBook/picselBookFolder/index.tsx
+++ b/src/screens/picsel/picselBook/picselBookFolder/index.tsx
@@ -16,7 +16,15 @@ const PicselBookFolderScreen = () => {
   const { bookId, bookName } = route.params;
 
   const handleBack = () => {
-    navigation.goBack();
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'PicselTab' }],
+    });
   };
 
   const handlePhotoPress = (picselId: string) => {

--- a/src/screens/picsel/picselDetail/index.tsx
+++ b/src/screens/picsel/picselDetail/index.tsx
@@ -17,26 +17,7 @@ import AspectRatioImage from '@/shared/components/ui/atoms/AspectRatioImage';
 import DropdownMenu from '@/shared/components/ui/molecules/DropdownMenu';
 import { useDropdownMenu } from '@/shared/hooks/useDropdownMenu';
 import SparkleImages from '@/shared/images/Sparkle';
-
-const DUMMY_PICSEL = {
-  takenDate: '2024-05-20',
-  title: '오늘의 즐거운 기록',
-  store: { storeName: '픽셀 스튜디오 강남점' },
-  representativeImagePath:
-    'https://images.unsplash.com/photo-1740498276422-e9df92e4a369?q=80&w=987&auto=format&fit=crop',
-  photos: [
-    {
-      imagePath:
-        'https://images.unsplash.com/photo-1740498276422-e9df92e4a369?q=80&w=987&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    },
-    {
-      imagePath:
-        'https://images.unsplash.com/photo-1762112800032-b8d8119557b8?q=80&w=2068&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    },
-  ],
-  content:
-    '오랜만에 친구랑 만나서 수다 떨면서 돌아다녔다. 평소처럼 놀다가 갑자기 눈이 오기 시작해서 괜히 더 기분이 좋아졌다',
-};
+import { getImageUrl } from '@/shared/utils/image';
 
 type Props = NativeStackScreenProps<MainNavigationProps, 'PicselDetail'>;
 
@@ -45,8 +26,7 @@ const PicselDetailScreen = ({ route, navigation }: Props) => {
   const { formatDate } = usePhotoFormat();
   const insets = useSafeAreaInsets();
 
-  const { data: picsel } = useGetPicselDetail(picselId);
-  const picselData = picsel || DUMMY_PICSEL;
+  const { data: picselData } = useGetPicselDetail(picselId);
 
   const postDropdown = useDropdownMenu();
   const { dropdownItems: postDropdownItems } = usePicselDetailMenu({
@@ -63,6 +43,8 @@ const PicselDetailScreen = ({ route, navigation }: Props) => {
     imagePath: viewer.uri,
     hideDropdown: viewerDropdown.hide,
   });
+
+  const extraPhotos = picselData?.photos.slice(1) ?? [];
 
   const closeViewer = () => {
     viewerDropdown.hide();
@@ -94,56 +76,67 @@ const PicselDetailScreen = ({ route, navigation }: Props) => {
     ],
   );
 
+  const handleBack = () => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+  };
+
   return (
     <ScreenLayout>
       <PicselDetailHeader
-        onBackPress={() => navigation.goBack()}
+        onBackPress={handleBack}
         rightIconPress={postDropdown.toggle}
       />
       <ScrollView>
-        {/* 픽셀 정보 */}
         <View className="items-center">
           <Text className="px-4 text-gray-900 headline-01">
-            {formatDate(picselData.takenDate)}
+            {formatDate(picselData?.takenDate)}
           </Text>
           <Text className="px-4 py-1 text-gray-900 title-02">
-            {picselData.title}
+            {picselData?.title}
           </Text>
 
           <View className="flex-row items-center gap-1 py-2">
             <SparkleImages shape="icon-one" height={24} width={24} />
             <Text className="text-gray-900 body-rg-03">
-              {picselData.store.storeName}
+              {picselData?.store.storeName}
             </Text>
           </View>
         </View>
-        {/* 대표 사진 */}
         <View className="mb-6 px-4">
           <Pressable
-            onPress={() => viewer.open(picselData.representativeImagePath)}>
+            onPress={() =>
+              viewer.open(getImageUrl(picselData?.representativeImagePath))
+            }>
             <AspectRatioImage
-              uri={picselData.representativeImagePath}
+              uri={getImageUrl(picselData?.representativeImagePath)}
               style={{ width: '100%' }}
             />
           </Pressable>
         </View>
-
-        {/* 본문 내용 */}
         <View className="px-6 pb-6 pt-2">
-          <Text className="text-gray-900 body-rg-02">{picselData.content}</Text>
+          <Text className="text-gray-900 body-rg-02">
+            {picselData?.content}
+          </Text>
         </View>
-
-        {/* 추가 사진 */}
         <View className="justify-between px-4">
-          {picselData.photos.map((photo, index) => (
-            <Pressable key={index} onPress={() => viewer.open(photo.imagePath)}>
-              <AspectRatioImage
-                uri={photo.imagePath}
-                style={{ width: '100%' }}
-                className="mb-4"
-              />
-            </Pressable>
-          ))}
+          {extraPhotos.length > 0 && (
+            <View className="justify-between px-4">
+              {extraPhotos.map(photo => (
+                <Pressable
+                  key={photo.imagePath}
+                  onPress={() => viewer.open(getImageUrl(photo.imagePath))}>
+                  <AspectRatioImage
+                    uri={getImageUrl(photo.imagePath)}
+                    style={{ width: '100%' }}
+                    className="mb-4"
+                  />
+                </Pressable>
+              ))}
+            </View>
+          )}
         </View>
       </ScrollView>
       <DropdownMenu

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -2,7 +2,6 @@ import React, { useRef } from 'react';
 
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import SelectButton from '@/feature/brand/ui/organisms/SelectButton';
@@ -89,13 +88,11 @@ const SelectPhotoScreen = () => {
       />
 
       {selectedCount > 0 && (
-        <View className="absolute bottom-6 left-0 right-0 px-5">
-          <SelectButton
-            disabled={selectedCount === 0}
-            actualSelectedCount={selectedCount}
-            handleSelectedCompleted={handleSelectedCompleted}
-          />
-        </View>
+        <SelectButton
+          disabled={selectedCount === 0}
+          actualSelectedCount={selectedCount}
+          handleSelectedCompleted={handleSelectedCompleted}
+        />
       )}
     </SafeAreaView>
   );

--- a/src/shared/api/images/getPresignedUrlApi.ts
+++ b/src/shared/api/images/getPresignedUrlApi.ts
@@ -1,22 +1,18 @@
-import DeviceInfo from 'react-native-device-info';
-
 import { axiosInstance } from '../axiosInstance';
 
 import { ImageType, PresignedUrlResponse } from './types';
-
 /**
  * 이미지 업로드를 위한 Presigned URL 발급 API
+ * @param uuid draftUuid
  * @param type 이미지 타입
  */
-export const getPresignedUrlApi = async (type: ImageType) => {
-  const deviceUUID = await DeviceInfo.getUniqueId();
-
+export const getPresignedUrlApi = async (uuid: string, type: ImageType) => {
   const response = await axiosInstance.get<PresignedUrlResponse>(
     '/images/presigned',
     {
       params: {
-        uuid: deviceUUID,
-        type: type,
+        uuid,
+        type,
       },
     },
   );

--- a/src/shared/utils/imageUpload.ts
+++ b/src/shared/utils/imageUpload.ts
@@ -24,17 +24,20 @@ const resolveLocalFilePath = async (uri: string): Promise<string> => {
     return resolvedPath;
   } catch (error) {
     console.log('iOS 이미지 경로 변환 실패', error);
+    return uri;
   }
 };
 
 /**
  * 로컬 이미지 URI를 받아 S3 저장소에 업로드하고, 서버(DB) 저장에 필요한 최종 URL을 반환
  * @param {string} uri - 업로드할 로컬 이미지 URI
+ * @param uuid draftUuid - 이미지 업로드 시 서버에서 Presigned URL 발급을 위해 필요한 고유 식별자
  * @param {ImageType} type - 이미지 업로드 타입
  * @returns {Promise<string>} S3 업로드 완료 후 생성된 이미지의 최종 URL
  */
 export const uploadImageToS3 = async (
   uri: string,
+  uuid: string,
   type: ImageType,
 ): Promise<string> => {
   const localPath = await resolveLocalFilePath(uri);
@@ -42,7 +45,7 @@ export const uploadImageToS3 = async (
   // Presigned URL 획득
   const {
     data: { presignedUrl, fileUrl },
-  } = await getPresignedUrlApi(type);
+  } = await getPresignedUrlApi(uuid, type);
 
   // 파일 Fetch 및 Blob 변환
   const response = await fetch(localPath);
@@ -65,13 +68,15 @@ export const uploadImageToS3 = async (
 /**
  * 여러 장의 이미지 URI 배열을 받아 병렬로 S3에 업로드
  * @param {string[]} uris - 업로드할 로컬 이미지 URI 배열
+ * @param uuid draftUuid - 이미지 업로드 시 서버에서 Presigned URL 발급을 위해 필요한 고유 식별자
  * @param {ImageType} type - 이미지 업로드 타입
  * @returns {Promise<string[]>} 업로드된 모든 이미지의 최종 URL 배열
  * @description 모든 이미지는 Promise.all을 통해 동시에 업로드 시작
  */
 export const uploadMultipleImagesToS3 = async (
   uris: string[],
+  uuid: string,
   type: ImageType,
 ): Promise<string[]> => {
-  return Promise.all(uris.map(uri => uploadImageToS3(uri, type)));
+  return Promise.all(uris.map(uri => uploadImageToS3(uri, uuid, type)));
 };


### PR DESCRIPTION
## 이슈 번호

> close #120

## 작업 내용 및 테스트 방법

> 
기존 픽셀북 생성 및 픽셀 업로드 로직에서  
S3에 이미지 복사가 정상으로 처리되지 않아도 API가 호출될 수 있는 구조였으며, 
이는 이미지 유실 문제를 야기할 수 있음

이를 해결하기 위해 백엔드 API 연동 Flow가 수정되었고,  
**드래프트 생성 API가 새롭게 도입되며 이에 따른 일부 파라미터가 수정이 되었습니다.**

### 드래프트 생성 (공통 선행 단계)

`POST /picselbooks/draft`
`POST /picsels/draft`

- 픽셀북 또는 픽셀 생성 전
- 먼저 **draftUuid 발급**
- 이후 모든 업로드 및 생성 Flow의 기준 ID로 사용


## 픽셀북 생성 Flow

1. 드래프트 생성 API 호출 → `draftUuid` 발급
2. Presigned URL 발급 API 호출 (uuid = draftUuid, type = PICSELBOOK)
3. 응답:
   - `presignedUrl` → S3 업로드용
   - `fileUrl` → DB 저장용 경로
4. `presignedUrl`로 S3 PUT 업로드
5. 업로드 완료 후
   - `fileUrl`을 `coverImagePath`로 치환하여 픽셀북 생성 API 호출

- presignedUrl = S3 업로드 전용
- fileUrl = DB 저장용 경로
- picselbookId = draftUuid


## 픽셀 업로드 Flow

1. 드래프트 생성 API 호출 → `draftUuid`
2. Presigned URL 발급 (uuid = draftUuid, type = PICSEL)
3. S3 업로드
4. fileUrl을 imagePaths에 담아 픽셀 생성 API 호출

즉,  드래프트 uuid 기반으로 식별 체계 변경**


## 주요 변경 사항

- 드래프트 생성 mutation 추가
- Presigned URL 발급 시 uuid를 draftUuid로 변경
- S3 업로드 완료 후 fileUrl을 payload에 치환하도록 수정
- 커버 이미지 미선택 시 업로드 스킵 처리
- null-safe 처리 및 startsWith 에러 방지
- formatDate null/undefined 안전 처리


## To reviewers
기존 회의 때 나왔던 이미지 타입 수정은 준희님께서 AWS 별도 설정을 수정해주셔서 해결되었습니다!
그래서 이에 대한 처리는 별도 프론트에서 수정하지 않았고, 기존의 내용에서 드래프트 API가 추가됨으로써 변경되는 Flow들 위주로 확인해주시면 될 거 같습니다!

또, 픽셀 상세 화면으로 연동은 우선 내 픽셀이 아닌 픽셀북 내의 리스트/텍스트 뷰에만 연결이 되어져있는 상태라 참고하시어 확인해주시면 될 것 같습니다! 