### PR TITLE
✨ Feat: 사진 업로드 카테고리 구현

### DIFF
--- a/src/feature/picsel/picselUpload/constants/album.ts
+++ b/src/feature/picsel/picselUpload/constants/album.ts
@@ -1,0 +1,8 @@
+import { Dimensions } from 'react-native';
+
+export const ALBUM_PANEL = {
+  SLIDE_DURATION: 400,
+  SCREEN_HEIGHT: Dimensions.get('window').height,
+};
+
+export const ITEM_HEIGHT = 80;

--- a/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
+++ b/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { CameraRoll } from '@react-native-camera-roll/camera-roll';
+
+export type AlbumGroupType = 'Album' | 'SmartAlbum';
+
+export interface Album {
+  title: string;
+  count: number;
+  thumbnailUri?: string;
+  groupTypes: AlbumGroupType;
+}
+
+export const useAlbumList = () => {
+  const [albums, setAlbums] = useState<Album[]>([]);
+  const [selectedAlbum, setSelectedAlbum] = useState<string | null>(null);
+  const [isAlbumListOpen, setIsAlbumListOpen] = useState(false);
+
+  const fetchAlbums = useCallback(async () => {
+    try {
+      const [userAlbums, smartAlbums] = await Promise.all([
+        CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'Album' }),
+        CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'SmartAlbum' }),
+      ]);
+      const taggedUser = userAlbums.map(a => ({
+        ...a,
+        groupTypes: 'Album' as const,
+      }));
+      const taggedSmart = smartAlbums.map(a => ({
+        ...a,
+        groupTypes: 'SmartAlbum' as const,
+      }));
+      const albumData = [...taggedUser, ...taggedSmart];
+
+      const uniqueAlbumData = albumData.filter(
+        (album, idx, arr) =>
+          album.count > 0 &&
+          arr.findIndex(a => a.title === album.title) === idx,
+      );
+
+      const albumsWithThumbnails: Album[] = await Promise.all(
+        uniqueAlbumData.map(async album => {
+          let thumbnailUri: string | undefined;
+          try {
+            const { edges } = await CameraRoll.getPhotos({
+              first: 1,
+              assetType: 'Photos',
+              groupName: album.title,
+              groupTypes: album.groupTypes,
+            });
+            thumbnailUri = edges[0]?.node.image.uri;
+          } catch {
+            thumbnailUri = undefined;
+          }
+          return {
+            title: album.title,
+            count: album.count,
+            thumbnailUri,
+            groupTypes: album.groupTypes,
+          };
+        }),
+      );
+
+      const sorted = albumsWithThumbnails.sort((a, b) => b.count - a.count);
+      setAlbums(sorted);
+    } catch (error) {
+      console.log('앨범 목록 불러오기 실패:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAlbums();
+  }, [fetchAlbums]);
+
+  const toggleAlbumList = () => setIsAlbumListOpen(prev => !prev);
+
+  const selectAlbum = (albumTitle: string) => {
+    setSelectedAlbum(albumTitle);
+    setIsAlbumListOpen(false);
+  };
+
+  const selectedGroupTypes =
+    albums.find(a => a.title === selectedAlbum)?.groupTypes ?? null;
+
+  return {
+    albums,
+    selectedAlbum,
+    selectedGroupTypes,
+    displayAlbumName: selectedAlbum ?? albums[0]?.title ?? '',
+    isAlbumListOpen,
+    toggleAlbumList,
+    selectAlbum,
+  };
+};

