### PR TITLE
⛑️ QA: TestFlight 0.1(13)v 수정사항 대응

### DIFF
--- a/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/MonthFilterView.tsx
@@ -31,6 +31,7 @@ interface Props {
   onViewMonthFolder: (year: string, month: string) => void;
   onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onShowSkeletonChange?: (showSkeleton: boolean) => void;
+  onPhotoPress?: (photoId: string) => void;
 }
 
 const MonthFilterView = forwardRef<FlatList, Props>(
@@ -41,6 +42,7 @@ const MonthFilterView = forwardRef<FlatList, Props>(
       onViewMonthFolder,
       onScroll,
       onShowSkeletonChange,
+      onPhotoPress,
     },
     ref,
   ) => {
@@ -107,6 +109,7 @@ const MonthFilterView = forwardRef<FlatList, Props>(
                   showYear={false}
                   onImageLoad={handleImageLoad}
                   onImageError={handleImageError}
+                  onPress={() => onPhotoPress?.(photo.id)}
                 />
               </View>
             ))}

--- a/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/YearFilterView.tsx
@@ -31,6 +31,7 @@ interface Props {
   onViewAllYear: (year: string) => void;
   onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onShowSkeletonChange?: (showSkeleton: boolean) => void;
+  onPhotoPress?: (photoId: string) => void;
 }
 
 const YearFilterView = forwardRef<FlatList, Props>(
@@ -42,6 +43,7 @@ const YearFilterView = forwardRef<FlatList, Props>(
       onViewAllYear,
       onScroll,
       onShowSkeletonChange,
+      onPhotoPress,
     },
     ref,
   ) => {
@@ -128,6 +130,7 @@ const YearFilterView = forwardRef<FlatList, Props>(
                     showYear={false}
                     onImageLoad={handleImageLoad}
                     onImageError={handleImageError}
+                    onPress={() => onPhotoPress?.(photo.id)}
                   />
                 </View>
               ))}

--- a/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/template/MyPicselTemplate.tsx
@@ -58,6 +58,7 @@ const MyPicselTemplate = () => {
 
     handleViewAllYear,
     handleViewMonthFolder,
+    handlePhotoPress,
   } = useMyPicsel();
 
   const [showingSkeleton, setShowingSkeleton] = useState(false);
