### PR TITLE
✨ Feat: 픽셀 편집 API 연동

### DIFF
--- a/src/feature/picsel/myPicsel/api/editPicselApi.ts
+++ b/src/feature/picsel/myPicsel/api/editPicselApi.ts
@@ -1,0 +1,18 @@
+import {
+  EditPicselRequest,
+  EditPicselResponse,
+  PicselDetailResponse,
+} from '../types';
+
+import { axiosInstance } from '@/shared/api/axiosInstance';
+
+export const editPicselApi = async (
+  picselId: string,
+  request: EditPicselRequest,
+): Promise<PicselDetailResponse> => {
+  const response = await axiosInstance.patch<EditPicselResponse>(
+    `/picsels/${picselId}`,
+    request,
+  );
+  return response.data.data;
+};

--- a/src/feature/picsel/myPicsel/constants/picselDetailTexts.ts
+++ b/src/feature/picsel/myPicsel/constants/picselDetailTexts.ts
@@ -1,5 +1,5 @@
 export const DROPDOWN_ITEMS = {
-  EDIT: '전체 편집',
+  EDIT: '편집',
   MOVE: '다른 픽셀북으로 이동',
   DELETE: '삭제',
 } as const;
@@ -12,7 +12,7 @@ export const DELETE_ALERT = {
 } as const;
 
 export const EDIT_ALERT = {
-  TITLE: '전체 편집을 종료할까요?',
+  TITLE: '편집을 종료할까요?',
   DESCRIPTION: '지금까지 편집한 정보는\n적용되지 않아요',
   CANCEL: '계속하기',
   CONFIRM: '종료',

--- a/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
+++ b/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
@@ -50,8 +50,8 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
     };
   }, [picselData]);
 
-  const [title, setTitle] = useState(picselData?.title ?? '');
-  const [content, setContent] = useState(picselData?.content ?? '');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
 
   useEffect(() => {
     if (!picselData) {
@@ -61,11 +61,19 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
     setContent(picselData.content);
   }, [picselData]);
 
+  const { mutate: editPicsel } = useEditPicsel();
+  const { mutate: deletePicsels } = useDeletePicsels();
+  const { showToast } = useToastStore();
+
   const { state, actions, datePicker } = useDateLocationForm({
     initialDate: picselData?.takenDate,
     initialStoreId: picselData?.store.storeId,
     initialLocation: picselData?.store.storeName,
     onNext: (date, storeId) => {
+      if (!mainPhoto) {
+        return;
+      }
+
       editPicsel(
         {
           picselId,
@@ -74,7 +82,7 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
             takenDate: date,
             title,
             content,
-            imagePaths: [mainPhoto!, ...extraPhotos],
+            imagePaths: [mainPhoto, ...extraPhotos],
           },
         },
         {
@@ -87,12 +95,11 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
     },
   });
 
-  const { mutate: editPicsel } = useEditPicsel();
-  const { mutate: deletePicsels } = useDeletePicsels();
-  const { showToast } = useToastStore();
-
   const isFilled =
-    state.isFilled && title.trim().length > 0 && content.trim().length > 0;
+    state.isFilled &&
+    !!mainPhoto &&
+    title.trim().length > 0 &&
+    content.trim().length > 0;
 
   const handleSelectMainPhoto = () => {
     navigation.navigate('SelectMainPhoto', { variant: 'main', from: 'edit' });

--- a/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
+++ b/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
@@ -8,6 +8,7 @@ import {
   TOAST_MESSAGES,
 } from '../constants/picselDetailTexts';
 import { useDeletePicsels } from '../mutations/useDeletePicsels';
+import { useEditPicsel } from '../mutations/useEditPicsel';
 import { useGetPicselDetail } from '../queries/useGetPicselDetail';
 
 import { useDateLocationForm } from '@/feature/picsel/shared/hooks/datePicker/useDateLocationForm';
@@ -64,11 +65,29 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
     initialDate: picselData?.takenDate,
     initialStoreId: picselData?.store.storeId,
     initialLocation: picselData?.store.storeName,
-    onNext: (_date, _storeId, _locationName) => {
-      // TODO: 편집 API 연동
+    onNext: (date, storeId) => {
+      editPicsel(
+        {
+          picselId,
+          request: {
+            storeId,
+            takenDate: date,
+            title,
+            content,
+            imagePaths: [mainPhoto!, ...extraPhotos],
+          },
+        },
+        {
+          onSuccess: () => {
+            showToast(TOAST_MESSAGES.EDIT_SUCCESS);
+            navigation.goBack();
+          },
+        },
+      );
     },
   });
 
+  const { mutate: editPicsel } = useEditPicsel();
   const { mutate: deletePicsels } = useDeletePicsels();
   const { showToast } = useToastStore();
 

--- a/src/feature/picsel/myPicsel/mutations/useEditPicsel.ts
+++ b/src/feature/picsel/myPicsel/mutations/useEditPicsel.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { editPicselApi } from '../api/editPicselApi';
+import { EditPicselRequest } from '../types';
+
+import { getRelativeImagePath } from '@/shared/utils/image';
+import { uploadMultipleImagesToS3 } from '@/shared/utils/imageUpload';
+
+export const useEditPicsel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      picselId,
+      request,
+    }: {
+      picselId: string;
+      request: EditPicselRequest;
+    }) => {
+      // 기존 사진(http URL)과 새 사진(로컬 경로)이 섞여 있으므로 새 사진만 S3에 업로드
+      const localPhotos = request.imagePaths.filter(p => !p.startsWith('http'));
+      const s3ImageUrls = await uploadMultipleImagesToS3(
+        localPhotos,
+        picselId,
+        'PICSEL',
+      );
+
+      // 기존 사진은 상대 경로로 변환, 새 사진은 S3 업로드 결과로 교체 (순서 유지)
+      let s3Index = 0;
+      const imagePaths = request.imagePaths.map(photo =>
+        photo.startsWith('http')
+          ? getRelativeImagePath(photo)
+          : s3ImageUrls[s3Index++],
+      );
+
+      return editPicselApi(picselId, { ...request, imagePaths });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myPicsels'] });
+      queryClient.invalidateQueries({ queryKey: ['picselDetail'] });
+      queryClient.invalidateQueries({ queryKey: ['picselBookPicsels'] });
+    },
+  });
+};

