### PR TITLE
⛑️ QA: 전체 QA(1차)

### DIFF
--- a/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
+++ b/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
@@ -56,6 +56,9 @@ export const useCompletePicselUpload = () => {
         queryClient.invalidateQueries({
           queryKey: ['picselBookPicsels', picselbookId],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['myPicsels'],
+        });
         navigation.reset({
           index: 1,
           routes: [

--- a/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
+++ b/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
@@ -60,8 +60,9 @@ export const useCompletePicselUpload = () => {
           queryKey: ['myPicsels'],
         });
         navigation.reset({
-          index: 1,
+          index: 2,
           routes: [
+            { name: 'Home', params: { screen: 'BookScreen' } },
             {
               name: 'PicselBookFolder',
               params: { bookId: picselbookId, bookName },

--- a/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
+++ b/src/feature/picsel/picselUpload/hooks/useCompletePicselUpload.ts
@@ -9,6 +9,7 @@ import { usePicselUploadStore } from './usePicselUploadStore';
 import { PlaceType } from '@/feature/picsel/shared/types';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { usePhotoStore } from '@/shared/store/picselUpload';
+import { useToastStore } from '@/shared/store/ui/toast';
 
 type Params = {
   title: string;
@@ -31,6 +32,7 @@ export const useCompletePicselUpload = () => {
   } = usePicselUploadStore();
 
   const { reset: resetPhotoStore } = usePhotoStore();
+  const { showToast } = useToastStore();
 
   const { mutate: uploadPicsel, isPending } = useAddPicselToPicselBook();
   const { mutateAsync: createDraft } = useCreatePicselDraft();
@@ -77,6 +79,7 @@ export const useCompletePicselUpload = () => {
       },
       onError: error => {
         console.error('픽셀 업로드 중 에러 발생:', error);
+        showToast('업로드에 실패했어요😭 다시 시도해주세요', 60);
       },
     });
   };

--- a/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/RecordWriteStep.tsx
@@ -26,8 +26,6 @@ const RecordWriteStep = () => {
   const { complete, isPending } = useCompletePicselUpload();
   const scrollRef = useRef<ScrollView>(null);
 
-  const isFilled = title.trim().length > 0 && content.trim().length > 0;
-
   const handleComplete = () => complete({ title, content });
 
   return (
@@ -64,9 +62,9 @@ const RecordWriteStep = () => {
           <Button
             className="w-full"
             text="완료"
-            color={isFilled ? 'active' : 'disabled'}
+            color="active"
             textColor="white"
-            disabled={!isFilled || isPending}
+            disabled={isPending}
             onPress={handleComplete}
           />
         </View>


### PR DESCRIPTION
## 이슈 번호

> #186 

## 작업 내용 및 테스트 방법

> QA 1차에서 확인된 픽셀 업로드 관련 이슈들을 수정했습니다.

### 주요 변경 사항

- **픽셀 업로드 완료 버튼**: 제목/내용 미입력 시에도 버튼이 항상 활성화되도록 수정
- **픽셀 업로드 완료 후 네비게이션**: 뒤로가기로 내 픽셀 탭(BookScreen) 진입 시 하단 바텀탭바가 사라지던 이슈 해결
- **내 픽셀 탭 최신화**: 업로드 완료 후 `myPicsels` 쿼리 무효화로 신규 게시글이 즉시 반영되도록 수정
- **픽셀 업로드 실패 처리**: 실패 시 `"업로드에 실패했어요😭 다시 시도해주세요"` 토스트 노출

### 테스트 방법

- [ ] 픽셀 업로드에서 제목/내용 비워도 완료 버튼 활성화 확인
- [ ] 업로드 완료 후 상세 → 뒤로가기 시 하단 바텀탭바 유지 확인
- [ ] 업로드 완료 후 내 픽셀 탭에서 신규 게시글 즉시 노출 확인
- [ ] 업로드 실패 시 토스트 노출 확인