### PR TITLE
✨Feat: 픽셀 업로드 시 내용 입력 화면 내 키보드 동작 수정

### DIFF
--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   KeyboardAvoidingView,
@@ -24,6 +24,7 @@ const RecordWriteStep = () => {
   const [content, setContent] = useState(savedContent || '');
 
   const { complete, isPending } = useCompletePicselUpload();
+  const scrollRef = useRef<ScrollView>(null);
 
   const isFilled = title.trim().length > 0 && content.trim().length > 0;
 
@@ -36,6 +37,7 @@ const RecordWriteStep = () => {
         behavior={Platform.select({ ios: 'padding' })}
         className="flex-1">
         <ScrollView
+          ref={scrollRef}
           keyboardDismissMode="none"
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
@@ -55,6 +57,7 @@ const RecordWriteStep = () => {
             content={content}
             onChangeTitle={setTitle}
             onChangeContent={setContent}
+            onFocus={() => scrollRef.current?.scrollToEnd({ animated: true })}
           />
         </ScrollView>
         <View className="px-4">


### PR DESCRIPTION
## 이슈 번호

> #170 

## 작업 내용 및 테스트 방법

> 픽셀 편집에서의 구현 내용과 같이 픽셀 업로드 시에도 본문 포커스 시 스크롤 하단 이동으로하여 CTA와 본문 겹침 현상을 해결했습니다. 

## To reviewers
충분히 심플하게 구현할 수 있었던 부분을, KAV와 ScrollView 간의 동작으로 어렵게 풀이하려고 했던 점이 너무 아쉽네요,, 🥲 약소하지만 확인 후 머지 부탁드립니다..!!