--- a/src/feature/picsel/myPicsel/mutations/useEditPicsel.ts
+++ b/src/feature/picsel/myPicsel/mutations/useEditPicsel.ts
@@ -26,11 +26,12 @@ export const useEditPicsel = () => {
       );
 
       // 기존 사진은 상대 경로로 변환, 새 사진은 S3 업로드 결과로 교체 (순서 유지)
-      let s3Index = 0;
+      const localToS3 = new Map(localPhotos.map((p, i) => [p, s3ImageUrls[i]]));
+
       const imagePaths = request.imagePaths.map(photo =>
         photo.startsWith('http')
           ? getRelativeImagePath(photo)
-          : s3ImageUrls[s3Index++],
+          : localToS3.get(photo)!,
       );
 
       return editPicselApi(picselId, { ...request, imagePaths });

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -107,6 +107,7 @@ export interface EditPicselRequest {
   takenDate: string;
   title: string;
   content: string;
+  /** 로컬 파일 경로, http URL, 상대 경로가 혼재할 수 있음. useEditPicsel에서 S3 업로드 후 상대 경로로 정규화됨 */
   imagePaths: string[];
 }
 

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -101,3 +101,15 @@ export interface MovePicselsRequest {
 export interface MovePicselsResponse extends CommonResponseType {
   data: null;
 }
+
+export interface EditPicselRequest {
+  storeId: string;
+  takenDate: string;
+  title: string;
+  content: string;
+  imagePaths: string[];
+}
+
+export interface EditPicselResponse extends CommonResponseType {
+  data: PicselDetailResponse;
+}

--- a/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoPicker.ts
@@ -9,6 +9,7 @@ export const usePhotoPicker = (
   variant: 'main' | 'extra' | 'cover',
   albumName: string | null,
   groupTypes: AlbumGroupType | null,
+  allowReplace = false,
 ) => {
   const { photos, fetchPhotos, hasNextPage, appendCapturedPhoto } =
     usePhotoGrid(albumName, groupTypes);
@@ -21,7 +22,7 @@ export const usePhotoPicker = (
     selectExtraPhoto,
     selectBookCoverPhoto,
     resetCurrentPhoto,
-  } = usePhotoSelection(variant);
+  } = usePhotoSelection(variant, allowReplace);
 
   const { capturePhoto } = useCameraCapture();
 

--- a/src/feature/picsel/picselUpload/hooks/usePhotoSelection.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePhotoSelection.ts
@@ -3,7 +3,10 @@ import { useCallback } from 'react';
 import { usePhotoStore } from '@/shared/store/picselUpload';
 import { useToastStore } from '@/shared/store/ui/toast';
 
-export const usePhotoSelection = (variant: 'main' | 'extra' | 'cover') => {
+export const usePhotoSelection = (
+  variant: 'main' | 'extra' | 'cover',
+  allowReplace = false,
+) => {
   const MAX_EXTRA_COUNT = 10;
   const { showToast } = useToastStore();
 
@@ -25,14 +28,14 @@ export const usePhotoSelection = (variant: 'main' | 'extra' | 'cover') => {
         return;
       }
 
-      if (mainPhoto) {
+      if (mainPhoto && !allowReplace) {
         showToast('대표사진은 1장만 선택 가능해요', 60);
         return;
       }
 
       setMainPhoto(uri);
     },
-    [mainPhoto, setMainPhoto, showToast],
+    [mainPhoto, setMainPhoto, showToast, allowReplace],
   );
 
   const selectBookCoverPhoto = useCallback(

--- a/src/feature/picsel/picselUpload/ui/organisms/MainPhotoCard.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/MainPhotoCard.tsx
@@ -10,17 +10,24 @@ interface Props {
   uri: string | null;
   onDelete: () => void;
   onSelect: () => void;
+  variant?: 'upload' | 'edit';
 }
 
-const MainPhotoCard = ({ uri, onDelete, onSelect }: Props) => {
+const MainPhotoCard = ({
+  uri,
+  onDelete,
+  onSelect,
+  variant = 'upload',
+}: Props) => {
   const hasPhoto = !!uri;
+  const isEdit = variant === 'edit';
 
   return (
     <View className="items-center px-4 pb-8 pt-6">
       <View className="relative max-h-[280px] max-w-[280px]">
         <Pressable
-          onPress={!hasPhoto ? onSelect : undefined}
-          disabled={hasPhoto}
+          onPress={!hasPhoto || isEdit ? onSelect : undefined}
+          disabled={hasPhoto && !isEdit}
           className={`aspect-square overflow-hidden rounded-xl border bg-white ${
             hasPhoto ? 'border-pink-300' : 'border-pink-500'
           }`}>
@@ -45,21 +52,22 @@ const MainPhotoCard = ({ uri, onDelete, onSelect }: Props) => {
           }`}>
           <Text className="text-pink-500 body-rg-01">대표{'\n'}사진</Text>
         </View>
-        {hasPhoto ? (
-          <Pressable
-            onPress={onDelete}
-            hitSlop={10}
-            className="absolute -right-2 -top-2">
-            <CloseCircleIcons shape="M" width={24} height={24} />
-          </Pressable>
-        ) : (
-          <Pressable
-            onPress={onSelect}
-            hitSlop={10}
-            className="absolute -right-2 -top-2">
-            <PlusCircleIcons shape="M" width={24} height={24} />
-          </Pressable>
-        )}
+        {!isEdit &&
+          (hasPhoto ? (
+            <Pressable
+              onPress={onDelete}
+              hitSlop={10}
+              className="absolute -right-2 -top-2">
+              <CloseCircleIcons shape="M" width={24} height={24} />
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={onSelect}
+              hitSlop={10}
+              className="absolute -right-2 -top-2">
+              <PlusCircleIcons shape="M" width={24} height={24} />
+            </Pressable>
+          ))}
       </View>
     </View>
   );

--- a/src/feature/picsel/shared/components/ui/organisms/PhotoEditSection.tsx
+++ b/src/feature/picsel/shared/components/ui/organisms/PhotoEditSection.tsx
@@ -12,6 +12,7 @@ interface Props {
   onSelectMainPhoto: () => void;
   onAddExtraPhoto: () => void;
   onRemoveExtraPhoto: (index: number) => void;
+  variant?: 'upload' | 'edit';
 }
 
 const PhotoEditSection = ({
@@ -21,6 +22,7 @@ const PhotoEditSection = ({
   onSelectMainPhoto,
   onAddExtraPhoto,
   onRemoveExtraPhoto,
+  variant,
 }: Props) => {
   return (
     <>
@@ -30,6 +32,7 @@ const PhotoEditSection = ({
           uri={mainPhoto}
           onDelete={onDeleteMainPhoto}
           onSelect={onSelectMainPhoto}
+          variant={variant}
         />
       </View>
 

--- a/src/screens/picsel/picselDetail/index.tsx
+++ b/src/screens/picsel/picselDetail/index.tsx
@@ -112,7 +112,7 @@ const PicselDetailScreen = ({ route, navigation }: Props) => {
         </View>
         <View className="justify-between px-4">
           {extraPhotos.length > 0 && (
-            <View className="justify-between px-4">
+            <View className="justify-between">
               {extraPhotos.map(photo => (
                 <Pressable
                   key={photo.imagePath}

--- a/src/screens/picsel/picselEdit/index.tsx
+++ b/src/screens/picsel/picselEdit/index.tsx
@@ -64,7 +64,7 @@ const PicselEditScreen = ({ route, navigation }: Props) => {
             color="#26272C"
           />
         </Pressable>
-        <Text className="text-gray-900 title-01">전체 편집</Text>
+        <Text className="text-gray-900 title-01">편집</Text>
         <Pressable className="absolute right-4" onPress={handleClose}>
           <CloseIcons height={24} width={24} shape="black" />
         </Pressable>
@@ -84,6 +84,7 @@ const PicselEditScreen = ({ route, navigation }: Props) => {
             onSelectMainPhoto={handleSelectMainPhoto}
             onAddExtraPhoto={handleAddExtraPhoto}
             onRemoveExtraPhoto={removeExtraPhoto}
+            variant="edit"
           />
 
           <InputButton

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -57,7 +57,12 @@ const SelectPhotoScreen = () => {
     handleSelectPhoto,
     handleOpenCamera,
     resetSelection,
-  } = usePhotoPicker(variant, selectedAlbum, selectedGroupTypes);
+  } = usePhotoPicker(
+    variant,
+    selectedAlbum,
+    selectedGroupTypes,
+    from === 'edit',
+  );
 
   const { handleSubmit } = usePicselBook();
 

--- a/src/shared/utils/image.ts
+++ b/src/shared/utils/image.ts
@@ -25,3 +25,17 @@ export const getImageUrl = (path?: string | null): string => {
 
   return `${baseUrl}${normalizedPath}`;
 };
+
+/**
+ * 완전한 이미지 URL에서 IMAGE_URL을 제거하여 상대 경로를 반환 (getImageUrl의 역연산)
+ *
+ * @param url - 완전한 이미지 URL
+ * @returns 상대 경로
+ *
+ * @example
+ * getRelativeImagePath('https://imgdev.picsel.co.kr/img/picsel/abc.jpg')  // 'img/picsel/abc.jpg'
+ */
+export const getRelativeImagePath = (url: string): string => {
+  const baseUrl = (Config.IMAGE_URL ?? '').replace(/\/+$/, '');
+  return url.replace(`${baseUrl}/`, '');
+};


### PR DESCRIPTION
## 이슈 번호

> #165 

## 작업 내용 및 테스트 방법
- 픽셀 편집 API 연동 (`useEditPicsel`)
    - 기존 사진(http URL)은 상대 경로로 변환, 새 사진(로컬 경로)만 S3 업로드 후 교체
    - `getRelativeImagePath` 유틸 함수 추가 (전체 이미지 URL → 상대 경로 역연산)
    
- 편집 화면 대표사진 카드 UI 개선 (`MainPhotoCard`)
    - 편집 모드에서 삭제/추가 아이콘 숨김
    - 이미지 영역 전체를 탭하면 사진 선택 화면으로 이동
    
- 편집 모드에서 대표사진 선택 시 교체 동작 구현
    - 기존 업로드 모드: 이미 선택된 경우 토스트 표시
    - 편집 모드: `allowReplace` 플래그로 토스트 없이 이미지 교체
   
## To reviewers
1. 기존 픽셀의 편집 화면 진입
2. 대표사진 탭 → 새 사진 선택 후 교체 확인
3. 추가 사진 변경 후 편집 완료 → 변경 내용 반영 확인
4. 기존 사진이 그대로 유지되는지 (새로 업로드되지 않는지) 확인