--- a/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
+++ b/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
@@ -15,6 +15,7 @@ export const useAlbumList = () => {
   const [albums, setAlbums] = useState<Album[]>([]);
   const [selectedAlbum, setSelectedAlbum] = useState<string | null>(null);
   const [isAlbumListOpen, setIsAlbumListOpen] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   const fetchAlbums = useCallback(async () => {
     try {
@@ -38,9 +39,22 @@ export const useAlbumList = () => {
           arr.findIndex(a => a.title === album.title) === idx,
       );
 
-      const albumsWithThumbnails: Album[] = await Promise.all(
-        uniqueAlbumData.map(async album => {
-          let thumbnailUri: string | undefined;
+      const sorted = uniqueAlbumData
+        .map(a => ({
+          title: a.title,
+          count: a.count,
+          groupTypes: a.groupTypes,
+        }))
+        .sort((a, b) => b.count - a.count);
+
+      setAlbums(sorted);
+      if (sorted.length > 0) {
+        setSelectedAlbum(sorted[0].title);
+      }
+      setIsReady(true);
+
+      const thumbnails = await Promise.all(
+        sorted.map(async album => {
           try {
             const { edges } = await CameraRoll.getPhotos({
               first: 1,
@@ -48,23 +62,22 @@ export const useAlbumList = () => {
               groupName: album.title,
               groupTypes: album.groupTypes,
             });
-            thumbnailUri = edges[0]?.node.image.uri;
+            return edges[0]?.node.image.uri;
           } catch {
-            thumbnailUri = undefined;
+            return undefined;
           }
-          return {
-            title: album.title,
-            count: album.count,
-            thumbnailUri,
-            groupTypes: album.groupTypes,
-          };
         }),
       );
 
-      const sorted = albumsWithThumbnails.sort((a, b) => b.count - a.count);
-      setAlbums(sorted);
+      setAlbums(prev =>
+        prev.map((album, i) => ({
+          ...album,
+          thumbnailUri: thumbnails[i],
+        })),
+      );
     } catch (error) {
       console.log('앨범 목록 불러오기 실패:', error);
+      setIsReady(true);
     }
   }, []);
 
@@ -86,8 +99,9 @@ export const useAlbumList = () => {
     albums,
     selectedAlbum,
     selectedGroupTypes,
-    displayAlbumName: selectedAlbum ?? albums[0]?.title ?? '',
+    displayAlbumName: selectedAlbum ?? '',
     isAlbumListOpen,
+    isReady,
     toggleAlbumList,
     selectAlbum,
   };

--- a/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
+++ b/src/feature/picsel/picselUpload/hooks/useAlbumList.ts
@@ -11,6 +11,49 @@ export interface Album {
   groupTypes: AlbumGroupType;
 }
 
+const getAlbumsByType = async () => {
+  const [userAlbums, smartAlbums] = await Promise.all([
+    CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'Album' }),
+    CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'SmartAlbum' }),
+  ]);
+
+  const tagged = [
+    ...userAlbums.map(a => ({ ...a, groupTypes: 'Album' as const })),
+    ...smartAlbums.map(a => ({ ...a, groupTypes: 'SmartAlbum' as const })),
+  ];
+
+  return tagged
+    .filter(
+      (album, idx, arr) =>
+        album.count > 0 && arr.findIndex(a => a.title === album.title) === idx,
+    )
+    .map(({ title, count, groupTypes }) => ({ title, count, groupTypes }))
+    .sort((a, b) => b.count - a.count);
+};
+
+const fetchThumbnails = async (albumList: Album[]) => {
+  const uris = await Promise.all(
+    albumList.map(async album => {
+      try {
+        const { edges } = await CameraRoll.getPhotos({
+          first: 1,
+          assetType: 'Photos',
+          groupName: album.title,
+          groupTypes: album.groupTypes,
+        });
+        return edges[0]?.node.image.uri;
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+
+  return albumList.map((album, i) => ({
+    ...album,
+    thumbnailUri: uris[i],
+  }));
+};
+
 export const useAlbumList = () => {
   const [albums, setAlbums] = useState<Album[]>([]);
   const [selectedAlbum, setSelectedAlbum] = useState<string | null>(null);
@@ -19,33 +62,7 @@ export const useAlbumList = () => {
 
   const fetchAlbums = useCallback(async () => {
     try {
-      const [userAlbums, smartAlbums] = await Promise.all([
-        CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'Album' }),
-        CameraRoll.getAlbums({ assetType: 'Photos', albumType: 'SmartAlbum' }),
-      ]);
-      const taggedUser = userAlbums.map(a => ({
-        ...a,
-        groupTypes: 'Album' as const,
-      }));
-      const taggedSmart = smartAlbums.map(a => ({
-        ...a,
-        groupTypes: 'SmartAlbum' as const,
-      }));
-      const albumData = [...taggedUser, ...taggedSmart];
-
-      const uniqueAlbumData = albumData.filter(
-        (album, idx, arr) =>
-          album.count > 0 &&
-          arr.findIndex(a => a.title === album.title) === idx,
-      );
-
-      const sorted = uniqueAlbumData
-        .map(a => ({
-          title: a.title,
-          count: a.count,
-          groupTypes: a.groupTypes,
-        }))
-        .sort((a, b) => b.count - a.count);
+      const sorted = await getAlbumsByType();
 
       setAlbums(sorted);
       if (sorted.length > 0) {
@@ -53,28 +70,8 @@ export const useAlbumList = () => {
       }
       setIsReady(true);
 
-      const thumbnails = await Promise.all(
-        sorted.map(async album => {
-          try {
-            const { edges } = await CameraRoll.getPhotos({
-              first: 1,
-              assetType: 'Photos',
-              groupName: album.title,
-              groupTypes: album.groupTypes,
-            });
-            return edges[0]?.node.image.uri;
-          } catch {
-            return undefined;
-          }
-        }),
-      );
-
-      setAlbums(prev =>
-        prev.map((album, i) => ({
-          ...album,
-          thumbnailUri: thumbnails[i],
-        })),
-      );
+      const withThumbnails = await fetchThumbnails(sorted);
+      setAlbums(withThumbnails);
     } catch (error) {
       console.log('앨범 목록 불러오기 실패:', error);
       setIsReady(true);

--- a/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
+++ b/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import { Alert } from 'react-native';
@@ -9,7 +9,10 @@ export type GridPhoto = {
   source: 'gallery' | 'camera';
 };
 
-export const useInfiniteScrollPhotos = () => {
+export const useInfiniteScrollPhotos = (
+  albumName: string | null,
+  groupTypes: 'Album' | 'SmartAlbum' | null,
+) => {
   const [photos, setPhotos] = useState<GridPhoto[]>([]);
   const [endCursor, setEndCursor] = useState<string | undefined>();
   const [hasNextPage, setHasNextPage] = useState(true);
@@ -28,6 +31,11 @@ export const useInfiniteScrollPhotos = () => {
         first: fetchCount,
         after: endCursor,
         assetType: 'Photos',
+        ...(albumName &&
+          groupTypes && {
+            groupName: albumName,
+            groupTypes,
+          }),
       });
 
       const mappedPhotos: GridPhoto[] = edges.map(edge => ({
@@ -50,7 +58,44 @@ export const useInfiniteScrollPhotos = () => {
     } finally {
       loadingRef.current = false;
     }
-  }, [endCursor, hasNextPage]);
+  }, [endCursor, hasNextPage, albumName, groupTypes]);
+
+  useEffect(() => {
+    setPhotos([]);
+    setEndCursor(undefined);
+    setHasNextPage(true);
+    loadingRef.current = true;
+
+    const loadFirstPage = async () => {
+      try {
+        const { edges, page_info } = await CameraRoll.getPhotos({
+          first: 15,
+          assetType: 'Photos',
+          ...(albumName &&
+            groupTypes && {
+              groupName: albumName,
+              groupTypes,
+            }),
+        });
+
+        const mappedPhotos: GridPhoto[] = edges.map(edge => ({
+          id: edge.node.id,
+          uri: edge.node.image.uri,
+          source: 'gallery',
+        }));
+
+        setPhotos(mappedPhotos);
+        setEndCursor(page_info.end_cursor);
+        setHasNextPage(page_info.has_next_page);
+      } catch (error) {
+        console.log('사진 불러오기 실패:', error);
+      } finally {
+        loadingRef.current = false;
+      }
+    };
+
+    loadFirstPage();
+  }, [albumName, groupTypes]);
 
   const resetPhotos = useCallback(() => {
     setPhotos([]);

--- a/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
+++ b/src/feature/picsel/picselUpload/hooks/useInfiniteScrollPhotos.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import { Alert } from 'react-native';
 
+import { AlbumGroupType } from './useAlbumList';
+
 export type GridPhoto = {
   id: string;
   uri: string;
@@ -11,30 +13,40 @@ export type GridPhoto = {
 
 export const useInfiniteScrollPhotos = (
   albumName: string | null,
-  groupTypes: 'Album' | 'SmartAlbum' | null,
+  groupTypes: AlbumGroupType | null,
 ) => {
   const [photos, setPhotos] = useState<GridPhoto[]>([]);
   const [endCursor, setEndCursor] = useState<string | undefined>();
   const [hasNextPage, setHasNextPage] = useState(true);
   const loadingRef = useRef(false);
 
+  const albumNameRef = useRef(albumName);
+  const groupTypesRef = useRef(groupTypes);
+  albumNameRef.current = albumName;
+  groupTypesRef.current = groupTypes;
+
+  const endCursorRef = useRef(endCursor);
+  const hasNextPageRef = useRef(hasNextPage);
+  endCursorRef.current = endCursor;
+  hasNextPageRef.current = hasNextPage;
+
   const fetchPhotos = useCallback(async () => {
-    if (loadingRef.current || !hasNextPage) {
+    if (loadingRef.current || !hasNextPageRef.current) {
       return;
     }
 
     loadingRef.current = true;
     try {
-      const fetchCount = endCursor ? 100 : 15;
+      const fetchCount = endCursorRef.current ? 100 : 15;
 
       const { edges, page_info } = await CameraRoll.getPhotos({
         first: fetchCount,
-        after: endCursor,
+        after: endCursorRef.current,
         assetType: 'Photos',
-        ...(albumName &&
-          groupTypes && {
-            groupName: albumName,
-            groupTypes,
+        ...(albumNameRef.current &&
+          groupTypesRef.current && {
+            groupName: albumNameRef.current,
+            groupTypes: groupTypesRef.current,
           }),
       });
 
@@ -44,12 +56,11 @@ export const useInfiniteScrollPhotos = (
         source: 'gallery',
       }));
 
-      if (page_info.end_cursor === endCursor) {
+      if (page_info.end_cursor === endCursorRef.current) {
         return;
       }
 
       setPhotos(prev => [...prev, ...mappedPhotos]);
-
       setEndCursor(page_info.end_cursor);
       setHasNextPage(page_info.has_next_page);
     } catch (error) {
@@ -58,9 +69,13 @@ export const useInfiniteScrollPhotos = (
     } finally {
       loadingRef.current = false;
     }
-  }, [endCursor, hasNextPage, albumName, groupTypes]);
+  }, []);
 
   useEffect(() => {
+    if (!albumName || !groupTypes) {
+      return;
+    }
+
     setPhotos([]);
     setEndCursor(undefined);
     setHasNextPage(true);
@@ -71,11 +86,8 @@ export const useInfiniteScrollPhotos = (
         const { edges, page_info } = await CameraRoll.getPhotos({
           first: 15,
           assetType: 'Photos',
-          ...(albumName &&
-            groupTypes && {
-              groupName: albumName,
-              groupTypes,
-            }),
+          groupName: albumName,
+          groupTypes,
         });
 
         const mappedPhotos: GridPhoto[] = edges.map(edge => ({

--- a/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
@@ -2,10 +2,13 @@ import { useMemo, useState } from 'react';
 
 import { GridPhoto, useInfiniteScrollPhotos } from './useInfiniteScrollPhotos';
 
-export const usePhotoGrid = (albumName: string | null) => {
+export const usePhotoGrid = (
+  albumName: string | null,
+  groupTypes: 'Album' | 'SmartAlbum' | null,
+) => {
   const [capturedPhotos, setCapturedPhotos] = useState<GridPhoto[]>([]);
   const { photos, fetchPhotos, hasNextPage, resetPhotos } =
-    useInfiniteScrollPhotos(albumName);
+    useInfiniteScrollPhotos(albumName, groupTypes);
 
   const combinedPhotos = useMemo(
     () => [

--- a/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
@@ -2,10 +2,10 @@ import { useMemo, useState } from 'react';
 
 import { GridPhoto, useInfiniteScrollPhotos } from './useInfiniteScrollPhotos';
 
-export const usePhotoGrid = () => {
+export const usePhotoGrid = (albumName: string | null) => {
   const [capturedPhotos, setCapturedPhotos] = useState<GridPhoto[]>([]);
   const { photos, fetchPhotos, hasNextPage, resetPhotos } =
-    useInfiniteScrollPhotos();
+    useInfiniteScrollPhotos(albumName);
 
   const combinedPhotos = useMemo(
     () => [

--- a/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoGrid.ts
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
 
+import { AlbumGroupType } from './useAlbumList';
 import { GridPhoto, useInfiniteScrollPhotos } from './useInfiniteScrollPhotos';
 
 export const usePhotoGrid = (
   albumName: string | null,
-  groupTypes: 'Album' | 'SmartAlbum' | null,
+  groupTypes: AlbumGroupType | null,
 ) => {
   const [capturedPhotos, setCapturedPhotos] = useState<GridPhoto[]>([]);
   const { photos, fetchPhotos, hasNextPage, resetPhotos } =

--- a/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
@@ -4,9 +4,12 @@ import { useCameraCapture } from './useCameraCapture';
 import { usePhotoGrid } from './usePhotoGrid';
 import { usePhotoSelection } from './usePhotoSelection';
 
-export const usePhotoPicker = (variant: 'main' | 'extra' | 'cover') => {
+export const usePhotoPicker = (
+  variant: 'main' | 'extra' | 'cover',
+  albumName: string | null,
+) => {
   const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto } =
-    usePhotoGrid();
+    usePhotoGrid(albumName);
 
   const {
     mainPhoto,

--- a/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
@@ -7,9 +7,10 @@ import { usePhotoSelection } from './usePhotoSelection';
 export const usePhotoPicker = (
   variant: 'main' | 'extra' | 'cover',
   albumName: string | null,
+  groupTypes: 'Album' | 'SmartAlbum' | null,
 ) => {
   const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto } =
-    usePhotoGrid(albumName);
+    usePhotoGrid(albumName, groupTypes);
 
   const {
     mainPhoto,

--- a/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { AlbumGroupType } from './useAlbumList';
 import { useCameraCapture } from './useCameraCapture';
 import { usePhotoGrid } from './usePhotoGrid';
 import { usePhotoSelection } from './usePhotoSelection';
@@ -7,7 +8,7 @@ import { usePhotoSelection } from './usePhotoSelection';
 export const usePhotoPicker = (
   variant: 'main' | 'extra' | 'cover',
   albumName: string | null,
-  groupTypes: 'Album' | 'SmartAlbum' | null,
+  groupTypes: AlbumGroupType | null,
 ) => {
   const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto } =
     usePhotoGrid(albumName, groupTypes);

--- a/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
@@ -111,7 +111,7 @@ const PhotoSelectHeader = ({
           onPress={onToggleAlbumList}
           className="flex-row items-center self-start"
           style={{ gap: 4 }}>
-          <Text className="text-gray-900 headline-03">{albumName}</Text>
+          <Text className="text-gray-900 headline-02">{albumName}</Text>
           <Animated.View style={toggleAnimatedStyle}>
             <ToggleIcons shape="down" width={24} height={24} />
           </Animated.View>

--- a/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
@@ -6,14 +6,25 @@ import { Pressable, Text, View } from 'react-native';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
 import ReplayIcons from '@/shared/icons/ReplayIcon';
+import ToggleIcons from '@/shared/icons/ToggleIcons';
 
 interface Props {
-  variant: 'main' | 'extra' | 'cover'; // 대표사진 / 추가사진 / 픽셀북 커버 사진
+  variant: 'main' | 'extra' | 'cover';
   onReset?: () => void;
   hasSelected?: boolean;
+  albumName: string;
+  isAlbumListOpen: boolean;
+  onToggleAlbumList: () => void;
 }
 
-const PhotoSelectHeader = ({ variant, onReset, hasSelected }: Props) => {
+const PhotoSelectHeader = ({
+  variant,
+  onReset,
+  hasSelected,
+  albumName,
+  isAlbumListOpen,
+  onToggleAlbumList,
+}: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
 
   const getHeaderText = () => {
@@ -75,6 +86,20 @@ const PhotoSelectHeader = ({ variant, onReset, hasSelected }: Props) => {
       </View>
 
       <View className="px-1 py-2">{content.desc}</View>
+
+      <View className="border-b border-gray-100 px-5 py-2">
+        <Pressable
+          onPress={onToggleAlbumList}
+          className="flex-row items-center self-start"
+          style={{ gap: 4 }}>
+          <Text className="text-gray-900 headline-03">{albumName}</Text>
+          <ToggleIcons
+            shape={isAlbumListOpen ? 'up' : 'down'}
+            width={24}
+            height={24}
+          />
+        </Pressable>
+      </View>
     </>
   );
 };

--- a/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 import { Pressable, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ArrowIcons from '@/shared/icons/ArrowIcons';
@@ -26,6 +32,19 @@ const PhotoSelectHeader = ({
   onToggleAlbumList,
 }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
+
+  const rotation = useSharedValue(0);
+
+  useEffect(() => {
+    rotation.value = withTiming(isAlbumListOpen ? 180 : 0, {
+      duration: 300,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [isAlbumListOpen]);
+
+  const toggleAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotation.value}deg` }],
+  }));
 
   const getHeaderText = () => {
     switch (variant) {
@@ -93,11 +112,9 @@ const PhotoSelectHeader = ({
           className="flex-row items-center self-start"
           style={{ gap: 4 }}>
           <Text className="text-gray-900 headline-03">{albumName}</Text>
-          <ToggleIcons
-            shape={isAlbumListOpen ? 'up' : 'down'}
-            width={24}
-            height={24}
-          />
+          <Animated.View style={toggleAnimatedStyle}>
+            <ToggleIcons shape="down" width={24} height={24} />
+          </Animated.View>
         </Pressable>
       </View>
     </>

--- a/src/feature/picsel/picselUpload/ui/molecules/AlbumItem.tsx
+++ b/src/feature/picsel/picselUpload/ui/molecules/AlbumItem.tsx
@@ -27,7 +27,7 @@ const AlbumItem = memo(({ item, isSelected, onPress }: Props) => (
     )}
     <View className="flex-1">
       <Text
-        className={`${isSelected ? 'text-pink-500' : 'text-gray-900'} headline-01`}>
+        className={`${isSelected ? 'text-pink-500' : 'text-gray-900'} body-rg-02`}>
         {item.title}
       </Text>
       <Text className="text-gray-500 body-rg-01">

--- a/src/feature/picsel/picselUpload/ui/molecules/AlbumItem.tsx
+++ b/src/feature/picsel/picselUpload/ui/molecules/AlbumItem.tsx
@@ -1,0 +1,40 @@
+import React, { memo } from 'react';
+
+import { Image, Pressable, Text, View } from 'react-native';
+
+import { ITEM_HEIGHT } from '../../constants/album';
+import { Album } from '../../hooks/useAlbumList';
+
+interface Props {
+  item: Album;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+const AlbumItem = memo(({ item, isSelected, onPress }: Props) => (
+  <Pressable
+    onPress={onPress}
+    className="flex-row items-center border-b border-gray-100 px-5 py-3"
+    style={{ height: ITEM_HEIGHT, gap: 12 }}>
+    {item.thumbnailUri ? (
+      <Image
+        source={{ uri: item.thumbnailUri }}
+        className="h-14 w-14 rounded-lg"
+        resizeMode="cover"
+      />
+    ) : (
+      <View className="h-14 w-14 items-center justify-center rounded-lg bg-gray-200" />
+    )}
+    <View className="flex-1">
+      <Text
+        className={`${isSelected ? 'text-pink-500' : 'text-gray-900'} headline-01`}>
+        {item.title}
+      </Text>
+      <Text className="text-gray-500 body-rg-01">
+        {item.count.toLocaleString()}
+      </Text>
+    </View>
+  </Pressable>
+));
+
+export default AlbumItem;

--- a/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
@@ -1,6 +1,6 @@
-import React, { memo, useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { FlatList, Image, Pressable, Text, View } from 'react-native';
+import { FlatList } from 'react-native';
 import Animated, {
   Easing,
   runOnJS,
@@ -11,6 +11,7 @@ import Animated, {
 
 import { ALBUM_PANEL, ITEM_HEIGHT } from '../../constants/album';
 import { Album } from '../../hooks/useAlbumList';
+import AlbumItem from '../molecules/AlbumItem';
 
 interface Props {
   albums: Album[];
@@ -18,42 +19,6 @@ interface Props {
   isVisible: boolean;
   onSelectAlbum: (albumTitle: string) => void;
 }
-
-const AlbumItem = memo(
-  ({
-    item,
-    isSelected,
-    onPress,
-  }: {
-    item: Album;
-    isSelected: boolean;
-    onPress: () => void;
-  }) => (
-    <Pressable
-      onPress={onPress}
-      className="flex-row items-center border-b border-gray-100 px-5 py-3"
-      style={{ height: ITEM_HEIGHT, gap: 12 }}>
-      {item.thumbnailUri ? (
-        <Image
-          source={{ uri: item.thumbnailUri }}
-          className="h-14 w-14 rounded-lg"
-          resizeMode="cover"
-        />
-      ) : (
-        <View className="h-14 w-14 items-center justify-center rounded-lg bg-gray-200" />
-      )}
-      <View className="flex-1">
-        <Text
-          className={`${isSelected ? 'text-pink-500' : 'text-gray-900'} headline-01`}>
-          {item.title}
-        </Text>
-        <Text className="text-gray-500 body-rg-01">
-          {item.count.toLocaleString()}
-        </Text>
-      </View>
-    </Pressable>
-  ),
-);
 
 const getItemLayout = (_: unknown, index: number) => ({
   length: ITEM_HEIGHT,

--- a/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+
+import { FlatList, Image, Pressable, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { Album } from '../../hooks/useAlbumList';
+
+interface Props {
+  albums: Album[];
+  selectedAlbum: string | null;
+  isVisible: boolean;
+  onSelectAlbum: (albumTitle: string) => void;
+}
+
+const SLIDE_DURATION = 250;
+const PANEL_HEIGHT = 400;
+
+const AlbumListPanel = ({
+  albums,
+  selectedAlbum,
+  isVisible,
+  onSelectAlbum,
+}: Props) => {
+  const [shouldRender, setShouldRender] = useState(false);
+  const translateY = useSharedValue(-PANEL_HEIGHT);
+
+  useEffect(() => {
+    if (isVisible) {
+      setShouldRender(true);
+    }
+  }, [isVisible]);
+
+  useEffect(() => {
+    if (shouldRender && isVisible) {
+      translateY.value = -PANEL_HEIGHT;
+      requestAnimationFrame(() => {
+        translateY.value = withTiming(0, {
+          duration: SLIDE_DURATION,
+          easing: Easing.out(Easing.cubic),
+        });
+      });
+    }
+  }, [shouldRender, isVisible]);
+
+  useEffect(() => {
+    if (!isVisible && shouldRender) {
+      translateY.value = withTiming(
+        -PANEL_HEIGHT,
+        { duration: SLIDE_DURATION, easing: Easing.in(Easing.cubic) },
+        () => {
+          runOnJS(setShouldRender)(false);
+        },
+      );
+    }
+  }, [isVisible]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  if (!shouldRender) {
+    return null;
+  }
+
+  const renderAlbumItem = ({ item }: { item: Album }) => {
+    const isSelected = item.title === selectedAlbum;
+
+    return (
+      <Pressable
+        onPress={() => onSelectAlbum(item.title)}
+        className="flex-row items-center border-b border-gray-100 px-5 py-3"
+        style={{ gap: 12 }}>
+        {item.thumbnailUri ? (
+          <Image
+            source={{ uri: item.thumbnailUri }}
+            className="h-14 w-14 rounded-lg"
+            resizeMode="cover"
+          />
+        ) : (
+          <View className="h-14 w-14 items-center justify-center rounded-lg bg-gray-200" />
+        )}
+        <View className="flex-1">
+          <Text
+            className={`headline-03 ${isSelected ? 'text-pink-500' : 'text-gray-900'}`}>
+            {item.title}
+          </Text>
+          <Text className="text-gray-500 body-rg-01">
+            {item.count.toLocaleString()}
+          </Text>
+        </View>
+      </Pressable>
+    );
+  };
+
+  return (
+    <Animated.View
+      style={[
+        animatedStyle,
+        {
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 0,
+          zIndex: 10,
+          backgroundColor: 'white',
+        },
+      ]}
+      pointerEvents={isVisible ? 'auto' : 'none'}>
+      <FlatList
+        data={albums}
+        keyExtractor={(item, index) => `${item.title}-${index}`}
+        renderItem={renderAlbumItem}
+        showsVerticalScrollIndicator={false}
+        bounces={false}
+        style={{ maxHeight: PANEL_HEIGHT }}
+      />
+    </Animated.View>
+  );
+};
+
+export default AlbumListPanel;

--- a/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/AlbumListPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { memo, useCallback, useEffect, useState } from 'react';
 
 import { FlatList, Image, Pressable, Text, View } from 'react-native';
 import Animated, {
@@ -9,6 +9,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { ALBUM_PANEL, ITEM_HEIGHT } from '../../constants/album';
 import { Album } from '../../hooks/useAlbumList';
 
 interface Props {
@@ -18,8 +19,47 @@ interface Props {
   onSelectAlbum: (albumTitle: string) => void;
 }
 
-const SLIDE_DURATION = 250;
-const PANEL_HEIGHT = 400;
+const AlbumItem = memo(
+  ({
+    item,
+    isSelected,
+    onPress,
+  }: {
+    item: Album;
+    isSelected: boolean;
+    onPress: () => void;
+  }) => (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center border-b border-gray-100 px-5 py-3"
+      style={{ height: ITEM_HEIGHT, gap: 12 }}>
+      {item.thumbnailUri ? (
+        <Image
+          source={{ uri: item.thumbnailUri }}
+          className="h-14 w-14 rounded-lg"
+          resizeMode="cover"
+        />
+      ) : (
+        <View className="h-14 w-14 items-center justify-center rounded-lg bg-gray-200" />
+      )}
+      <View className="flex-1">
+        <Text
+          className={`${isSelected ? 'text-pink-500' : 'text-gray-900'} headline-01`}>
+          {item.title}
+        </Text>
+        <Text className="text-gray-500 body-rg-01">
+          {item.count.toLocaleString()}
+        </Text>
+      </View>
+    </Pressable>
+  ),
+);
+
+const getItemLayout = (_: unknown, index: number) => ({
+  length: ITEM_HEIGHT,
+  offset: ITEM_HEIGHT * index,
+  index,
+});
 
 const AlbumListPanel = ({
   albums,
@@ -28,7 +68,7 @@ const AlbumListPanel = ({
   onSelectAlbum,
 }: Props) => {
   const [shouldRender, setShouldRender] = useState(false);
-  const translateY = useSharedValue(-PANEL_HEIGHT);
+  const height = useSharedValue(0);
 
   useEffect(() => {
     if (isVisible) {
@@ -38,10 +78,10 @@ const AlbumListPanel = ({
 
   useEffect(() => {
     if (shouldRender && isVisible) {
-      translateY.value = -PANEL_HEIGHT;
+      height.value = 0;
       requestAnimationFrame(() => {
-        translateY.value = withTiming(0, {
-          duration: SLIDE_DURATION,
+        height.value = withTiming(ALBUM_PANEL.SCREEN_HEIGHT, {
+          duration: ALBUM_PANEL.SLIDE_DURATION,
           easing: Easing.out(Easing.cubic),
         });
       });
@@ -50,9 +90,12 @@ const AlbumListPanel = ({
 
   useEffect(() => {
     if (!isVisible && shouldRender) {
-      translateY.value = withTiming(
-        -PANEL_HEIGHT,
-        { duration: SLIDE_DURATION, easing: Easing.in(Easing.cubic) },
+      height.value = withTiming(
+        0,
+        {
+          duration: ALBUM_PANEL.SLIDE_DURATION,
+          easing: Easing.in(Easing.cubic),
+        },
         () => {
           runOnJS(setShouldRender)(false);
         },
@@ -61,42 +104,28 @@ const AlbumListPanel = ({
   }, [isVisible]);
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.value }],
+    height: height.value,
   }));
+
+  const renderAlbumItem = useCallback(
+    ({ item }: { item: Album }) => (
+      <AlbumItem
+        item={item}
+        isSelected={item.title === selectedAlbum}
+        onPress={() => onSelectAlbum(item.title)}
+      />
+    ),
+    [selectedAlbum, onSelectAlbum],
+  );
+
+  const keyExtractor = useCallback(
+    (item: Album, index: number) => `${item.title}-${index}`,
+    [],
+  );
 
   if (!shouldRender) {
     return null;
   }
-
-  const renderAlbumItem = ({ item }: { item: Album }) => {
-    const isSelected = item.title === selectedAlbum;
-
-    return (
-      <Pressable
-        onPress={() => onSelectAlbum(item.title)}
-        className="flex-row items-center border-b border-gray-100 px-5 py-3"
-        style={{ gap: 12 }}>
-        {item.thumbnailUri ? (
-          <Image
-            source={{ uri: item.thumbnailUri }}
-            className="h-14 w-14 rounded-lg"
-            resizeMode="cover"
-          />
-        ) : (
-          <View className="h-14 w-14 items-center justify-center rounded-lg bg-gray-200" />
-        )}
-        <View className="flex-1">
-          <Text
-            className={`headline-03 ${isSelected ? 'text-pink-500' : 'text-gray-900'}`}>
-            {item.title}
-          </Text>
-          <Text className="text-gray-500 body-rg-01">
-            {item.count.toLocaleString()}
-          </Text>
-        </View>
-      </Pressable>
-    );
-  };
 
   return (
     <Animated.View
@@ -109,16 +138,21 @@ const AlbumListPanel = ({
           top: 0,
           zIndex: 10,
           backgroundColor: 'white',
+          overflow: 'hidden',
         },
       ]}
       pointerEvents={isVisible ? 'auto' : 'none'}>
       <FlatList
         data={albums}
-        keyExtractor={(item, index) => `${item.title}-${index}`}
+        keyExtractor={keyExtractor}
         renderItem={renderAlbumItem}
+        getItemLayout={getItemLayout}
+        initialNumToRender={10}
+        maxToRenderPerBatch={10}
+        removeClippedSubviews
         showsVerticalScrollIndicator={false}
         bounces={false}
-        style={{ maxHeight: PANEL_HEIGHT }}
+        style={{ flex: 1 }}
       />
     </Animated.View>
   );

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -2,13 +2,16 @@ import React, { useRef } from 'react';
 
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import SelectButton from '@/feature/brand/ui/organisms/SelectButton';
 import { usePicselBook } from '@/feature/picsel/picselBook/hooks/usePicselBook';
+import { useAlbumList } from '@/feature/picsel/picselUpload/hooks/useAlbumList';
 import { usePhotoPicker } from '@/feature/picsel/picselUpload/hooks/usePhotoPicker';
 import { usePicselUploadStore } from '@/feature/picsel/picselUpload/hooks/usePicselUploadStore';
 import PhotoSelectHeader from '@/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader';
+import AlbumListPanel from '@/feature/picsel/picselUpload/ui/organisms/AlbumListPanel';
 import { PhotoGrid } from '@/feature/picsel/picselUpload/ui/organisms/PhotoGrid';
 import PicselBookBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet';
 import { MainNavigationProps } from '@/navigation';
@@ -38,6 +41,15 @@ const SelectPhotoScreen = () => {
   const { setMainPhoto, addExtraPhotos } = usePicselUploadStore();
 
   const {
+    albums,
+    selectedAlbum,
+    displayAlbumName,
+    isAlbumListOpen,
+    toggleAlbumList,
+    selectAlbum,
+  } = useAlbumList();
+
+  const {
     photos,
     selectedUris,
     selectedCount,
@@ -45,7 +57,7 @@ const SelectPhotoScreen = () => {
     handleSelectPhoto,
     handleOpenCamera,
     resetSelection,
-  } = usePhotoPicker(variant);
+  } = usePhotoPicker(variant, selectedAlbum);
 
   const { handleSubmit } = usePicselBook();
 
@@ -69,17 +81,29 @@ const SelectPhotoScreen = () => {
       <PhotoSelectHeader
         variant={variant}
         onReset={resetSelection}
-        hasSelected={!!selectedUris}
+        hasSelected={!!selectedUris.length}
+        albumName={displayAlbumName}
+        isAlbumListOpen={isAlbumListOpen}
+        onToggleAlbumList={toggleAlbumList}
       />
 
-      <PhotoGrid
-        photos={photos}
-        selectedUris={selectedUris}
-        variant={variant}
-        onSelectPhoto={handleSelectPhoto}
-        onOpenCamera={handleOpenCamera}
-        onLoadMore={fetchPhotos}
-      />
+      <View style={{ flex: 1 }}>
+        <PhotoGrid
+          photos={photos}
+          selectedUris={selectedUris}
+          variant={variant}
+          onSelectPhoto={handleSelectPhoto}
+          onOpenCamera={handleOpenCamera}
+          onLoadMore={fetchPhotos}
+        />
+
+        <AlbumListPanel
+          albums={albums}
+          selectedAlbum={selectedAlbum}
+          isVisible={isAlbumListOpen}
+          onSelectAlbum={selectAlbum}
+        />
+      </View>
 
       <PicselBookBottomSheet
         ref={picselBookRef}

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -43,6 +43,7 @@ const SelectPhotoScreen = () => {
   const {
     albums,
     selectedAlbum,
+    selectedGroupTypes,
     displayAlbumName,
     isAlbumListOpen,
     toggleAlbumList,
@@ -57,7 +58,7 @@ const SelectPhotoScreen = () => {
     handleSelectPhoto,
     handleOpenCamera,
     resetSelection,
-  } = usePhotoPicker(variant, selectedAlbum);
+  } = usePhotoPicker(variant, selectedAlbum, selectedGroupTypes);
 
   const { handleSubmit } = usePicselBook();
 

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -46,6 +46,7 @@ const SelectPhotoScreen = () => {
     selectedGroupTypes,
     displayAlbumName,
     isAlbumListOpen,
+    isReady,
     toggleAlbumList,
     selectAlbum,
   } = useAlbumList();
@@ -89,14 +90,16 @@ const SelectPhotoScreen = () => {
       />
 
       <View style={{ flex: 1 }}>
-        <PhotoGrid
-          photos={photos}
-          selectedUris={selectedUris}
-          variant={variant}
-          onSelectPhoto={handleSelectPhoto}
-          onOpenCamera={handleOpenCamera}
-          onLoadMore={fetchPhotos}
-        />
+        {isReady && (
+          <PhotoGrid
+            photos={photos}
+            selectedUris={selectedUris}
+            variant={variant}
+            onSelectPhoto={handleSelectPhoto}
+            onOpenCamera={handleOpenCamera}
+            onLoadMore={fetchPhotos}
+          />
+        )}
 
         <AlbumListPanel
           albums={albums}


### PR DESCRIPTION
## 이슈 번호

> close #147 

## 작업 내용 및 테스트 방법

https://github.com/user-attachments/assets/68d3bfbd-f441-4c8f-93fd-bcc73de6a0b5

- 사진 선택 화면에서 디바이스 앨범(User Album + Smart Album) 목록을 조회하고 카테고리별로 전환할 수 있는 기능 추가
- 헤더 토글 클릭 시 앨범 리스트 패널이 슬라이드 애니메이션으로 확장/축소
- 각 앨범별 썸네일, 사진 수 표시 및 `groupTypes` 기반 정확한 사진 필터링 적용