### PR TITLE
🚨 Hotfix: 픽셀북 Context-Menu 접근시 앱 비정상 종료되는 버그

### DIFF
--- a/src/@types/react-native-ios-context-menu.d.ts
+++ b/src/@types/react-native-ios-context-menu.d.ts
@@ -1,0 +1,48 @@
+declare module 'react-native-ios-context-menu' {
+  import { Component } from 'react';
+
+  import { ViewProps } from 'react-native';
+
+  interface MenuItemConfig {
+    actionKey: string;
+    actionTitle: string;
+    menuAttributes?: string[];
+    icon?: {
+      type: string;
+      imageValue: {
+        systemName: string;
+      };
+    };
+  }
+
+  interface MenuConfig {
+    menuTitle: string;
+    menuItems: MenuItemConfig[];
+  }
+
+  interface PreviewConfig {
+    previewType?: string;
+    previewSize?: string;
+    isResizeAnimated?: boolean;
+    borderRadius?: number;
+  }
+
+  interface OnPressMenuItemEvent {
+    nativeEvent: {
+      actionKey: string;
+      actionTitle: string;
+    };
+  }
+
+  interface ContextMenuViewProps extends ViewProps {
+    menuConfig: MenuConfig;
+    previewConfig?: PreviewConfig;
+    onPressMenuItem?: (event: OnPressMenuItemEvent) => void;
+    onMenuWillShow?: () => void;
+    onMenuDidShow?: () => void;
+    onMenuWillHide?: () => void;
+    onMenuDidHide?: () => void;
+  }
+
+  export class ContextMenuView extends Component<ContextMenuViewProps> {}
+}

--- a/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
+++ b/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Pressable, Text, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { ContextMenuView } from 'react-native-ios-context-menu';
 
 import PicselBookSkeleton from '@/feature/picsel/shared/components/ui/atoms/Skeleton/PicselBookSkeleton';
