### PR TITLE
⛑️ QA: 픽셀 업로드 위치 선택값에 따른 업로드 불가 이슈

### DIFF
--- a/src/feature/picsel/myPicsel/hooks/useFolderView.ts
+++ b/src/feature/picsel/myPicsel/hooks/useFolderView.ts
@@ -87,7 +87,7 @@ export const useFolderView = ({
       id: item.picselId,
       uri: getImageUrl(item.imagePath),
       date: item.takenDate,
-      storeName: item.storeName,
+      storeName: item.placeNameSnapshot,
     }));
   }, [myPicselsData, filterType, year, month, brandIds, isFilterActive]);
 

--- a/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
+++ b/src/feature/picsel/myPicsel/hooks/useMyPicsel.ts
@@ -74,7 +74,7 @@ export const useMyPicsel = () => {
         id: item.picselId,
         uri: getImageUrl(item.imagePath),
         date: item.takenDate,
-        storeName: item.storeName,
+        storeName: item.placeNameSnapshot,
       })),
     [filteredContent],
   );

--- a/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
+++ b/src/feature/picsel/myPicsel/hooks/usePicselEdit.ts
@@ -67,9 +67,10 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
 
   const { state, actions, datePicker } = useDateLocationForm({
     initialDate: picselData?.takenDate,
-    initialStoreId: picselData?.store.storeId,
-    initialLocation: picselData?.store.storeName,
-    onNext: (date, storeId) => {
+    initialPlaceId: picselData?.placeId,
+    initialPlaceType: picselData?.placeType,
+    initialLocation: picselData?.placeNameSnapshot,
+    onNext: (date, placeId, placeType) => {
       if (!mainPhoto) {
         return;
       }
@@ -78,7 +79,8 @@ export const usePicselEdit = ({ picselId, navigation }: Props) => {
         {
           picselId,
           request: {
-            storeId,
+            placeType,
+            placeId,
             takenDate: date,
             title,
             content,

--- a/src/feature/picsel/myPicsel/types/index.ts
+++ b/src/feature/picsel/myPicsel/types/index.ts
@@ -1,3 +1,4 @@
+import { PlaceType } from '@/feature/picsel/shared/types';
 import { CommonResponseType } from '@/shared/api/types';
 
 export type DateFilterType = 'all' | 'year' | 'month';
@@ -5,13 +6,16 @@ export type DateFilterType = 'all' | 'year' | 'month';
 // 정렬 타입
 export type MyPicselSortType = 'RECENT_DESC' | 'OLDEST_ASC';
 
+export type { PlaceType };
+
 // 개별 픽셀 아이템
 export interface MyPicselItem {
   picselId: string;
   imagePath: string;
   takenDate: string;
-  storeId: string;
-  storeName: string;
+  placeType: PlaceType;
+  placeId: string;
+  placeNameSnapshot: string;
   brandImagePath: string;
   brand: {
     brandId: string;
@@ -68,12 +72,6 @@ export interface PicselDetailBook {
   coverImagePath: string;
 }
 
-// 상세 페이지 내 스토어 정보
-export interface PicselDetailStore {
-  storeId: string;
-  storeName: string;
-}
-
 // 상세 페이지 내 개별 사진 아이템
 export interface PicselDetailPhoto {
   imagePath: string;
@@ -88,7 +86,9 @@ export interface PicselDetailResponse {
   title: string;
   content: string;
   takenDate: string;
-  store: PicselDetailStore;
+  placeType: PlaceType;
+  placeId: string;
+  placeNameSnapshot: string;
   photos: PicselDetailPhoto[];
 }
 
@@ -106,7 +106,8 @@ export interface MovePicselsResponse extends CommonResponseType {
 }
 
 export interface EditPicselRequest {
-  storeId: string;
+  placeType: PlaceType;
+  placeId: string;
   takenDate: string;
   title: string;
   content: string;

--- a/src/feature/picsel/myPicsel/utils/groupByDate.ts
+++ b/src/feature/picsel/myPicsel/utils/groupByDate.ts
@@ -8,7 +8,7 @@ const toGroupPhoto = (item: MyPicselItem): GroupPhoto => ({
   id: item.picselId,
   uri: getImageUrl(item.imagePath),
   date: item.takenDate,
-  storeName: item.storeName,
+  storeName: item.placeNameSnapshot,
 });
 
 /**

--- a/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
+++ b/src/feature/picsel/picselBook/components/ui/organisms/PhotoTextListItem.tsx
@@ -117,7 +117,7 @@ const PhotoTextListItem = ({
         <View className="flex-row items-center justify-end self-stretch">
           <SparkleImages shape="icon-one" width={25} height={25} />
           <Text className="text-primary-pink body-rg-02">
-            {picsel.storeName}
+            {picsel.placeNameSnapshot}
           </Text>
         </View>
       </View>

--- a/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBookFolder.ts
@@ -81,7 +81,7 @@ export const usePicselBookFolder = ({ bookId }: UsePicselBookFolderOptions) => {
       id: item.picselId,
       uri: getImageUrl(item.representativeImagePath),
       date: item.takenDate,
-      storeName: item.storeName,
+      storeName: item.placeNameSnapshot,
     }));
   }, [data, brandIds, isFilterActive]);
 

--- a/src/feature/picsel/picselBook/types/index.ts
+++ b/src/feature/picsel/picselBook/types/index.ts
@@ -1,3 +1,4 @@
+import { PlaceType } from '@/feature/picsel/shared/types';
 import { CommonResponseType } from '@/shared/api/types';
 
 // 정렬 타입 (API 명세 기준)
@@ -52,8 +53,9 @@ export interface PicselBookPicselItem {
   title: string;
   contentPreview: string;
   takenDate: string;
-  storeId: string;
-  storeName: string;
+  placeType: PlaceType;
+  placeId: string;
+  placeNameSnapshot: string;
   brandImagePath: string;
   brand: {
     brandId: string;

--- a/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
+++ b/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
@@ -6,6 +6,7 @@ import { useCreatePicselDraft } from '../mutations/useCreatePicselDraft';
 
 import { usePicselUploadStore } from './usePicselUploadStore';
 
+import { PlaceType } from '@/feature/picsel/shared/types';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { usePhotoStore } from '@/shared/store/picselUpload';
 
@@ -20,7 +21,8 @@ export const useCompletePicselUpload = () => {
 
   const {
     takenDate,
-    storeId,
+    placeId,
+    placeType,
     picselbookId,
     bookName,
     setRecord,
@@ -39,7 +41,8 @@ export const useCompletePicselUpload = () => {
     const requestPayload = {
       picselId: draftUuid,
       picselbookId,
-      storeId,
+      placeType: placeType as PlaceType,
+      placeId,
       takenDate,
       title,
       content,

--- a/src/feature/picsel/picselUpload/hooks/usePicselUploadStore.ts
+++ b/src/feature/picsel/picselUpload/hooks/usePicselUploadStore.ts
@@ -1,12 +1,15 @@
 import { create } from 'zustand';
 
+import { PlaceType } from '@/feature/picsel/shared/types';
+
 interface PicselUploadStore {
   // States
   mainPhoto: string | null;
   extraPhotos: string[];
 
   takenDate: string;
-  storeId: string;
+  placeType: PlaceType | '';
+  placeId: string;
   locationName: string;
 
   picselbookId: string;
@@ -23,7 +26,8 @@ interface PicselUploadStore {
 
   setDateLocation: (
     date: string,
-    storeId: string,
+    placeId: string,
+    placeType: PlaceType,
     locationName?: string,
   ) => void;
   setPicselbookId: (id: string, name: string) => void;
@@ -37,7 +41,8 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
   mainPhoto: null,
   extraPhotos: [],
   takenDate: '',
-  storeId: '',
+  placeType: '',
+  placeId: '',
   locationName: '',
   picselbookId: '',
   bookName: '',
@@ -56,10 +61,11 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
       extraPhotos: state.extraPhotos.filter(p => p !== uri),
     })),
 
-  setDateLocation: (date, storeId, locationName) =>
+  setDateLocation: (date, placeId, placeType, locationName) =>
     set({
       takenDate: date,
-      storeId,
+      placeId,
+      placeType,
       locationName: locationName,
     }),
 
@@ -77,7 +83,8 @@ export const usePicselUploadStore = create<PicselUploadStore>((set, get) => ({
       mainPhoto: null,
       extraPhotos: [],
       takenDate: '',
-      storeId: '',
+      placeType: '',
+      placeId: '',
       locationName: '',
       picselbookId: '',
       bookName: '',

--- a/src/feature/picsel/picselUpload/types/index.ts
+++ b/src/feature/picsel/picselUpload/types/index.ts
@@ -1,10 +1,12 @@
+import { PlaceType } from '@/feature/picsel/shared/types';
 import { CommonResponseType } from '@/shared/api/types';
 
 // 픽셀 추가 요청
 export interface PicselUploadRequest {
   picselId: string;
   picselbookId: string;
-  storeId: string;
+  placeType: PlaceType;
+  placeId: string;
   takenDate: string;
   title: string;
   content: string;

--- a/src/feature/picsel/picselUpload/ui/organisms/DateLocationStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/DateLocationStep.tsx
@@ -20,15 +20,16 @@ interface Props {
 }
 
 const DateLocationStep = ({ onNext }: Props) => {
-  const { takenDate, storeId, setDateLocation, locationName } =
+  const { takenDate, placeId, placeType, setDateLocation, locationName } =
     usePicselUploadStore();
 
   const { state, actions, datePicker } = useDateLocationForm({
     initialDate: takenDate,
-    initialStoreId: storeId,
+    initialPlaceId: placeId,
+    initialPlaceType: placeType || undefined,
     initialLocation: locationName,
-    onNext: (date, locationId, locName) => {
-      setDateLocation(date, locationId, locName);
+    onNext: (date, locationId, locPlaceType, locName) => {
+      setDateLocation(date, locationId, locPlaceType, locName);
       onNext();
     },
   });

--- a/src/feature/picsel/shared/components/ui/organisms/bottomSheet/LocationSearchBottomSheet.tsx
+++ b/src/feature/picsel/shared/components/ui/organisms/bottomSheet/LocationSearchBottomSheet.tsx
@@ -7,6 +7,7 @@ import { useHandleScroll } from '@/feature/brand/model/hooks/useHandleScroll';
 import NoResult from '@/feature/brand/ui/organisms/NoResult';
 import { useLocationSearch } from '@/feature/picsel/shared/hooks/bottomSheet/useLocationSearch';
 import { useLocationSearchBottomSheet } from '@/feature/picsel/shared/hooks/bottomSheet/useLocationSearchBottomSheet';
+import { PlaceType } from '@/feature/picsel/shared/types';
 import SearchResultList from '@/feature/search/ui/organisms/SearchResultList';
 import { bottomSheetIndicator } from '@/shared/styles/bottomSheetIndicator';
 import { bottomSheetShadow } from '@/shared/styles/shadows';
@@ -15,7 +16,7 @@ import Input from '@/shared/ui/atoms/Input';
 interface Props {
   visible: boolean;
   onClose: () => void;
-  onSelect: (id: string, name: string) => void;
+  onSelect: (id: string, name: string, placeType: PlaceType) => void;
 }
 
 const LocationSearchBottomSheet = ({ visible, onClose, onSelect }: Props) => {

--- a/src/feature/picsel/shared/hooks/bottomSheet/useLocationSearch.ts
+++ b/src/feature/picsel/shared/hooks/bottomSheet/useLocationSearch.ts
@@ -3,13 +3,20 @@ import { useCallback, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { Keyboard } from 'react-native';
 
+import { PlaceType } from '@/feature/picsel/shared/types';
 import { SearchResultView } from '@/feature/search/hooks/useSearchResultSections';
 import { useStoreSearch } from '@/feature/search/hooks/useStoreSearch';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { useMapLocationStore } from '@/shared/store';
 
+const KIND_TO_PLACE_TYPE: Record<SearchResultView['kind'], PlaceType> = {
+  store: 'STORE',
+  station: 'SUBWAY_STATION',
+  administrativeDistrict: 'ADMINISTRATIVE_DISTRICT',
+};
+
 interface Props {
-  onSelect: (id: string, name: string) => void;
+  onSelect: (id: string, name: string, placeType: PlaceType) => void;
   onClose: () => void;
 }
 
@@ -28,7 +35,7 @@ export const useLocationSearch = ({ onSelect, onClose }: Props) => {
     (item: SearchResultView) => {
       if (item?.id && item?.title) {
         Keyboard.dismiss();
-        onSelect(item.id, item.title);
+        onSelect(item.id, item.title, KIND_TO_PLACE_TYPE[item.kind]);
         onClose();
       }
     },

--- a/src/feature/picsel/shared/hooks/datePicker/useDateLocationForm.ts
+++ b/src/feature/picsel/shared/hooks/datePicker/useDateLocationForm.ts
@@ -3,24 +3,35 @@ import { useCallback, useState } from 'react';
 import dayjs from 'dayjs';
 
 import { useDatePickerController } from '@/feature/picsel/picselUpload/hooks/useDatePickerController';
+import { PlaceType } from '@/feature/picsel/shared/types';
 
 interface Props {
   initialDate?: string;
-  initialStoreId?: string;
+  initialPlaceId?: string;
+  initialPlaceType?: PlaceType;
   initialLocation?: string;
-  onNext: (date: string, storeId: string, locationName: string) => void;
+  onNext: (
+    date: string,
+    placeId: string,
+    placeType: PlaceType,
+    locationName: string,
+  ) => void;
 }
 
 export const useDateLocationForm = ({
   initialDate,
-  initialStoreId,
+  initialPlaceId,
+  initialPlaceType,
   initialLocation,
   onNext,
 }: Props) => {
   const [selectedDate, setSelectedDate] = useState(initialDate);
   const [selectedLocationName, setSelectedLocationName] =
     useState(initialLocation);
-  const [selectedStoreId, setSelectedStoreId] = useState(initialStoreId || '');
+  const [selectedPlaceId, setSelectedPlaceId] = useState(initialPlaceId || '');
+  const [selectedPlaceType, setSelectedPlaceType] = useState<
+    PlaceType | undefined
+  >(initialPlaceType);
 
   const [activeSheet, setActiveSheet] = useState<'date' | 'location' | null>(
     null,
@@ -41,21 +52,33 @@ export const useDateLocationForm = ({
   }, [datePicker]);
 
   const handleSelectLocation = useCallback(
-    (id: string, name: string) => {
-      setSelectedStoreId(id);
+    (id: string, name: string, placeType: PlaceType) => {
+      setSelectedPlaceId(id);
       setSelectedLocationName(name);
+      setSelectedPlaceType(placeType);
       closeSheet();
     },
     [closeSheet],
   );
 
   const handleSubmit = useCallback(() => {
-    if (selectedDate && selectedStoreId) {
-      onNext(selectedDate, selectedStoreId, selectedLocationName);
+    if (selectedDate && selectedPlaceId && selectedPlaceType) {
+      onNext(
+        selectedDate,
+        selectedPlaceId,
+        selectedPlaceType,
+        selectedLocationName,
+      );
     }
-  }, [selectedDate, selectedStoreId, selectedLocationName, onNext]);
+  }, [
+    selectedDate,
+    selectedPlaceId,
+    selectedPlaceType,
+    selectedLocationName,
+    onNext,
+  ]);
 
-  const isFilled = !!(selectedDate && selectedStoreId);
+  const isFilled = !!(selectedDate && selectedPlaceId && selectedPlaceType);
 
   return {
     state: {

--- a/src/feature/picsel/shared/types/index.ts
+++ b/src/feature/picsel/shared/types/index.ts
@@ -1,0 +1,1 @@
+export type PlaceType = 'STORE' | 'ADMINISTRATIVE_DISTRICT' | 'SUBWAY_STATION';

--- a/src/screens/picsel/picselDetail/index.tsx
+++ b/src/screens/picsel/picselDetail/index.tsx
@@ -88,7 +88,7 @@ const PicselDetailScreen = ({ route, navigation }: Props) => {
           <View className="flex-row items-center gap-1 py-2">
             <SparkleImages shape="icon-one" height={24} width={24} />
             <Text className="text-gray-900 body-rg-03">
-              {picselData?.store.storeName}
+              {picselData?.placeNameSnapshot}
             </Text>
           </View>
         </View>


### PR DESCRIPTION
## 이슈 번호

> #187 

## 작업 내용 및 테스트 방법

> - 장소(Place) API 스펙 변경에 따라 프론트 코드를 일괄 수정했습니다.
> - 기존 `store_id` / `store_name` 필드가 `placeType` / `placeId` / `placeNameSnapshot` 형태로 확장되어 장소 타입(매장/지하철역/행정구역)을 구분할 수 있도록 반영했습니다.

### 주요 변경 사항

- 공용 `PlaceType` 타입 추가 (`STORE` / `SUBWAY_STATION` / `ADMINISTRATIVE_DISTRICT`)
- 응답 타입 반영
  - 내 픽셀 모아보기
  - 픽셀 상세 조회
  - 픽셀북 내 픽셀 목록 조회
- 요청 타입 반영
  - 픽셀 수정 
  - 픽셀 추가 
- 장소 선택 흐름(`useLocationSearch`, `useDateLocationForm`, `usePicselUploadStore`)이 `placeType`까지 함께 관리하도록 확장

### 테스트 방법

- [ ] 내 픽셀 모아보기 목록/필터 정상 표시되는지
- [ ] 픽셀 상세 조회에서 위치명 정상 표시되는지
- [ ] 픽셀북 내 픽셀 목록 정상 표시되는지
- [ ] 픽셀 추가 시 매장/지하철역/지역 세 가지의 형태 모두 업로드가 정상적으로 이루어지는지 