### PR TITLE
🐛 Fix :  typing 입력 스크롤 및 제목 폰트 이슈 수정

### DIFF
--- a/src/feature/picsel/picselUpload/constants/styles/input.ts
+++ b/src/feature/picsel/picselUpload/constants/styles/input.ts
@@ -1,0 +1,11 @@
+export const INPUT_COLORS = {
+  placeholder: '#7E8392',
+  selection: '#FF6C9A',
+};
+
+export const INPUT_TEXT_STYLE =
+  'font-nanum-square-ac-regular text-[16px] leading-[20px]';
+
+export const TITLE_INPUT_STYLE = `h-6 ${INPUT_TEXT_STYLE} text-primary-black`;
+
+export const CONTENT_INPUT_STYLE = `flex-1 pr-[10px] pt-0 ${INPUT_TEXT_STYLE} text-gray-900`;

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -54,7 +54,7 @@ const RecordWriteStep = () => {
         <View className="px-5 pt-6">
           <Text className="mb-3 text-gray-900 headline-02">내용</Text>
 
-          <View className="min-h-[300px] gap-2 rounded-xl border border-gray-300 p-2">
+          <View className="h-[300px] gap-2 rounded-xl border border-gray-300 p-2">
             <TextInput
               value={title}
               onChangeText={setTitle}

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -9,6 +9,11 @@ import {
   View,
 } from 'react-native';
 
+import {
+  CONTENT_INPUT_STYLE,
+  INPUT_COLORS,
+  TITLE_INPUT_STYLE,
+} from '../../constants/styles/input';
 import { useCompletePicselUpload } from '../../hooks/useCompletePicselUpload';
 import { usePicselUploadStore } from '../../hooks/usePicselUploadStore';
 
@@ -32,12 +37,10 @@ const RecordWriteStep = () => {
       behavior={Platform.select({ ios: 'padding' })}
       className="flex-1">
       <ScrollView
-        contentContainerStyle={{ flexGrow: 1 }}
         keyboardDismissMode="none"
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        bounces={false}
-        className="flex-1">
+        bounces={false}>
         <UploadStepHeader
           title={
             <>
@@ -51,38 +54,35 @@ const RecordWriteStep = () => {
         <View className="px-5 pt-6">
           <Text className="mb-3 text-gray-900 headline-02">내용</Text>
 
-          <View className="min-h-[300px] rounded-xl border border-gray-300 p-4">
+          <View className="min-h-[300px] gap-2 rounded-xl border border-gray-300 p-2">
             <TextInput
               value={title}
               onChangeText={setTitle}
               placeholder="✏️ 제목 입력"
-              placeholderTextColor="#7E8392"
-              className="mb-2 font-nanum-square-ac-regular text-primary-black headline-02"
+              placeholderTextColor={INPUT_COLORS.placeholder}
+              selectionColor={INPUT_COLORS.selection}
+              className={TITLE_INPUT_STYLE}
               maxLength={20}
               returnKeyType="next"
-              style={{ lineHeight: 20 }}
-              selectionColor="#FF6C9A"
             />
-
             <TextInput
               value={content}
               onChangeText={setContent}
               placeholder={
                 '사진과 관련된 에피소드를 자유롭게 작성하여\n이날의 추억을 글로 기록해보아요:)'
               }
-              placeholderTextColor="#7E8392"
+              placeholderTextColor={INPUT_COLORS.placeholder}
+              selectionColor={INPUT_COLORS.selection}
               multiline
               scrollEnabled
-              textAlignVertical="top"
-              className="font-nanum-square-ac-regular text-gray-900"
-              style={{ minHeight: 180, lineHeight: 22 }}
-              selectionColor="#FF6C9A"
+              className={CONTENT_INPUT_STYLE}
             />
           </View>
         </View>
       </ScrollView>
-      <View className="w-full items-center">
+      <View className="px-4">
         <Button
+          className="w-full"
           text="완료"
           color={isFilled ? 'active' : 'disabled'}
           textColor="white"


### PR DESCRIPTION
## 이슈 번호

> close #149 

## 작업 내용 및 테스트 방법

### 작업 내용
- TextInput overflow 시 input이 확장되지 않고 input 내부에서 스크롤되도록 수정
- 제목 TextInput font가 중복되어 적용되는 문제 수정
- TextInput 스타일 중복 제거 및 스타일 상수 분리
  - `INPUT_TEXT_STYLE`
  - `TITLE_INPUT_STYLE`
  - `CONTENT_INPUT_STYLE`
  - `INPUT_COLORS`
- RecordWriteStep 내 불필요한 코드 및 레이아웃 정리

### 테스트 방법
1. 픽셀 업로드 화면 진입
2. 내용 입력(TextInput)에 긴 텍스트 입력
3. 텍스트가 overflow 될 경우 TextInput 내부에서 스크롤되는지 확인
4. `뷁` 등 일부 문자 입력이 정상적으로 가능한지 확인


## To reviewers
버튼 디자인 수정과 관련하여서도 말씀 드릴 부분이 있습니다!
초기에는 버튼을 감싸는 컨테이너의 배경색을 `transparent`로 적용하면 해결될 문제라고 판단했지만, 전체 레이아웃의 배경색을 변경해도 동일한 문제가 발생하여 단순 스타일 수정으로 해결되지 않는 이슈임을 확인했습니다.. 🥲

이후 다은님과 논의한 결과, **TextInput이 focus 되었을 때 키보드가 올라오면서 해당 요소를 위로 밀어 올리는 동작과 비슷하게 버튼과 TextInput이 겹치지 않도록 처리하는 방식**으로 구현 방향을 검토했습니다! 

다만 해당 방식은 예상보다 구현 리소스가 클 것으로 확인 되었고,
정확한 동작 정의를 위해 **피그마 프로토타입이 필요**하다고 판단이 되어 이를 다은님께서 프로토타입을 먼저 정리해주시기로 하셨고, 해당 이슈는 **다른 작업 이후 별도 Task로 진행**하기로 결정했습니다 🙏🏻

또, 업로드 과정 이탈 시 기존 선택되었던 이미지가 초기화 되지 않는 이슈는 제가 확인 하는대로 수정해놓겠습니다! 여러모로 작업 늦어져서 죄송합니다.. 😓