### PR TITLE
💄 CSS : 픽셀북 add button, tooltip

### DIFF
--- a/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MonthFolderTemplate.tsx
@@ -87,6 +87,7 @@ const MonthFolderTemplate = ({ year, month, onBack }: Props) => {
         onAlbumPress={handleAlbumPress}
         onQrPress={handleQrPress}
         onCloseFunctionButtons={closeFunctionButtons}
+        noTabBar
       />
     </ScreenLayout>
   );

--- a/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/YearFolderTemplate.tsx
@@ -86,6 +86,7 @@ const YearFolderTemplate = ({ year, onBack }: Props) => {
         onAlbumPress={handleAlbumPress}
         onQrPress={handleQrPress}
         onCloseFunctionButtons={closeFunctionButtons}
+        noTabBar
       />
     </ScreenLayout>
   );

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookFolderTemplate.tsx
@@ -115,6 +115,7 @@ const PicselBookFolderTemplate = ({
               onQrPress={handleQrPress}
               onCloseFunctionButtons={closeFunctionButtons}
               tooltip={<UploadTooltip />}
+              noTabBar
             />
           }>
           <EmptyMessage message="픽셀북이 비어있어요" />
@@ -153,6 +154,7 @@ const PicselBookFolderTemplate = ({
             onAlbumPress={handleAlbumPress}
             onQrPress={handleQrPress}
             onCloseFunctionButtons={closeFunctionButtons}
+            noTabBar
           />
         </>
       )}

--- a/src/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/Button/FloatingActionButtons.tsx
@@ -17,6 +17,7 @@ interface FloatingActionButtonsProps {
   onQrPress: () => void;
   onCloseFunctionButtons: () => void;
   tooltip?: ReactNode;
+  noTabBar?: boolean;
 }
 
 const FloatingActionButtons = ({
@@ -29,13 +30,15 @@ const FloatingActionButtons = ({
   onQrPress,
   onCloseFunctionButtons,
   tooltip,
+  noTabBar,
 }: FloatingActionButtonsProps) => {
   if (isSelecting) {
     return null;
   }
 
   return (
-    <View className="absolute bottom-3 right-4 items-end">
+    <View
+      className={`absolute right-4 items-end ${noTabBar ? 'bottom-12' : 'bottom-3'}`}>
       {!showFunctionButtons && tooltip}
       {showUpButton && (
         <View className="mb-4">

--- a/src/feature/picsel/shared/hooks/useFunctionButtons.ts
+++ b/src/feature/picsel/shared/hooks/useFunctionButtons.ts
@@ -21,13 +21,13 @@ export const useFunctionButtons = (): UseFunctionButtonsReturn => {
   };
 
   const handleAlbumPress = () => {
-    setShowFunctionButtons(false);
     navigation.navigate('SelectMainPhoto');
+    setTimeout(() => setShowFunctionButtons(false), 300);
   };
 
   const handleQrPress = () => {
-    setShowFunctionButtons(false);
     navigation.navigate('QrScan');
+    setTimeout(() => setShowFunctionButtons(false), 300);
   };
 
   const closeFunctionButtons = () => {


### PR DESCRIPTION
## 이슈 번호

> close #143 

## 작업 내용 및 테스트 방법

### tooltip
- 기존 문제: function button의 action을 트리거하면 navigation 과 함께 state가 false가 되었음
-> 이로인해 tooltip이 화면 이동 중 렌더링 되는 이슈 발생

- 해결: setTimeout으로 navigation이 완료된 후 state가 업데이트 되게 수정

### button - bottom 
- 하단 탭바 여부를 props로 내려주어 디자인 분기처리