@@ -120,6 +121,7 @@ const MyPicselTemplate = () => {
           onViewMore={handleViewMonthFolder}
           onViewAllYear={handleViewAllYear}
           onShowSkeletonChange={handleShowSkeletonChange}
+          onPhotoPress={handlePhotoPress}
         />
       ) : dateFilter === 'month' ? (
         <MonthFilterView
@@ -129,6 +131,7 @@ const MyPicselTemplate = () => {
           isLoading={isLoading}
           onViewMonthFolder={handleViewMonthFolder}
           onShowSkeletonChange={handleShowSkeletonChange}
+          onPhotoPress={handlePhotoPress}
         />
       ) : (
         <PhotoListView
@@ -141,6 +144,7 @@ const MyPicselTemplate = () => {
           onScroll={handleScroll}
           onEndReached={handleEndReached}
           onShowSkeletonChange={handleShowSkeletonChange}
+          onPhotoPress={handlePhotoPress}
         />
       )}
 

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -149,6 +149,11 @@ export const useMyPicsel = () => {
     navigation.navigate('MonthFolder', { year, month });
   };
 
+  // 픽셀 상세로 이동
+  const handlePhotoPress = (picselId: string) => {
+    navigation.navigate('PicselDetail', { picselId });
+  };
+
   // 정렬 액션시트
   const { showSortSheet } = useSortActionSheet({
     onSort: setSortType,
@@ -213,5 +218,6 @@ export const useMyPicsel = () => {
     // 네비게이션
     handleViewAllYear,
     handleViewMonthFolder,
+    handlePhotoPress,
   };
 };

--- a/src/feature/picsel/myPicsel/hooks/usePicselDetailMenu.tsx
+++ b/src/feature/picsel/myPicsel/hooks/usePicselDetailMenu.tsx
@@ -13,6 +13,7 @@ import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
 import PicselActionIcons from '@/shared/icons/PicselActionIcons';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
+import { useMyPicselStore } from '@/shared/store/myPicsel';
 import { useToastStore } from '@/shared/store/ui/toast';
 
 interface Props {
@@ -28,6 +29,7 @@ export const usePicselDetailMenu = ({
 }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const { showToast } = useToastStore();
+  const { setActiveTab } = useMyPicselStore();
 
   const { mutate: deletePicsels } = useDeletePicsels();
 
@@ -66,7 +68,8 @@ export const usePicselDetailMenu = ({
                   {
                     onSuccess: () => {
                       showToast(TOAST_MESSAGES.DELETE_SUCCESS);
-                      navigation.goBack();
+                      setActiveTab('my');
+                      navigation.pop(2);
                     },
                   },
                 );
@@ -90,6 +93,7 @@ export const usePicselDetailMenu = ({
       showToast,
       navigation,
       deletePicsels,
+      setActiveTab,
     ],
   );
 

--- a/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
+++ b/src/feature/picsel/picselUpload/ui/layout/PicselUploadLayout.tsx
@@ -8,6 +8,7 @@ import PicselUploadHeader from './PicselUploadHeader';
 
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
+import { useMyPicselStore } from '@/shared/store/myPicsel';
 
 interface Props {
   children: React.ReactNode;
@@ -17,13 +18,11 @@ interface Props {
 const PicselUploadLayout = ({ children, onBack }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const { confirmExitUpload } = useConfirmExit();
+  const { setActiveTab } = useMyPicselStore();
 
   const navigateToExit = () => {
-    if (navigation.canGoBack()) {
-      navigation.goBack();
-    } else {
-      navigation.navigate('Home');
-    }
+    setActiveTab('my');
+    navigation.navigate('Home', { screen: 'BookScreen' });
   };
 
   const handleBack = () => {

--- a/src/feature/picsel/shared/hooks/animation/usePicselBookTab.ts
+++ b/src/feature/picsel/shared/hooks/animation/usePicselBookTab.ts
@@ -1,14 +1,16 @@
-import { useState } from 'react';
+import { useEffect } from 'react';
 
 import { useWindowDimensions } from 'react-native';
 import { useSharedValue, withTiming } from 'react-native-reanimated';
 
 import { tabAnimationService } from './tabAnimationService';
 
+import { useMyPicselStore } from '@/shared/store/myPicsel';
+
 const INDICATOR_WIDTH = 167;
 
 export const usePicselBookTab = (initialTab: 'my' | 'book' = 'my') => {
-  const [activeTab, setActiveTab] = useState<'my' | 'book'>(initialTab);
+  const { activeTab, setActiveTab } = useMyPicselStore();
   const { width: screenWidth } = useWindowDimensions();
   const tabWidth = screenWidth / 2;
 
@@ -19,10 +21,9 @@ export const usePicselBookTab = (initialTab: 'my' | 'book' = 'my') => {
   );
   const indicatorPosition = useSharedValue(initialPosition);
 
-  const handleTabChange = (tab: 'my' | 'book') => {
-    setActiveTab(tab);
+  useEffect(() => {
     const newPosition = tabAnimationService.calculateIndicatorPosition(
-      tab,
+      activeTab,
       tabWidth,
       INDICATOR_WIDTH,
     );
@@ -30,6 +31,10 @@ export const usePicselBookTab = (initialTab: 'my' | 'book' = 'my') => {
       newPosition,
       tabAnimationService.getAnimationConfig(),
     );
+  }, [activeTab, tabWidth, indicatorPosition]);
+
+  const handleTabChange = (tab: 'my' | 'book') => {
+    setActiveTab(tab);
   };
 
   return {

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -21,6 +21,13 @@ import QrScanScreen from '@/screens/qr/scan';
 import QrViewerScreen from '@/screens/qr/viewer';
 import StoreSearchScreen from '@/screens/search';
 
+export type BottomTabNavigationProps = {
+  HomeScreen: undefined;
+  QRScreen: undefined;
+  BookScreen: undefined;
+  MyScreen: undefined;
+};
+
 export type MainNavigationProps = {
   // Auth
   Onboarding: undefined;
@@ -28,7 +35,7 @@ export type MainNavigationProps = {
   SignupRoute: undefined;
 
   // Main
-  Home: undefined;
+  Home: NavigatorScreenParams<BottomTabNavigationProps>;
   StoreSearch: undefined;
 
   // QR

--- a/src/screens/search/index.tsx
+++ b/src/screens/search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import Geolocation from '@react-native-community/geolocation';
 import { useNavigation } from '@react-navigation/native';
@@ -124,12 +124,15 @@ const StoreSearchScreen = () => {
           autoFocus
         />
         <View className="flex-1">
-          <SearchResultList
-            data={result}
-            highlight={highlight}
-            onPressItem={handleResultPress}
-          />
-          {!hasResults && <NoResult visible={uiState === 'noResults'} />}
+          {hasResults ? (
+            <SearchResultList
+              data={result}
+              highlight={highlight}
+              onPressItem={handleResultPress}
+            />
+          ) : (
+            <NoResult visible={uiState === 'noResults'} />
+          )}
         </View>
       </ScreenLayout>
     </TouchableWithoutFeedback>

--- a/src/shared/store/myPicsel/index.ts
+++ b/src/shared/store/myPicsel/index.ts
@@ -2,12 +2,18 @@ import { create } from 'zustand';
 
 import { MyPicselSortType } from '@/feature/picsel/myPicsel/types';
 
+type PicselTab = 'my' | 'book';
+
 interface MyPicselState {
   sortType: MyPicselSortType;
   setSortType: (sort: MyPicselSortType) => void;
+  activeTab: PicselTab;
+  setActiveTab: (tab: PicselTab) => void;
 }
 
 export const useMyPicselStore = create<MyPicselState>(set => ({
   sortType: 'RECENT_DESC',
   setSortType: sort => set({ sortType: sort }),
+  activeTab: 'my',
+  setActiveTab: tab => set({ activeTab: tab }),
 }));


### PR DESCRIPTION
## 이슈 번호

> #176 

## 작업 내용
- 내 픽셀 년/월/전체 필터 뷰에서 사진 클릭 시 픽셀 게시글로 이동하는 기능 추가
- 바텀탭 중첩 네비게이션 타입 정의 (`BottomTabNavigationProps`)
- 픽셀 탭 상태(`activeTab`)를 전역 스토어로 이동하여 탭 간 상태 공유 지원
- 브랜드 검색 바텀시트 내 스파클 이미지 포지셔닝 수정

## 테스트 방법
1. 내 픽셀 > 연/월 필터 뷰에서 사진 클릭 → 해당 게시글 상세로 이동 확인
2. 픽셀 삭제 성공 → "내 픽셀" 피드 화면으로 이동 확인
3. 픽셀 업로드 도중 종료 시  → "내 픽셀" 피드 화면으로 이동 확인
4. 홈 내 브랜드 검색 화면 진입 → 정중앙에 스파클 이미지가 위치하는지 확인

## To reviewers
`activeTab` 상태를 로컬에서 전역 스토어(`useMyPicselStore`)로 이동했습니다.
기존 `usePicselBookTab` 훅에서 참조하던 부분도 함께 변경되었으니 확인 부탁드립니다!