### PR TITLE
⛑️ QA: QR 스캔 시 사진 저장 미동작 이슈

### DIFF
--- a/ios/picselFE/Info.plist
+++ b/ios/picselFE/Info.plist
@@ -77,6 +77,16 @@
 		<false/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>mx2.co.kr</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>QR 코드를 스캔하기 위해 카메라 접근 권한이 필요합니다.</string>

--- a/src/feature/picsel/myPicsel/constants/photoViewerTexts.ts
+++ b/src/feature/picsel/myPicsel/constants/photoViewerTexts.ts
@@ -19,13 +19,6 @@ export const SET_REPRESENTATIVE_ALERT = {
   CONFIRM: '변경',
 } as const;
 
-export const SAVE_PERMISSION_MODAL = {
-  TITLE: '설정에서 픽셀의\n사진 접근을 허용해야 해요',
-  DESCRIPTION: '설정 > 픽셀 > 사진에서\n사진 접근 허용으로 변경해 주세요',
-  CANCEL: '취소',
-  CONFIRM: '설정으로 이동',
-} as const;
-
 export const TOAST_MESSAGES = {
   REPRESENTATIVE_SUCCESS: '대표사진이 변경됐어요',
   SAVE_SUCCESS: '사진을 앨범에 저장했어요',

--- a/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
+++ b/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
@@ -1,16 +1,12 @@
 import React, { useMemo } from 'react';
 
-import { openSettings } from 'react-native-permissions';
-
 import { DROPDOWN_ITEMS } from '../constants/photoViewerTexts';
 
 import { useSavePhoto } from './useSavePhoto';
 
 import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
-import { SAVE_PERMISSION_MODAL } from '@/shared/constants/text/photoPermissionText';
 import PicselActionIcons from '@/shared/icons/PicselActionIcons';
-import { showConfirmModal } from '@/shared/lib/confirmModal';
-import { requestPhotoPermission } from '@/shared/lib/photoPermission';
+import { requestPhotoPermissionWithModal } from '@/shared/lib/photoPermission';
 
 interface Props {
   uri: string;
@@ -26,13 +22,8 @@ export const usePhotoViewerMenu = ({ uri, hideDropdown }: Props) => {
         label: DROPDOWN_ITEMS.SAVE_PHOTO,
         onPress: () => {
           hideDropdown(async () => {
-            const hasPermission = await requestPhotoPermission();
+            const hasPermission = await requestPhotoPermissionWithModal();
             if (!hasPermission) {
-              showConfirmModal(SAVE_PERMISSION_MODAL.TITLE, openSettings, {
-                title: SAVE_PERMISSION_MODAL.DESCRIPTION,
-                confirmText: SAVE_PERMISSION_MODAL.CONFIRM,
-                cancelText: SAVE_PERMISSION_MODAL.CANCEL,
-              });
               return;
             }
             savePhoto();

--- a/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
+++ b/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
@@ -7,11 +7,12 @@ import {
   SAVE_PERMISSION_MODAL,
 } from '../constants/photoViewerTexts';
 
-import { checkPhotoPermission, useSavePhoto } from './useSavePhoto';
+import { useSavePhoto } from './useSavePhoto';
 
 import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
 import PicselActionIcons from '@/shared/icons/PicselActionIcons';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
+import { requestPhotoPermission } from '@/shared/lib/photoPermission';
 
 interface Props {
   uri: string;
@@ -27,7 +28,7 @@ export const usePhotoViewerMenu = ({ uri, hideDropdown }: Props) => {
         label: DROPDOWN_ITEMS.SAVE_PHOTO,
         onPress: () => {
           hideDropdown(async () => {
-            const hasPermission = await checkPhotoPermission();
+            const hasPermission = await requestPhotoPermission();
             if (!hasPermission) {
               showConfirmModal(SAVE_PERMISSION_MODAL.TITLE, openSettings, {
                 title: SAVE_PERMISSION_MODAL.DESCRIPTION,

--- a/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
+++ b/src/feature/picsel/myPicsel/hooks/usePhotoViewerMenu.tsx
@@ -2,14 +2,12 @@ import React, { useMemo } from 'react';
 
 import { openSettings } from 'react-native-permissions';
 
-import {
-  DROPDOWN_ITEMS,
-  SAVE_PERMISSION_MODAL,
-} from '../constants/photoViewerTexts';
+import { DROPDOWN_ITEMS } from '../constants/photoViewerTexts';
 
 import { useSavePhoto } from './useSavePhoto';
 
 import { DropdownMenuItem } from '@/shared/components/ui/molecules/DropdownMenu';
+import { SAVE_PERMISSION_MODAL } from '@/shared/constants/text/photoPermissionText';
 import PicselActionIcons from '@/shared/icons/PicselActionIcons';
 import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { requestPhotoPermission } from '@/shared/lib/photoPermission';

--- a/src/feature/picsel/myPicsel/hooks/useSavePhoto.ts
+++ b/src/feature/picsel/myPicsel/hooks/useSavePhoto.ts
@@ -1,16 +1,10 @@
 import { CameraRoll } from '@react-native-camera-roll/camera-roll';
 import RNFS from 'react-native-fs';
 import ImageManipulator from 'react-native-image-manipulator';
-import { PERMISSIONS, request, RESULTS } from 'react-native-permissions';
 
 import { TOAST_MESSAGES } from '../constants/photoViewerTexts';
 
 import { useToastStore } from '@/shared/store/ui/toast';
-
-export const checkPhotoPermission = async (): Promise<boolean> => {
-  const result = await request(PERMISSIONS.IOS.PHOTO_LIBRARY);
-  return result === RESULTS.GRANTED || result === RESULTS.LIMITED;
-};
 
 /**
  * 원격 이미지 URI를 임시 파일로 다운로드한 뒤,

--- a/src/feature/qr/constants/qrDownload.ts
+++ b/src/feature/qr/constants/qrDownload.ts
@@ -1,0 +1,7 @@
+export const QR_DOWNLOAD_TOAST = {
+  SUCCESS: '사진이 앨범에 저장됐어요',
+  FAILURE: '저장에 실패했어요',
+  PERMISSION_DENIED: '사진첩 접근 권한이 필요해요',
+} as const;
+
+export const QR_TOAST_MARGIN = 100;

--- a/src/feature/qr/constants/qrDownload.ts
+++ b/src/feature/qr/constants/qrDownload.ts
@@ -1,7 +1,6 @@
 export const QR_DOWNLOAD_TOAST = {
   SUCCESS: '사진이 앨범에 저장됐어요',
   FAILURE: '저장에 실패했어요',
-  PERMISSION_DENIED: '사진첩 접근 권한이 필요해요',
 } as const;
 
 export const QR_TOAST_MARGIN = 100;

--- a/src/feature/qr/hooks/useQrMediaDownload.ts
+++ b/src/feature/qr/hooks/useQrMediaDownload.ts
@@ -1,15 +1,12 @@
 import { useCallback } from 'react';
 
-import { openSettings } from 'react-native-permissions';
 import type { WebViewMessageEvent } from 'react-native-webview';
 
 import { QR_DOWNLOAD_TOAST, QR_TOAST_MARGIN } from '../constants/qrDownload';
 import { QR_DOWNLOAD_INJECTED_SCRIPT } from '../utils/qrDownloadInjectedScript';
 import { savePhotoFromBase64 } from '../utils/savePhotoFromBase64';
 
-import { SAVE_PERMISSION_MODAL } from '@/shared/constants/text/photoPermissionText';
-import { showConfirmModal } from '@/shared/lib/confirmModal';
-import { requestPhotoPermission } from '@/shared/lib/photoPermission';
+import { requestPhotoPermissionWithModal } from '@/shared/lib/photoPermission';
 import { useToastStore } from '@/shared/store/ui/toast';
 
 type QrCompleteMessage = {
@@ -50,13 +47,8 @@ export const useQrMediaDownload = () => {
 
   const handleComplete = useCallback(
     async (message: QrCompleteMessage) => {
-      const hasPermission = await requestPhotoPermission();
+      const hasPermission = await requestPhotoPermissionWithModal();
       if (!hasPermission) {
-        showConfirmModal(SAVE_PERMISSION_MODAL.TITLE, openSettings, {
-          title: SAVE_PERMISSION_MODAL.DESCRIPTION,
-          confirmText: SAVE_PERMISSION_MODAL.CONFIRM,
-          cancelText: SAVE_PERMISSION_MODAL.CANCEL,
-        });
         return;
       }
 

--- a/src/feature/qr/hooks/useQrMediaDownload.ts
+++ b/src/feature/qr/hooks/useQrMediaDownload.ts
@@ -1,0 +1,96 @@
+import { useCallback } from 'react';
+
+import type { WebViewMessageEvent } from 'react-native-webview';
+
+import { QR_DOWNLOAD_TOAST, QR_TOAST_MARGIN } from '../constants/qrDownload';
+import { QR_DOWNLOAD_INJECTED_SCRIPT } from '../utils/qrDownloadInjectedScript';
+import { savePhotoFromBase64 } from '../utils/savePhotoFromBase64';
+
+import { requestPhotoPermission } from '@/shared/lib/photoPermission';
+import { useToastStore } from '@/shared/store/ui/toast';
+
+type QrCompleteMessage = {
+  type: 'qr-download:complete';
+  base64: string;
+  mimeType?: string;
+  filename?: string;
+};
+
+type QrDownloadMessage =
+  | QrCompleteMessage
+  | { type: 'qr-download:error'; message?: string }
+  | { type: 'qr-download:debug'; [key: string]: unknown };
+
+/**
+ * QR 뷰어 WebView에 다운로드 브리지 스크립트를 주입하고,
+ * 스크립트가 보낸 base64 이미지를 받아 앨범에 저장하는 Hook
+ *
+ * WebView 안에서 실행되는 브리지 스크립트가 벤더별 다운로드 방식을 가로채
+ * base64로 변환해 postMessage로 보내주면, 권한 확인 후 카메라 롤에 저장하고
+ * 성공/실패 토스트로 사용자에게 피드백을 준다.
+ *
+ * @returns WebView에 바로 꽂을 수 있는 두 값
+ * - `injectedJavaScript`: 페이지 로드 시 실행될 Bridge 스크립트 문자열
+ * - `onMessage`: 스크립트가 보낸 메시지를 처리할 핸들러
+ *
+ * @example
+ * const { injectedJavaScript, onMessage } = useQrMediaDownload();
+ *
+ * <WebView
+ *   source={{ uri: qrUrl }}
+ *   injectedJavaScript={injectedJavaScript}
+ *   onMessage={onMessage}
+ * />
+ */
+export const useQrMediaDownload = () => {
+  const { showToast } = useToastStore();
+
+  const handleComplete = useCallback(
+    async (message: QrCompleteMessage) => {
+      const hasPermission = await requestPhotoPermission();
+      if (!hasPermission) {
+        showToast(QR_DOWNLOAD_TOAST.PERMISSION_DENIED, QR_TOAST_MARGIN);
+        return;
+      }
+
+      try {
+        await savePhotoFromBase64(message.base64, message.mimeType || '');
+        showToast(QR_DOWNLOAD_TOAST.SUCCESS, QR_TOAST_MARGIN);
+      } catch {
+        showToast(QR_DOWNLOAD_TOAST.FAILURE, QR_TOAST_MARGIN);
+      }
+    },
+    [showToast],
+  );
+
+  const onMessage = useCallback(
+    async (event: WebViewMessageEvent) => {
+      let parsed: QrDownloadMessage;
+      try {
+        parsed = JSON.parse(event.nativeEvent.data);
+      } catch {
+        return;
+      }
+
+      switch (parsed?.type) {
+        case 'qr-download:debug':
+          console.log('[QR WebView debug]', parsed);
+          return;
+
+        case 'qr-download:error':
+          showToast(QR_DOWNLOAD_TOAST.FAILURE, QR_TOAST_MARGIN);
+          return;
+
+        case 'qr-download:complete':
+          await handleComplete(parsed);
+          return;
+
+        default:
+          return;
+      }
+    },
+    [handleComplete, showToast],
+  );
+
+  return { injectedJavaScript: QR_DOWNLOAD_INJECTED_SCRIPT, onMessage };
+};

--- a/src/feature/qr/hooks/useQrMediaDownload.ts
+++ b/src/feature/qr/hooks/useQrMediaDownload.ts
@@ -9,12 +9,12 @@ import { savePhotoFromBase64 } from '../utils/savePhotoFromBase64';
 import { requestPhotoPermissionWithModal } from '@/shared/lib/photoPermission';
 import { useToastStore } from '@/shared/store/ui/toast';
 
-type QrCompleteMessage = {
+interface QrCompleteMessage {
   type: 'qr-download:complete';
   base64: string;
   mimeType?: string;
   filename?: string;
-};
+}
 
 type QrDownloadMessage =
   | QrCompleteMessage

--- a/src/feature/qr/hooks/useQrMediaDownload.ts
+++ b/src/feature/qr/hooks/useQrMediaDownload.ts
@@ -73,7 +73,6 @@ export const useQrMediaDownload = () => {
 
       switch (parsed?.type) {
         case 'qr-download:debug':
-          console.log('[QR WebView debug]', parsed);
           return;
 
         case 'qr-download:error':

--- a/src/feature/qr/hooks/useQrMediaDownload.ts
+++ b/src/feature/qr/hooks/useQrMediaDownload.ts
@@ -1,11 +1,14 @@
 import { useCallback } from 'react';
 
+import { openSettings } from 'react-native-permissions';
 import type { WebViewMessageEvent } from 'react-native-webview';
 
 import { QR_DOWNLOAD_TOAST, QR_TOAST_MARGIN } from '../constants/qrDownload';
 import { QR_DOWNLOAD_INJECTED_SCRIPT } from '../utils/qrDownloadInjectedScript';
 import { savePhotoFromBase64 } from '../utils/savePhotoFromBase64';
 
+import { SAVE_PERMISSION_MODAL } from '@/shared/constants/text/photoPermissionText';
+import { showConfirmModal } from '@/shared/lib/confirmModal';
 import { requestPhotoPermission } from '@/shared/lib/photoPermission';
 import { useToastStore } from '@/shared/store/ui/toast';
 
@@ -49,7 +52,11 @@ export const useQrMediaDownload = () => {
     async (message: QrCompleteMessage) => {
       const hasPermission = await requestPhotoPermission();
       if (!hasPermission) {
-        showToast(QR_DOWNLOAD_TOAST.PERMISSION_DENIED, QR_TOAST_MARGIN);
+        showConfirmModal(SAVE_PERMISSION_MODAL.TITLE, openSettings, {
+          title: SAVE_PERMISSION_MODAL.DESCRIPTION,
+          confirmText: SAVE_PERMISSION_MODAL.CONFIRM,
+          cancelText: SAVE_PERMISSION_MODAL.CANCEL,
+        });
         return;
       }
 

--- a/src/feature/qr/ui/molecules/QrScanFooter.tsx
+++ b/src/feature/qr/ui/molecules/QrScanFooter.tsx
@@ -11,10 +11,6 @@ const QrScanFooter = () => {
 
   return (
     <View className="w-full items-center gap-4 pb-28">
-      <Text className="text-center text-white body-rg-01">
-        QR 스캔을 지원하지 않는 브랜드일 땐,{'\n'} 사진이 담긴 링크를
-        열어드릴게요
-      </Text>
       <Pressable
         className="flex-row items-center justify-center gap-1 rounded-xl border border-pink-500 p-3"
         onPress={() => navigation.navigate('SelectMainPhoto')}>

--- a/src/feature/qr/utils/qrDownloadInjectedScript.ts
+++ b/src/feature/qr/utils/qrDownloadInjectedScript.ts
@@ -1,0 +1,166 @@
+/**
+ * QR 페이지 WebView에 주입되어 벤더별 다운로드 방식(blob/server endpoint/Web Share API)을
+ * 가로채 base64로 변환한 뒤 RN에 전달하는 Bridge Script.
+ * RN과 주고받는 메시지 타입: qr-download:complete / error / debug
+ */
+export const QR_DOWNLOAD_INJECTED_SCRIPT = `
+(function() {
+  // WebView는 페이지 내부 네비게이션 시 스크립트를 재주입할 수 있어, 리스너/override가 중복 등록되면
+  // 같은 클릭이 여러 번 처리된다. 플래그로 최초 1회만 설치되도록 방어한다.
+  if (window.__picselQrDownloadHookInstalled) { return true; }
+  window.__picselQrDownloadHookInstalled = true;
+
+  // RN으로 메시지를 보내는 유일한 통로. ReactNativeWebView가 붙기 전(초기 로드 시점)에
+  // 호출될 경우를 대비해 존재 여부를 매번 확인한다.
+  function post(payload) {
+    if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+      window.ReactNativeWebView.postMessage(JSON.stringify(payload));
+    }
+  }
+
+  // 다운로드 파이프라인: URL → fetch → blob → base64 → RN. 각 단계마다 debug 메시지를 남겨
+  // 실패 시 어느 구간에서 끊겼는지(네트워크 / MIME / FileReader) 바로 추적할 수 있게 한다.
+  function handle(href, downloadName) {
+    post({ type: 'qr-download:debug', event: 'handle:start', href: href, downloadName: downloadName });
+    fetch(href)
+      .then(function(res) {
+        post({ type: 'qr-download:debug', event: 'handle:fetched', status: res.status, ok: res.ok });
+        return res.blob();
+      })
+      .then(function(blob) {
+        post({ type: 'qr-download:debug', event: 'handle:blob', size: blob.size, mimeType: blob.type });
+        // 영상은 현재 저장 대상에서 제외 (네이티브 저장 경로가 사진만 지원). 영상 지원이 필요해지면
+        // RN 쪽 savePhoto 로직과 함께 이 분기를 열어야 한다.
+        if (blob.type && blob.type.indexOf('video/') === 0) {
+          post({ type: 'qr-download:debug', event: 'handle:skip-video' });
+          return null;
+        }
+        return new Promise(function(resolve, reject) {
+          var reader = new FileReader();
+          reader.onloadend = function() {
+            post({ type: 'qr-download:debug', event: 'handle:base64-ready', mimeType: blob.type, length: (reader.result && reader.result.length) || 0 });
+            resolve({ base64: reader.result, mimeType: blob.type || '' });
+          };
+          reader.onerror = function() { reject(new Error('FileReader error')); };
+          reader.readAsDataURL(blob);
+        });
+      })
+      .then(function(data) {
+        if (!data) return;
+        post({ type: 'qr-download:debug', event: 'handle:posting-complete' });
+        post({
+          type: 'qr-download:complete',
+          base64: data.base64,
+          mimeType: data.mimeType,
+          filename: downloadName || '',
+        });
+      })
+      .catch(function(err) {
+        post({ type: 'qr-download:debug', event: 'handle:catch', message: (err && err.message) || String(err) });
+        post({ type: 'qr-download:error', message: (err && err.message) || String(err) });
+      });
+  }
+
+  // ── 진입점 1: <a> 클릭 인터셉트 ────────────────────────────────────────────
+  // capture phase(true)로 등록해 벤더 페이지의 자체 핸들러보다 먼저 실행되게 한다.
+  // 그래야 preventDefault로 기본 네비게이션을 막을 수 있다.
+  document.addEventListener('click', function(e) {
+    // 먼저 어떤 엘리먼트가 눌렸는지 부모 5단계까지 기록해서 디버깅 데이터를 확보한다.
+    // 새 벤더에서 저장이 안 될 때 이 체인을 보고 필요한 매칭 조건을 역산한다.
+    var chain = [];
+    var cur = e.target;
+    for (var i = 0; i < 5 && cur; i++) {
+      chain.push({
+        tag: cur.tagName,
+        id: cur.id || null,
+        className: (typeof cur.className === 'string') ? cur.className : null,
+        href: cur.getAttribute ? cur.getAttribute('href') : null,
+        download: cur.hasAttribute ? cur.hasAttribute('download') : null,
+      });
+      cur = cur.parentElement;
+    }
+    post({ type: 'qr-download:debug', event: 'click', chain: chain });
+
+    // 실제로 다운로드로 이어지는 클릭은 <a> 태그(자신 또는 조상)인 경우에 한정한다.
+    // 아이콘 SVG나 내부 span이 클릭돼도 조상을 타고 올라가 A를 찾는다.
+    var el = e.target;
+    var foundA = null;
+    while (el && el !== document.body) {
+      if (el.tagName === 'A') { foundA = el; break; }
+      el = el.parentElement;
+    }
+
+    if (!foundA) return;
+
+    var href = foundA.getAttribute('href') || '';
+    var absHref = foundA.href || '';
+    var hasDownload = foundA.hasAttribute('download');
+
+    // 벤더마다 다운로드 방식이 다르므로 두 축으로 감지한다.
+    //  ① blob: URL 또는 download 속성 — 하루필름처럼 웹 표준에 충실한 구현
+    //  ② 미디어 URL 휴리스틱 — 포토이즘처럼 서버 엔드포인트로 바로 보내는 구현
+    //     (확장자, 또는 download/albumdn/type=photo 등 쿼리 키워드로 추정)
+    var isBlobOrDownload = href.indexOf('blob:') === 0 || hasDownload;
+    var isMediaUrl =
+      /\\.(jpe?g|png|gif|webp|heic|heif|mp4|mov|m4v)(\\?|$)/i.test(absHref) ||
+      /(download|albumdn|attachment|file=|type=(photo|video))/i.test(absHref);
+
+    if (isBlobOrDownload || isMediaUrl) {
+      // WebView가 URL로 이동해버리면 페이지를 이탈하거나 이미지만 풀스크린으로 열려 저장이 안 된다.
+      // 그러므로, 기본 동작을 완전히 막고 우리 파이프라인으로 넘긴다.
+      e.preventDefault();
+      e.stopPropagation();
+      handle(foundA.href, foundA.getAttribute('download'));
+    }
+  }, true);
+
+  // ── 진입점 2: navigator.share override ─────────────────────────────────────
+  // 일부 벤더는 <a download> 대신 Web Share API로 파일을 넘긴다. 네이티브 공유 시트가 뜨면
+  // 앱 카메라 롤로 직접 저장하는 흐름이 끊기므로, share 호출을 가로채서 첫 번째 이미지 파일을
+  // base64로 변환해 RN으로 보낸다. 이미지가 없으면 원래 share 동작을 그대로 위임한다.
+  if (navigator.share) {
+    var originalShare = navigator.share.bind(navigator);
+    navigator.share = function(data) {
+      var files = data && data.files;
+      if (files && files.length > 0) {
+        // 여러 파일이 있을 수 있으니 이미지 타입(MIME 또는 확장자)을 찾고, 영상은 제외한다.
+        var imageFile = null;
+        for (var i = 0; i < files.length; i++) {
+          var f = files[i];
+          var isImageByType = f && f.type && f.type.indexOf('image/') === 0;
+          var isImageByName = f && f.name && /\\.(jpe?g|png|gif|webp|heic|heif)$/i.test(f.name);
+          var isVideo = f && f.type && f.type.indexOf('video/') === 0;
+          if (!imageFile && !isVideo && (isImageByType || isImageByName)) {
+            imageFile = f;
+          }
+        }
+
+        if (imageFile) {
+          return new Promise(function(resolve, reject) {
+            var reader = new FileReader();
+            reader.onloadend = function() {
+              post({
+                type: 'qr-download:complete',
+                base64: reader.result,
+                mimeType: imageFile.type || '',
+                filename: imageFile.name || '',
+              });
+              resolve();
+            };
+            reader.onerror = function() {
+              post({ type: 'qr-download:error', message: 'share FileReader error' });
+              reject(new Error('FileReader error'));
+            };
+            reader.readAsDataURL(imageFile);
+          });
+        }
+      }
+
+      // 이미지 파일이 없으면 원래 share 동작 유지 (텍스트/URL 공유 등)
+      return originalShare(data);
+    };
+  }
+
+  true;
+})();
+`;

--- a/src/feature/qr/utils/qrDownloadInjectedScript.ts
+++ b/src/feature/qr/utils/qrDownloadInjectedScript.ts
@@ -20,7 +20,16 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
 
   // 다운로드 파이프라인: URL → fetch → blob → base64 → RN. 각 단계마다 debug 메시지를 남겨
   // 실패 시 어느 구간에서 끊겼는지(네트워크 / MIME / FileReader) 바로 추적할 수 있게 한다.
+  //
+  // 빠른 연타로 같은 이미지가 중복 저장되는 것을 막기 위해 진행 중에는 플래그로 재진입을 차단한다.
+  // 성공/실패 모두에서 finally로 해제해야 다음 다운로드가 가능해진다.
   function handle(href, downloadName) {
+    if (window.__picselQrDownloading) {
+      post({ type: 'qr-download:debug', event: 'handle:skip-inflight' });
+      return;
+    }
+    window.__picselQrDownloading = true;
+
     post({ type: 'qr-download:debug', event: 'handle:start', href: href, downloadName: downloadName });
     fetch(href)
       .then(function(res) {
@@ -58,6 +67,9 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
       .catch(function(err) {
         post({ type: 'qr-download:debug', event: 'handle:catch', message: (err && err.message) || String(err) });
         post({ type: 'qr-download:error', message: (err && err.message) || String(err) });
+      })
+      .finally(function() {
+        window.__picselQrDownloading = false;
       });
   }
 
@@ -138,6 +150,13 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
         }
 
         if (imageFile) {
+          // handle()과 동일한 in-flight 플래그를 공유해 연타로 인한 중복 저장을 차단한다.
+          if (window.__picselQrDownloading) {
+            post({ type: 'qr-download:debug', event: 'share:skip-inflight' });
+            return Promise.resolve();
+          }
+          window.__picselQrDownloading = true;
+
           return new Promise(function(resolve, reject) {
             var reader = new FileReader();
             reader.onloadend = function() {
@@ -154,6 +173,8 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
               reject(new Error('FileReader error'));
             };
             reader.readAsDataURL(imageFile);
+          }).finally(function() {
+            window.__picselQrDownloading = false;
           });
         }
       }

--- a/src/feature/qr/utils/qrDownloadInjectedScript.ts
+++ b/src/feature/qr/utils/qrDownloadInjectedScript.ts
@@ -65,22 +65,6 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
   // capture phase(true)로 등록해 벤더 페이지의 자체 핸들러보다 먼저 실행되게 한다.
   // 그래야 preventDefault로 기본 네비게이션을 막을 수 있다.
   document.addEventListener('click', function(e) {
-    // 먼저 어떤 엘리먼트가 눌렸는지 부모 5단계까지 기록해서 디버깅 데이터를 확보한다.
-    // 새 벤더에서 저장이 안 될 때 이 체인을 보고 필요한 매칭 조건을 역산한다.
-    var chain = [];
-    var cur = e.target;
-    for (var i = 0; i < 5 && cur; i++) {
-      chain.push({
-        tag: cur.tagName,
-        id: cur.id || null,
-        className: (typeof cur.className === 'string') ? cur.className : null,
-        href: cur.getAttribute ? cur.getAttribute('href') : null,
-        download: cur.hasAttribute ? cur.hasAttribute('download') : null,
-      });
-      cur = cur.parentElement;
-    }
-    post({ type: 'qr-download:debug', event: 'click', chain: chain });
-
     // 실제로 다운로드로 이어지는 클릭은 <a> 태그(자신 또는 조상)인 경우에 한정한다.
     // 아이콘 SVG나 내부 span이 클릭돼도 조상을 타고 올라가 A를 찾는다.
     var el = e.target;
@@ -90,7 +74,25 @@ export const QR_DOWNLOAD_INJECTED_SCRIPT = `
       el = el.parentElement;
     }
 
-    if (!foundA) return;
+    // A 미발견 시에만 부모 5단계 체인을 남긴다. 새 벤더가 <a>가 아닌 엘리먼트로
+    // 저장 버튼을 만들 때, 이 로그만이 어떤 매칭 조건을 추가해야 할지 역산하는 단서가 된다.
+    // 성공 케이스는 handle:* 디버그 로그로 추적 가능하므로 여기서 또 남기지 않는다.
+    if (!foundA) {
+      var chain = [];
+      var cur = e.target;
+      for (var i = 0; i < 5 && cur; i++) {
+        chain.push({
+          tag: cur.tagName,
+          id: cur.id || null,
+          className: (typeof cur.className === 'string') ? cur.className : null,
+          href: cur.getAttribute ? cur.getAttribute('href') : null,
+          download: cur.hasAttribute ? cur.hasAttribute('download') : null,
+        });
+        cur = cur.parentElement;
+      }
+      post({ type: 'qr-download:debug', event: 'click-no-a', chain: chain });
+      return;
+    }
 
     var href = foundA.getAttribute('href') || '';
     var absHref = foundA.href || '';

--- a/src/feature/qr/utils/savePhotoFromBase64.ts
+++ b/src/feature/qr/utils/savePhotoFromBase64.ts
@@ -1,0 +1,26 @@
+import { CameraRoll } from '@react-native-camera-roll/camera-roll';
+import RNFS from 'react-native-fs';
+
+const SUPPORTED_EXTS = ['png', 'gif', 'webp'] as const;
+
+const extFromMime = (mime: string): string =>
+  SUPPORTED_EXTS.find(ext => mime.includes(ext)) ?? 'jpg';
+
+export const savePhotoFromBase64 = async (
+  base64: string,
+  mimeType: string,
+): Promise<void> => {
+  const ext = extFromMime(mimeType);
+  const randomSuffix = Math.random().toString(36).slice(2);
+  const tempPath = `${RNFS.TemporaryDirectoryPath}qr_${Date.now()}_${randomSuffix}.${ext}`;
+  const base64Body = base64.replace(/^data:.*?;base64,/, '');
+
+  try {
+    await RNFS.writeFile(tempPath, base64Body, 'base64');
+    await CameraRoll.saveAsset(`file://${tempPath}`, { type: 'photo' });
+  } finally {
+    await RNFS.unlink(tempPath).catch(e =>
+      console.warn('임시 파일 삭제 실패:', e),
+    );
+  }
+};

--- a/src/screens/qr/viewer/index.tsx
+++ b/src/screens/qr/viewer/index.tsx
@@ -4,6 +4,7 @@ import { RouteProp, useNavigation } from '@react-navigation/native';
 import { View } from 'react-native';
 import WebView from 'react-native-webview';
 
+import { useQrMediaDownload } from '@/feature/qr/hooks/useQrMediaDownload';
 import QrViewerHeader from '@/feature/qr/ui/layout/QrViewerHeader';
 import { MainNavigationProps } from '@/navigation';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
@@ -19,6 +20,7 @@ interface Props {
 const QrViewerScreen = ({ route }: Props) => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const webViewRef = useRef<WebView>(null);
+  const { injectedJavaScript, onMessage } = useQrMediaDownload();
 
   const { url } = route.params || {};
 
@@ -34,7 +36,15 @@ const QrViewerScreen = ({ route }: Props) => {
       />
 
       <View className="flex-1">
-        <WebView ref={webViewRef} source={{ uri: url }} style={{ flex: 1 }} />
+        <WebView
+          ref={webViewRef}
+          source={{ uri: url }}
+          style={{ flex: 1 }}
+          injectedJavaScript={injectedJavaScript}
+          onMessage={onMessage}
+          allowsInlineMediaPlayback
+          mediaPlaybackRequiresUserAction={false}
+        />
       </View>
 
       <View className="px-4 py-3">

--- a/src/shared/constants/text/photoPermissionText.ts
+++ b/src/shared/constants/text/photoPermissionText.ts
@@ -1,0 +1,6 @@
+export const SAVE_PERMISSION_MODAL = {
+  TITLE: '설정에서 픽셀의\n사진 접근을 허용해야 해요',
+  DESCRIPTION: '설정 > 픽셀 > 사진에서\n사진 접근 허용으로 변경해 주세요',
+  CANCEL: '취소',
+  CONFIRM: '설정으로 이동',
+} as const;

--- a/src/shared/lib/photoPermission.ts
+++ b/src/shared/lib/photoPermission.ts
@@ -1,4 +1,12 @@
-import { PERMISSIONS, request, RESULTS } from 'react-native-permissions';
+import {
+  openSettings,
+  PERMISSIONS,
+  request,
+  RESULTS,
+} from 'react-native-permissions';
+
+import { SAVE_PERMISSION_MODAL } from '@/shared/constants/text/photoPermissionText';
+import { showConfirmModal } from '@/shared/lib/confirmModal';
 
 /**
  * 사진 저장(쓰기)에 필요한 최소 권한을 요청
@@ -7,4 +15,20 @@ import { PERMISSIONS, request, RESULTS } from 'react-native-permissions';
 export const requestPhotoPermission = async (): Promise<boolean> => {
   const result = await request(PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY);
   return result === RESULTS.GRANTED || result === RESULTS.LIMITED;
+};
+
+/**
+ * 사진 접근 권한을 요청하고, 거부된 경우 설정 이동으로 유도하는 모달을 띄운다.
+ * @returns 권한 허용 여부
+ */
+export const requestPhotoPermissionWithModal = async (): Promise<boolean> => {
+  const hasPermission = await requestPhotoPermission();
+  if (!hasPermission) {
+    showConfirmModal(SAVE_PERMISSION_MODAL.TITLE, openSettings, {
+      title: SAVE_PERMISSION_MODAL.DESCRIPTION,
+      confirmText: SAVE_PERMISSION_MODAL.CONFIRM,
+      cancelText: SAVE_PERMISSION_MODAL.CANCEL,
+    });
+  }
+  return hasPermission;
 };

--- a/src/shared/lib/photoPermission.ts
+++ b/src/shared/lib/photoPermission.ts
@@ -1,0 +1,10 @@
+import { PERMISSIONS, request, RESULTS } from 'react-native-permissions';
+
+/**
+ * 사진 저장(쓰기)에 필요한 최소 권한을 요청
+ * 읽기는 불필요하므로 ADD_ONLY 스코프만 받아 과도한 권한 요청을 피한다.
+ */
+export const requestPhotoPermission = async (): Promise<boolean> => {
+  const result = await request(PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY);
+  return result === RESULTS.GRANTED || result === RESULTS.LIMITED;
+};


### PR DESCRIPTION
## 이슈 번호

> close #191 

## 작업 내용 및 테스트 방법

<img width="370" height="770" alt="ScreenRecording_04-21-2026 00-10-30_1" src="https://github.com/user-attachments/assets/c1cf31f0-d5b7-4575-813d-86c33dd915c8" />

### 작업 내용
브랜드 무관하게 **"저장 버튼 → 카메라 롤 저장 → 토스트 안내"** 로 UX 일관화

- WebView 진입 시 **공통 브릿지 스크립트 주입**으로 브랜드별 다운로드 동작을 가로채 네이티브로 위임
  - `<a download>` 클릭 가로채기 → base64 추출 후 RN으로 postMessage
  - `navigator.share()` 후킹 → 공유 시트 대신 동일 저장 플로우 사용
- base64 이미지를 카메라 롤에 저장하는 **공통 유틸 추가** + 권한 요청 로직 분리
- RN 측 **WebView 메시지 핸들링 훅** 추가 (저장 성공/실패 토스트 처리)
- 하루필름 도메인(`mx2.co.kr`)을 **iOS ATS 예외 도메인으로 등록**하여 HTTP 로드 허용
- QR 스캔 footer 안내 문구 제거 (기능 변경으로 기존 문구가 부정확하여 경진님과 상의하여 제거)

### 테스트 방법
1. QR 스캔 → 포토이즘 / 포토그레이 / 하루필름 각 브랜드 진입
2. "사진 저장" 버튼 탭 → 카메라 롤 저장 확인
3. 저장 성공 토스트 노출 확인
4. iOS 사진 권한 거부 시나리오 동작 확인 (권한 설정을 유도하는 모달이 뜨는지)

## To reviewers
- 브릿지 스크립트는 브랜드별 분기 없이 공통 동작으로 묶었습니다. 최대한 새 브랜드 추가 시에도 동일 플로우가 적용되도록 설계했습니다.
- ATS 예외는 브랜드 목록을 수집해야 하는 영역이기 때문에, 경진님과 상의 후 우선은 특정 도메인(하루필름) 한정으로 허용하도록 했습니다.