@@ -36,9 +37,12 @@ const PicselBookCard = ({
   onImageLoad,
   onImageError,
 }: Props) => {
-  const handlePress = () => {
-    onPress?.(id, title);
-  };
+  const tapGesture = Gesture.Tap()
+    .maxDuration(400)
+    .onEnd(() => {
+      onPress?.(id, title);
+    })
+    .runOnJS(true);
 
   // 스켈레톤 상태일 때
   if (isLoading) {
@@ -86,7 +90,7 @@ const PicselBookCard = ({
   if (isSelecting) {
     return (
       <Pressable
-        onPress={handlePress}
+        onPress={() => onPress?.(id, title)}
         className="flex flex-col items-center"
         style={{ width: 80 }}>
         {cardContent}
@@ -152,12 +156,11 @@ const PicselBookCard = ({
             break;
         }
       }}>
-      <Pressable
-        onPress={handlePress}
-        className="flex flex-col items-center"
-        style={{ width: 80 }}>
-        {cardContent}
-      </Pressable>
+      <GestureDetector gesture={tapGesture}>
+        <View className="flex flex-col items-center" style={{ width: 80 }}>
+          {cardContent}
+        </View>
+      </GestureDetector>
     </ContextMenuView>
   );
 };

--- a/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
+++ b/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
@@ -98,70 +98,83 @@ const PicselBookCard = ({
     );
   }
 
+  const menuConfig = {
+    menuTitle: '',
+    menuItems: [
+      {
+        actionKey: 'edit',
+        actionTitle: '이름 변경',
+        icon: {
+          type: 'IMAGE_SYSTEM',
+          imageValue: { systemName: 'pencil' },
+        },
+      },
+      {
+        actionKey: 'cover',
+        actionTitle: '커버사진 변경',
+        icon: {
+          type: 'IMAGE_SYSTEM',
+          imageValue: { systemName: 'photo' },
+        },
+      },
+      {
+        actionKey: 'delete',
+        actionTitle: '삭제',
+        menuAttributes: ['destructive'],
+        icon: {
+          type: 'IMAGE_SYSTEM',
+          imageValue: { systemName: 'trash' },
+        },
+      },
+    ],
+  };
+
+  const handleMenuItem = ({
+    nativeEvent,
+  }: {
+    nativeEvent: { actionKey: string };
+  }) => {
+    switch (nativeEvent.actionKey) {
+      case 'edit':
+        onEdit?.(id, title);
+        break;
+      case 'cover':
+        onChangeCover?.(id);
+        break;
+      case 'delete':
+        onDelete?.(id, title);
+        break;
+    }
+  };
+
   // 선택 모드가 아닐 때는 ContextMenuView 사용
   return (
-    <ContextMenuView
-      menuConfig={{
-        menuTitle: '',
-        menuItems: [
-          {
-            actionKey: 'edit',
-            actionTitle: '이름 변경',
-            icon: {
-              type: 'IMAGE_SYSTEM',
-              imageValue: {
-                systemName: 'pencil',
-              },
-            },
-          },
-          {
-            actionKey: 'cover',
-            actionTitle: '커버사진 변경',
-            icon: {
-              type: 'IMAGE_SYSTEM',
-              imageValue: {
-                systemName: 'photo',
-              },
-            },
-          },
-          {
-            actionKey: 'delete',
-            actionTitle: '삭제',
-            menuAttributes: ['destructive'],
-            icon: {
-              type: 'IMAGE_SYSTEM',
-              imageValue: {
-                systemName: 'trash',
-              },
-            },
-          },
-        ],
-      }}
-      previewConfig={{
-        previewType: 'DEFAULT',
-        previewSize: 'STRETCH',
-        isResizeAnimated: false,
-        borderRadius: 0,
-      }}
-      onPressMenuItem={({ nativeEvent }) => {
-        switch (nativeEvent.actionKey) {
-          case 'edit':
-            onEdit?.(id, title);
-            break;
-          case 'cover':
-            onChangeCover?.(id);
-            break;
-          case 'delete':
-            onDelete?.(id, title);
-            break;
-        }
-      }}>
-      <GestureDetector gesture={tapGesture}>
-        <View className="flex flex-col items-center" style={{ width: 80 }}>
-          {cardContent}
+    <GestureDetector gesture={tapGesture}>
+      <View className="flex flex-col items-center" style={{ width: 80 }}>
+        <View className="mb-2">
+          <ContextMenuView
+            menuConfig={menuConfig}
+            onPressMenuItem={handleMenuItem}>
+            <PicselBookIcons
+              shape={coverImage ? 'cover-selected' : 'default'}
+              width={80}
+              height={72}
+              imageUri={coverImage}
+              onImageLoad={onImageLoad}
+              onImageError={onImageError}
+            />
+          </ContextMenuView>
         </View>
-      </GestureDetector>
-    </ContextMenuView>
+
+        <Text
+          className="mb-1 text-center text-gray-900 body-rg-02"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={{ width: 80 }}>
+          {title}
+        </Text>
+      </View>
+    </GestureDetector>
   );
 };
 


### PR DESCRIPTION
## 이슈 번호

> close #157 

## 작업 내용 및 테스트 방법

### 픽셀북 Context Menu 크래시 수정
- **원인**: long press 시 `ContextMenuView` 활성화와 `Pressable.onPress`가 동시 발생 → 화면 전환과 context menu preview 충돌로 앱 크래시
- **해결**: `Pressable` 제거 → `GestureDetector` + `Gesture.Tap().maxDuration(400)` 적용. 400ms 이상 터치는 제스처 시스템 레벨에서 tap으로 인식하지 않아 navigation 차단


### 픽셀북 Context Menu config 수정
- `ContextMenuView`가 아이콘(PicselBookIcons)만 감싸도록 구조 변경 → preview에 불필요한 영역 포함 방지
- `previewConfig.backgroundColor: transparent` 적용 → preview 배경 투명 처리


## To reviewers
#157 문제의 경우 유저가 실제로 접하기 어려운 케이스이긴 한데요, 아무래도 앱이 크래시 되는 버그이기 때문에
빠르게 수정하여 PR 생성하였습니다!

React Native의 `GestureDetector` 활용하여 수정하였습니다 👍🏻 