### PR TITLE
⛑️ QA: 심사 요청 전 QA 이슈 대응

### DIFF
--- a/ios/picselFE.xcodeproj/project.pbxproj
+++ b/ios/picselFE.xcodeproj/project.pbxproj
@@ -248,9 +248,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-picselFE/Pods-picselFE-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-picselFE/Pods-picselFE-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -265,9 +269,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-picselFE/Pods-picselFE-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-picselFE/Pods-picselFE-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -318,7 +326,7 @@
 				CODE_SIGN_ENTITLEMENTS = picselFE/picselFE.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = Y343288YP2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = picselFE/Info.plist;
@@ -352,7 +360,7 @@
 				CODE_SIGN_ENTITLEMENTS = picselFE/picselFE.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = Y343288YP2;
 				INFOPLIST_FILE = picselFE/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
@@ -445,10 +453,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -518,10 +523,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/src/feature/map/ui/atoms/QrSaveButton.tsx
+++ b/src/feature/map/ui/atoms/QrSaveButton.tsx
@@ -5,16 +5,16 @@ import { Text, TouchableOpacity } from 'react-native';
 import QrIcons from '@/shared/icons/QrIcons';
 import { defaultButtonShadow } from '@/shared/styles/shadows';
 
-const QrSaveButton = () => {
-  const [isPressed, setIsPressed] = useState(false);
+interface Props {
+  onPress: () => void;
+}
 
-  const handlePress = () => {
-    // TODO: 큐알 저장 로직 구현
-  };
+const QrSaveButton = ({ onPress }: Props) => {
+  const [isPressed, setIsPressed] = useState(false);
 
   return (
     <TouchableOpacity
-      onPress={handlePress}
+      onPress={onPress}
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}
       activeOpacity={0.5}

--- a/src/feature/map/ui/organisms/BrandDetailBottomSheet/BrandDetailContent.tsx
+++ b/src/feature/map/ui/organisms/BrandDetailBottomSheet/BrandDetailContent.tsx
@@ -17,6 +17,7 @@ interface Props extends MapBottomSheetProps {
   openCopy: boolean;
   handleCopyButton: () => void;
   handleCopyAddress: (address: string) => void;
+  onQrSave: () => void;
 }
 
 const BrandDetailContent = ({
@@ -26,6 +27,7 @@ const BrandDetailContent = ({
   openCopy,
   handleCopyButton,
   handleCopyAddress,
+  onQrSave,
 }: Props) => {
   const { userLocation } = useLocationStore();
   const { location, detailLocation } = splitAddress(storeDetail.address);
@@ -59,7 +61,7 @@ const BrandDetailContent = ({
       )}
 
       <View className="mb-2 py-4">
-        <QrSaveButton />
+        <QrSaveButton onPress={onQrSave} />
       </View>
     </View>
   );

--- a/src/feature/map/ui/organisms/BrandDetailBottomSheet/index.tsx
+++ b/src/feature/map/ui/organisms/BrandDetailBottomSheet/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   onClose: () => void;
   isFavorite: boolean;
   animatedPosition: SharedValue<number>;
+  onQrSave: () => void;
 }
 
 const BrandDetailBottomSheet = ({
@@ -24,6 +25,7 @@ const BrandDetailBottomSheet = ({
   onClose,
   isFavorite,
   animatedPosition,
+  onQrSave,
 }: Props) => {
   const { bottomSheetModalRef, openCopy, handleCopyButton, handleCopyAddress } =
     useBrandDetailBottomSheet({
@@ -65,6 +67,7 @@ const BrandDetailBottomSheet = ({
           openCopy={openCopy}
           handleCopyButton={handleCopyButton}
           handleCopyAddress={handleCopyAddress}
+          onQrSave={onQrSave}
         />
       </BottomSheetView>
     </BottomSheetModal>

--- a/src/feature/mypage/setting/constants/settingMenuItems.ts
+++ b/src/feature/mypage/setting/constants/settingMenuItems.ts
@@ -6,7 +6,8 @@ export const EXTERNAL_LINKS = {
   notice:
     'https://daisy-tamarillo-7ee.notion.site/2e22a4516dff8019a8f5eb6c96169ad1?v=2e22a4516dff80ff8a36000c693971d6',
   faq: '', // 추후 FAQ 페이지 오픈 시 링크 추가
-  inquiry: 'https://forms.gle/3FEVyNMcb1yEFRvq5',
+  inquiry:
+    'https://docs.google.com/forms/u/0/d/11cldn40YEX12Rr7p3C0syL9xt-1yQT74_J_YU2hqBWE',
 } as const;
 
 export interface SettingMenuItem {

--- a/src/feature/picsel/myPicsel/components/ui/organisms/PicselbookSection.tsx
+++ b/src/feature/picsel/myPicsel/components/ui/organisms/PicselbookSection.tsx
@@ -28,7 +28,7 @@ const PicselbookSection = ({ picselbook, onMovePress }: Props) => {
 
       <View className="items-center gap-2" style={{ width: 80 }}>
         <PicselBookIcons
-          shape={picselbook?.coverImagePath ? 'cover-selected' : 'default'}
+          shape="default"
           width={80}
           height={72}
           imageUri={

--- a/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
+++ b/src/feature/picsel/picselBook/components/ui/molecules/PicselBookCard.tsx
@@ -54,7 +54,7 @@ const PicselBookCard = ({
       {/* 픽셀북 아이콘 */}
       <View className="relative mb-2">
         <PicselBookIcons
-          shape={coverImage ? 'cover-selected' : 'default'}
+          shape="default"
           width={80}
           height={72}
           imageUri={coverImage}
@@ -156,7 +156,7 @@ const PicselBookCard = ({
             menuConfig={menuConfig}
             onPressMenuItem={handleMenuItem}>
             <PicselBookIcons
-              shape={coverImage ? 'cover-selected' : 'default'}
+              shape="default"
               width={80}
               height={72}
               imageUri={coverImage}

--- a/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
+++ b/src/feature/picsel/picselBook/components/ui/template/PicselBookTemplate.tsx
@@ -52,6 +52,7 @@ const PicselBookTemplate = () => {
     editingBookId,
     editingBookName,
     bookCoverPhoto,
+    draftBookName,
 
     picselBookRef,
 
@@ -91,7 +92,12 @@ const PicselBookTemplate = () => {
           />
         </View>
 
-        <PicselBookBottomSheet ref={picselBookRef} onSubmit={handleSubmit} />
+        <PicselBookBottomSheet
+          ref={picselBookRef}
+          onSubmit={handleSubmit}
+          coverPhotoUri={bookCoverPhoto}
+          initialBookName={draftBookName ?? ''}
+        />
       </EmptyStateLayout>
     );
   }
@@ -124,7 +130,12 @@ const PicselBookTemplate = () => {
         onShowSkeletonChange={handleShowSkeletonChange}
       />
 
-      <PicselBookBottomSheet ref={picselBookRef} onSubmit={handleSubmit} />
+      <PicselBookBottomSheet
+        ref={picselBookRef}
+        onSubmit={handleSubmit}
+        coverPhotoUri={bookCoverPhoto}
+        initialBookName={draftBookName ?? ''}
+      />
 
       <PicselBookBottomSheet
         ref={editNameBottomSheetRef}

--- a/src/feature/picsel/picselBook/hooks/usePicselBook.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBook.ts
@@ -71,6 +71,7 @@ export const usePicselBook = () => {
   const { mutate: deletePicselBooks } = useDeletePicselBooks();
 
   const { reset: resetPhotoStore } = usePhotoStore();
+  const draftBookName = usePhotoStore(state => state.draftBookName);
   const { mutateAsync: createDraft } = useCreatePicselBookDraft();
 
   const books: PicselBookItem[] = data ?? [];
@@ -132,9 +133,6 @@ export const usePicselBook = () => {
 
     createPicselBook(payload, {
       onSuccess: response => {
-        if (bookCoverPhoto) {
-          navigation.pop(1);
-        }
         showToast(`"${bookName}"을 추가했어요`, 60);
 
         const newBookId = response.data?.picselbookId;
@@ -218,6 +216,13 @@ export const usePicselBook = () => {
     }
   }, [isFocused, bookCoverPhoto, editingBookId]);
 
+  // 픽셀북 생성 리턴 플로우: 사진 선택 후 돌아왔을 때 create 시트 자동 재오픈
+  useEffect(() => {
+    if (isFocused && bookCoverPhoto && draftBookName) {
+      picselBookRef.current?.present();
+    }
+  }, [isFocused, bookCoverPhoto, draftBookName]);
+
   useEffect(() => {
     if (selectedBookIds.length === 0 && savedBookId && books.length > 0) {
       const target = books.find(b => b.picselbookId === savedBookId);
@@ -275,6 +280,7 @@ export const usePicselBook = () => {
     editingBookId,
     editingBookName,
     bookCoverPhoto,
+    draftBookName,
 
     // Refs
     picselBookRef,

--- a/src/feature/picsel/picselBook/hooks/usePicselBookActions.ts
+++ b/src/feature/picsel/picselBook/hooks/usePicselBookActions.ts
@@ -38,7 +38,9 @@ export const usePicselBookActions = () => {
     bookName: string,
     options?: HandleEditNameSubmitOptions,
   ) => {
-    if (!editingBookId) return;
+    if (!editingBookId) {
+      return;
+    }
 
     patchPicselBook(
       { picselbookId: editingBookId, bookName },
@@ -60,16 +62,19 @@ export const usePicselBookActions = () => {
     setEditingBookId(id);
     navigation.navigate('SelectBookCover', {
       variant: 'cover',
-      bookName: '',
       picselbookId: id,
     });
   };
 
   const handleCoverEditSubmit = (coverType: CoverType) => {
-    if (!editingBookId) return;
+    if (!editingBookId) {
+      return;
+    }
 
     const coverImagePath = coverType === 'default' ? null : bookCoverPhoto;
-    if (coverType === 'photo' && !coverImagePath) return;
+    if (coverType === 'photo' && !coverImagePath) {
+      return;
+    }
 
     patchPicselBook(
       { picselbookId: editingBookId, coverImagePath },

--- a/src/feature/picsel/picselUpload/ui/organisms/PhotoSelectStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PhotoSelectStep.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useNavigation } from '@react-navigation/native';
-import { Text, View } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
 
 import { STEP_TEXTS } from '../../constants/stepTexts';
 
@@ -22,8 +22,10 @@ const PhotoSelectStep = ({ onNext }: Props) => {
     usePhotoStore();
 
   return (
-    <>
-      <View className="flex-1">
+    <View className="flex-1">
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: 100 }}
+        showsVerticalScrollIndicator={false}>
         <UploadStepHeader
           title={
             <>
@@ -45,17 +47,17 @@ const PhotoSelectStep = ({ onNext }: Props) => {
           onAdd={() => navigation.navigate('SelectExtraPhoto')}
           onRemove={removeExtraPhoto}
         />
-        <View className="absolute bottom-2 w-full items-center">
-          <Button
-            text="다음"
-            color={`${mainPhoto ? 'active' : 'disabled'}`}
-            textColor="white"
-            disabled={!mainPhoto}
-            onPress={onNext}
-          />
-        </View>
+      </ScrollView>
+      <View className="absolute bottom-2 w-full items-center">
+        <Button
+          text="다음"
+          color={`${mainPhoto ? 'active' : 'disabled'}`}
+          textColor="white"
+          disabled={!mainPhoto}
+          onPress={onNext}
+        />
       </View>
-    </>
+    </View>
   );
 };
 

--- a/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
@@ -71,7 +71,7 @@ const PicselBookSelectStep = ({ onNext }: Props) => {
         </View>
       </View>
 
-      <View className="absolute bottom-[-5px] w-full items-center">
+      <View className="absolute bottom-2 w-full items-center">
         <Button
           text="다음"
           color={isNextEnabled ? 'active' : 'disabled'}

--- a/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
+++ b/src/feature/picsel/picselUpload/ui/organisms/PicselBookSelectStep.tsx
@@ -24,6 +24,8 @@ const PicselBookSelectStep = ({ onNext }: Props) => {
     handleAddBook,
     picselBookRef,
     handleSubmit,
+    bookCoverPhoto,
+    draftBookName,
   } = usePicselBook();
 
   const setPicselbookId = usePicselUploadStore(state => state.setPicselbookId);
@@ -67,7 +69,12 @@ const PicselBookSelectStep = ({ onNext }: Props) => {
             isLoading={isLoading}
             onAddBook={handleAddBook}
           />
-          <PicselBookBottomSheet ref={picselBookRef} onSubmit={handleSubmit} />
+          <PicselBookBottomSheet
+            ref={picselBookRef}
+            onSubmit={handleSubmit}
+            coverPhotoUri={bookCoverPhoto}
+            initialBookName={draftBookName ?? ''}
+          />
         </View>
       </View>
 

--- a/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
+++ b/src/feature/picsel/shared/components/ui/molecules/SelectablePhotoCard.tsx
@@ -57,12 +57,12 @@ const SelectablePhotoCard = ({
         {isSelecting && <SelectionCheckbox isSelected={isSelected} />}
 
         <View
-          className="items-center justify-center overflow-hidden bg-white"
+          className="overflow-hidden"
           style={{ width: imageWidth, height: imageHeight }}>
           <CachedImage
             uri={photo.uri}
             style={{ width: imageWidth, height: imageHeight }}
-            resizeMode="contain"
+            resizeMode="cover"
             onLoad={() => onImageLoad?.(photo.uri)}
             onError={() => onImageError?.(photo.uri)}
           />

--- a/src/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet.tsx
+++ b/src/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   BottomSheetBackdrop,
@@ -6,7 +6,13 @@ import {
   BottomSheetView,
 } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
-import { Keyboard, Pressable, Text, View } from 'react-native';
+import {
+  Keyboard,
+  Pressable,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import PicselBookInput from '../../atoms/PicselBookInput';
 
@@ -14,6 +20,7 @@ import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import CheckRoundIcons from '@/shared/icons/CheckRound';
 import PicselBookIcons from '@/shared/icons/PicselBookIcons';
 import { cn } from '@/shared/lib/cn';
+import { usePhotoStore } from '@/shared/store/picselUpload';
 import {
   bottomSheetBackdrop,
   bottomSheetBackground,
@@ -57,13 +64,19 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
     ref,
   ) => {
     const navigation = useNavigation<RootStackNavigationProp>();
+    const setDraftBookName = usePhotoStore(state => state.setDraftBookName);
+    const isNavigatingRef = useRef(false);
     const isEditCoverMode = mode === 'editCover';
     const isEditNameMode = mode === 'editName';
 
     const [bookName, setBookName] = useState(initialBookName);
     const [errorMessage, setErrorMessage] = useState('');
-    const [isEdited, setIsEdited] = useState(!isEditCoverMode);
-    const [selectedCover, setSelectedCover] = useState<CoverType>('default');
+    const [isEdited, setIsEdited] = useState(
+      !isEditCoverMode && !(mode === 'create' && initialBookName),
+    );
+    const [selectedCover, setSelectedCover] = useState<CoverType>(
+      mode === 'create' && initialBookName ? 'photo' : 'default',
+    );
     const snapPoints = useMemo(
       () => [isEditCoverMode ? '50%' : '100%'],
       [isEditCoverMode],
@@ -79,12 +92,12 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
       }
     }, [initialBookName, mode]);
 
-    // 커버 편집 모드: 사진 선택 후 돌아왔을 때 사진 지정 체크
+    // 사진 선택 후 돌아왔을 때 사진 지정 체크
     useEffect(() => {
-      if (isEditCoverMode && coverPhotoUri) {
+      if (coverPhotoUri) {
         setSelectedCover('photo');
       }
-    }, [isEditCoverMode, coverPhotoUri]);
+    }, [coverPhotoUri]);
 
     const handleNextStep = () => {
       if (bookName.trim() && !errorMessage) {
@@ -107,10 +120,15 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
 
     const handleDismiss = () => {
       Keyboard.dismiss();
+      if (isNavigatingRef.current) {
+        isNavigatingRef.current = false;
+        return;
+      }
       setBookName('');
       setIsEdited(!isEditCoverMode);
       setErrorMessage('');
       setSelectedCover('default');
+      setDraftBookName(null);
     };
 
     const dismiss = () => {
@@ -130,9 +148,12 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
     };
 
     const navigateToSelectCover = () => {
+      if (mode === 'create' && bookName.trim()) {
+        setDraftBookName(bookName.trim());
+      }
+      isNavigatingRef.current = true;
       navigation.navigate('SelectBookCover', {
         variant: 'cover',
-        bookName: isEditCoverMode ? '' : bookName,
         ...(picselbookId && { picselbookId }),
       });
       dismiss();
@@ -233,25 +254,15 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
                       />
                     </Pressable>
 
-                    <Pressable
-                      onPress={
-                        isEditCoverMode && coverPhotoUri
-                          ? undefined
-                          : handleSelectedCover
-                      }
-                      className={cn(
-                        selectedCover === 'photo' && 'opacity-40',
-                        'flex flex-col items-center space-y-2 self-stretch px-6 py-2',
-                      )}>
+                    <TouchableOpacity
+                      onPress={coverPhotoUri ? undefined : handleSelectedCover}
+                      activeOpacity={0.4}
+                      className="flex flex-col items-center space-y-2 self-stretch px-6 py-2">
                       <PicselBookIcons
                         height={72}
                         width={80}
                         shape="cover-selected"
-                        imageUri={
-                          isEditCoverMode && coverPhotoUri
-                            ? coverPhotoUri
-                            : undefined
-                        }
+                        imageUri={coverPhotoUri ?? undefined}
                       />
                       <Text className="pb-4 text-gray-900 body-rg-02">
                         사진 지정
@@ -261,7 +272,7 @@ const PicselBookBottomSheet = forwardRef<BottomSheetModal, Props>(
                         height={24}
                         width={24}
                       />
-                    </Pressable>
+                    </TouchableOpacity>
                   </View>
                 </View>
 

--- a/src/feature/picsel/shared/components/ui/organisms/datePicker/DatePickerDayView.tsx
+++ b/src/feature/picsel/shared/components/ui/organisms/datePicker/DatePickerDayView.tsx
@@ -4,9 +4,8 @@ import dayjs from 'dayjs';
 import { Pressable, Text, View } from 'react-native';
 
 import {
-  CELL_WIDTH,
   DATE_STYLES,
-  TOTAL_CALENDAR_CELLS,
+  DAYS_PER_WEEK,
   WEEK_DAYS,
 } from '@/feature/picsel/shared/constants/datePicker';
 
@@ -19,10 +18,11 @@ interface Props {
 const DatePickerDayView = ({ current, selectedDate, onSelect }: Props) => {
   const cells = useMemo(() => {
     const daysInMonth = current.daysInMonth();
-
     const startDay = current.startOf('month').day();
+    const weeksNeeded = Math.ceil((startDay + daysInMonth) / DAYS_PER_WEEK);
+    const totalCells = weeksNeeded * DAYS_PER_WEEK;
 
-    return Array.from({ length: TOTAL_CALENDAR_CELLS }, (_, i) => {
+    return Array.from({ length: totalCells }, (_, i) => {
       const dayOffset = i - startDay + 1;
       const date = current.startOf('month').add(dayOffset - 1, 'day');
 
@@ -55,35 +55,42 @@ const DatePickerDayView = ({ current, selectedDate, onSelect }: Props) => {
     return { containerStyle, textStyle };
   };
 
+  const weeksNeeded = cells.length / DAYS_PER_WEEK;
+
   return (
     <View className="pt-2">
       <View className="mb-3 flex-row">
         {WEEK_DAYS.map(day => (
-          <View
-            key={day.key}
-            style={{ flexBasis: CELL_WIDTH }}
-            className="items-center">
+          <View key={day.key} style={{ flex: 1 }} className="items-center">
             <Text className="text-gray-300 body-rg-01">{day.label}</Text>
           </View>
         ))}
       </View>
 
-      <View className="flex-row flex-wrap">
-        {cells.map((item, idx) => {
-          const { containerStyle, textStyle } = getDateStyles(item);
+      <View>
+        {Array.from({ length: weeksNeeded }, (_, weekIdx) => (
+          <View key={weekIdx} className="flex-row">
+            {cells
+              .slice(weekIdx * DAYS_PER_WEEK, (weekIdx + 1) * DAYS_PER_WEEK)
+              .map((item, idx) => {
+                const { containerStyle, textStyle } = getDateStyles(item);
 
-          return (
-            <Pressable
-              key={`${item.date.toString()}-${idx}`}
-              onPress={() => item.isCurrentMonth && onSelect(item.date)}
-              style={{ flexBasis: CELL_WIDTH }}
-              className="mb-3 items-center">
-              <View className={containerStyle}>
-                <Text className={`body-rg-03 ${textStyle}`}>{item.day}</Text>
-              </View>
-            </Pressable>
-          );
-        })}
+                return (
+                  <Pressable
+                    key={`${item.date.toString()}-${idx}`}
+                    onPress={() => item.isCurrentMonth && onSelect(item.date)}
+                    style={{ flex: 1 }}
+                    className="mb-3 items-center">
+                    <View className={containerStyle}>
+                      <Text className={`body-rg-03 ${textStyle}`}>
+                        {item.day}
+                      </Text>
+                    </View>
+                  </Pressable>
+                );
+              })}
+          </View>
+        ))}
       </View>
     </View>
   );

--- a/src/feature/picsel/shared/constants/datePicker.ts
+++ b/src/feature/picsel/shared/constants/datePicker.ts
@@ -9,8 +9,6 @@ export const WEEK_DAYS = [
 ] as const;
 
 export const DAYS_PER_WEEK = 7;
-export const TOTAL_CALENDAR_CELLS = 42;
-export const CELL_WIDTH = `${100 / DAYS_PER_WEEK}%`;
 export const MONTH_GRID_COLUMNS = 3;
 
 export const DATE_STYLES = {

--- a/src/feature/qr/hooks/useCameraPermission.ts
+++ b/src/feature/qr/hooks/useCameraPermission.ts
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 
-import { Camera } from 'react-native-vision-camera';
+import { requestCameraPermissionWithModal } from '@/shared/lib/cameraPermission';
 
 export const useCameraPermission = () => {
   const [permission, setPermission] = useState(false);
 
   useEffect(() => {
     (async () => {
-      const status = await Camera.requestCameraPermission();
-      setPermission(status === 'granted');
+      const granted = await requestCameraPermissionWithModal();
+      setPermission(granted);
     })();
   }, []);
 

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -58,7 +58,6 @@ export type MainNavigationProps = {
   PicselBookFolder: { bookId: string; bookName: string };
   SelectBookCover: {
     variant: 'cover';
-    bookName: string;
     picselbookId?: string;
   };
 
@@ -105,7 +104,7 @@ const MainRoute = () => {
       <Stack.Screen
         name="SelectBookCover"
         component={SelectPhotoScreen}
-        initialParams={{ variant: 'cover', bookName: '' }}
+        initialParams={{ variant: 'cover' }}
       />
       <Stack.Screen name="RegisterPhoto" component={RegisterPhotoScreen} />
       <Stack.Screen name="PicselUpload" component={PicselUploadScreen} />

--- a/src/navigation/tabs/TabBarIcon.tsx
+++ b/src/navigation/tabs/TabBarIcon.tsx
@@ -15,8 +15,8 @@ const TabBarIcon = ({ routeName, focused }: Props) => {
       return (
         <MapIcons
           shape={focused ? 'fill-pink' : 'border-gray'}
-          width={32}
-          height={32}
+          width={focused ? 38 : 32}
+          height={focused ? 38 : 32}
         />
       );
     case 'QRScreen':

--- a/src/screens/home/index.tsx
+++ b/src/screens/home/index.tsx
@@ -5,6 +5,7 @@ import {
   NaverMapView,
   Region,
 } from '@mj-studio/react-native-naver-map';
+import { useNavigation } from '@react-navigation/native';
 import { Pressable, StyleSheet } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -21,6 +22,7 @@ import EmptyBottomSheet from '@/feature/map/ui/organisms/EmptyBottomSheet';
 import MapActionButton from '@/feature/map/ui/organisms/MapActionButton';
 import MapOverlay from '@/feature/map/ui/organisms/MapOverlay';
 import { usePrefetchMyPage } from '@/feature/mypage/main/hooks/usePrefetchMyPage';
+import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import ScreenLayout from '@/shared/components/layouts/ScreenLayout';
 import { HEIGHT } from '@/shared/constants/size';
 import { useRequestNotificationPermission } from '@/shared/hooks/useRequestNotificationPermission';
@@ -35,7 +37,13 @@ const GPS_SHEET_GAP = -30;
 const HomeScreen = () => {
   useRequestNotificationPermission();
   usePrefetchMyPage();
+  const navigation = useNavigation<RootStackNavigationProp>();
   const { showBrandTooltip, fadeAnim } = useBrandTooltipOnce();
+
+  const handleQrSave = () => {
+    hideSheet('detail');
+    navigation.navigate('QrScan');
+  };
 
   const {
     targetLocation,
@@ -232,6 +240,7 @@ const HomeScreen = () => {
         isFavorite={isFavorite}
         onClose={handleBottomSheetClose}
         animatedPosition={sheetAnimatedPosition}
+        onQrSave={handleQrSave}
       />
 
       {filteredBrands?.length === 0 && (

--- a/src/screens/picsel/picselUpload/selectPhoto/index.tsx
+++ b/src/screens/picsel/picselUpload/selectPhoto/index.tsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 
-import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { Alert, Linking, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import SelectButton from '@/feature/brand/ui/organisms/SelectButton';
-import { usePicselBook } from '@/feature/picsel/picselBook/hooks/usePicselBook';
 import { PHOTO_PERMISSION_ALERT } from '@/feature/picsel/picselUpload/constants/album';
 import { useAlbumList } from '@/feature/picsel/picselUpload/hooks/useAlbumList';
 import { usePhotoPicker } from '@/feature/picsel/picselUpload/hooks/usePhotoPicker';
@@ -14,7 +12,6 @@ import { usePicselUploadStore } from '@/feature/picsel/picselUpload/hooks/usePic
 import PhotoSelectHeader from '@/feature/picsel/picselUpload/ui/layout/PhotoSelectHeader';
 import AlbumListPanel from '@/feature/picsel/picselUpload/ui/organisms/AlbumListPanel';
 import { PhotoGrid } from '@/feature/picsel/picselUpload/ui/organisms/PhotoGrid';
-import PicselBookBottomSheet from '@/feature/picsel/shared/components/ui/organisms/bottomSheet/PicselBookBottomSheet';
 import { MainNavigationProps } from '@/navigation';
 import { RootStackNavigationProp } from '@/navigation/types/navigateTypeUtil';
 import { usePhotoStore } from '@/shared/store/picselUpload';
@@ -28,15 +25,9 @@ const SelectPhotoScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const route = useRoute<SelectPhotoRouteProp>();
   const variant = route.params.variant;
-  const picselBookRef = useRef<BottomSheetModal>(null);
 
-  const {
-    from,
-    bookName: pendingBookName = '',
-    picselbookId,
-  } = route.params as {
+  const { from, picselbookId } = route.params as {
     from?: 'edit';
-    bookName?: string;
     picselbookId?: string;
   };
 
@@ -91,20 +82,13 @@ const SelectPhotoScreen = () => {
     from === 'edit',
   );
 
-  const { handleSubmit } = usePicselBook();
-
   const { setBookCoverPhoto } = usePhotoStore();
 
   const handleSelectedCompleted = () => {
     switch (variant) {
       case 'cover':
-        if (picselbookId) {
-          setBookCoverPhoto(selectedUris[0]);
-          navigation.goBack();
-
-          return;
-        }
-        picselBookRef.current?.present();
+        setBookCoverPhoto(selectedUris[0]);
+        navigation.goBack();
 
         return;
       case 'main':
@@ -153,12 +137,6 @@ const SelectPhotoScreen = () => {
           onSelectAlbum={selectAlbum}
         />
       </View>
-
-      <PicselBookBottomSheet
-        ref={picselBookRef}
-        initialBookName={pendingBookName}
-        onSubmit={handleSubmit}
-      />
 
       {selectedCount > 0 && (
         <SelectButton

--- a/src/shared/constants/text/cameraPermissionText.ts
+++ b/src/shared/constants/text/cameraPermissionText.ts
@@ -1,0 +1,6 @@
+export const CAMERA_PERMISSION_MODAL = {
+  TITLE: '설정에서 픽셀의\n카메라 접근을 허용해야 해요',
+  DESCRIPTION: '설정 > 픽셀 > 카메라에서\n카메라 접근 허용으로 변경해 주세요',
+  CANCEL: '취소',
+  CONFIRM: '설정으로 이동',
+} as const;

--- a/src/shared/lib/cameraPermission.ts
+++ b/src/shared/lib/cameraPermission.ts
@@ -1,0 +1,22 @@
+import { openSettings } from 'react-native-permissions';
+import { Camera } from 'react-native-vision-camera';
+
+import { CAMERA_PERMISSION_MODAL } from '@/shared/constants/text/cameraPermissionText';
+import { showConfirmModal } from '@/shared/lib/confirmModal';
+
+export const requestCameraPermission = async (): Promise<boolean> => {
+  const result = await Camera.requestCameraPermission();
+  return result === 'granted';
+};
+
+export const requestCameraPermissionWithModal = async (): Promise<boolean> => {
+  const hasPermission = await requestCameraPermission();
+  if (!hasPermission) {
+    showConfirmModal(CAMERA_PERMISSION_MODAL.TITLE, openSettings, {
+      title: CAMERA_PERMISSION_MODAL.DESCRIPTION,
+      confirmText: CAMERA_PERMISSION_MODAL.CONFIRM,
+      cancelText: CAMERA_PERMISSION_MODAL.CANCEL,
+    });
+  }
+  return hasPermission;
+};

--- a/src/shared/store/picselUpload/index.ts
+++ b/src/shared/store/picselUpload/index.ts
@@ -4,9 +4,11 @@ interface PhotoState {
   mainPhoto: string | null;
   extraPhotos: string[];
   bookCoverPhoto: string | null;
+  draftBookName: string | null;
 
   setMainPhoto: (uri: string | null) => void;
   setBookCoverPhoto: (uri: string | null) => void;
+  setDraftBookName: (name: string | null) => void;
 
   setExtraPhotos: (uris: string[]) => void;
   addExtraPhotos: (uris: string[]) => void;
@@ -19,10 +21,13 @@ export const usePhotoStore = create<PhotoState>(set => ({
   mainPhoto: null,
   extraPhotos: [],
   bookCoverPhoto: null,
+  draftBookName: null,
 
   setMainPhoto: uri => set({ mainPhoto: uri }),
 
   setBookCoverPhoto: uri => set({ bookCoverPhoto: uri }),
+
+  setDraftBookName: name => set({ draftBookName: name }),
 
   addExtraPhotos: uris =>
     set(state => ({
@@ -36,5 +41,11 @@ export const usePhotoStore = create<PhotoState>(set => ({
       extraPhotos: state.extraPhotos.filter((_, i) => i !== index),
     })),
 
-  reset: () => set({ mainPhoto: null, extraPhotos: [], bookCoverPhoto: null }),
+  reset: () =>
+    set({
+      mainPhoto: null,
+      extraPhotos: [],
+      bookCoverPhoto: null,
+      draftBookName: null,
+    }),
 }));


### PR DESCRIPTION
## 이슈 번호

> close #201 

## 작업 내용 및 테스트 방법

심사 요청 전 QA에서 발견된 이슈와, 추가로 발견된 이슈를 함께 대응했습니다.

### 🐛 Fix
- **날짜 선택 바텀시트**: 캘린더 7열 정렬 및 동적 주 수 계산 적용
- **브랜드 바텀시트**: QR 저장 버튼 미동작 이슈 해결
- **카메라 권한 거부 시**: 설정 이동 안내 모달 노출
- **사진 선택 화면**: 작은 디바이스 대응을 위한 스크롤 적용
- **픽셀북 선택 화면**: 작은 디바이스 대응으로 바텀 px값 조정 (DateLocationStep과 동일하게 적용)
- **픽셀북 기본 커버 이미지**: 사진 지정 이미지 → 기본 이미지로 수정
- **1:1 문의하기**: 최신 링크로 수정

### ✨ Feat
- **픽셀북 추가**: 사진 지정 시 프리뷰 노출
- **하단 탭바**: 선택된 지도 아이콘 크기 조정

### 💄 Design
- **사진 카드**: 여백 제거 및 이미지 size mode `cover`로 변경
(배경색을 흰색으로 바꿔주셨지만, 기존 년/월 카드와 크기가 맞지 않아 이를 맞추기 위해 변경 진행했습니다!)

### 🔨 Etc
- iOS 빌드 넘버 갱신

### 테스트 방법
1. 날짜 선택 바텀시트에서 캘린더가 7열로 정렬되고 월별 주 수가 깨지지 않고 표시되는지 확인
2. 지도 → 브랜드 바텀시트에서 QR 저장 버튼 정상 동작 확인
3. 카메라 권한 거부 후 진입 시 설정 이동 모달 노출 확인
4. 픽셀북 추가 시 사진 지정 → 프리뷰 노출 확인
5. 하단 탭바 지도 아이콘 선택 시 크기 확인
6. 마이페이지 → 1:1 문의하기 링크 정상 연결 확인

## To reviewers
날짜 선택 바텀시트 캘린더 주 수 깨짐 현상은 iPhone 14 기준으로 확인하여 수정 진행하였고, 현중님께서도 그때 확인이 된다고 하셨던 부분이라 재차 확인 한 번 해주시면 감사하겠습니다! 이를 대응하면서 작은 디바이스 테스트까지 간단하게 진행했고 간단한 스크롤 레이아웃 하나 정도 수정 했습니다!